### PR TITLE
Add self-lint test

### DIFF
--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -132,3 +132,16 @@ def test_linter_no_warning_for_known_rule_ids(valid_plugin):
 
     unknown_warnings = [v for v in violations if v.rule_id == "invalid-config"]
     assert len(unknown_warnings) == 0
+
+
+def test_self_lint():
+    """Skillsaw's own .claude/ directory should pass linting with no errors"""
+    repo_root = Path(__file__).parent.parent
+    context = RepositoryContext(repo_root)
+    config = LinterConfig.default()
+    linter = ClaudeLinter(context, config)
+
+    violations = linter.run()
+    errors = [v for v in violations if v.severity.value == "error"]
+
+    assert len(errors) == 0, f"Self-lint found errors: {errors}"


### PR DESCRIPTION
## Summary
- Adds a test that runs skillsaw against its own `.claude/` directory
- Ensures the repo's own configuration stays valid as rules evolve

## Test plan
- [x] `test_self_lint` passes locally
- [x] Full test suite (193 tests) passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>