### PR TITLE
Drop Python 3.8, add 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,17 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
 ]
 keywords = ["agentskills", "claude", "claude-code", "linter", "plugin", "skills", "validation", "skillsaw"]
-requires-python = ">=3.8.1"
+requires-python = ">=3.9"
 dependencies = [
     "PyYAML>=6.0",
 ]
@@ -65,7 +66,7 @@ addopts = "-v"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 extend-exclude = '''
 /(


### PR DESCRIPTION
## Summary

- Drop Python 3.8 from CI and classifiers (EOL October 2024)
- Keep Python 3.9 (RHEL 9 default, supported through RHEL 9 lifecycle)
- Add Python 3.13 and 3.14 to CI matrix and classifiers
- Update `requires-python` to `>=3.9`
- Update black `target-version` accordingly

## Test plan

- [x] All 218 tests pass locally on 3.14
- [ ] CI matrix runs on 3.9, 3.10, 3.11, 3.12, 3.13, 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)