### PR TITLE
Add skillsaw GitHub Action with inline PR review comments

### DIFF
--- a/.apm/instructions/new-linter-rules.instructions.md
+++ b/.apm/instructions/new-linter-rules.instructions.md
@@ -1,0 +1,25 @@
+---
+description: Guidelines for implementing new linter rules
+---
+
+# Writing New Linter Rules
+
+## Line Numbers
+
+Rules MUST report line numbers in violations whenever the violation can be
+traced to a specific line in a file. This enables the GitHub Action to post
+inline PR comments on the exact line.
+
+- **Frontmatter fields:** Use `_frontmatter_key_line()` (see
+  `agentskills.py`) or a similar helper to find the line of the offending key.
+- **Markdown sections:** Scan for the heading or content that triggered the
+  violation and report its line.
+- **JSON files:** Exempt from line number requirements. The `json` module does
+  not preserve line numbers and scanning raw JSON text for keys is unreliable.
+  File-level reporting is acceptable for JSON validation rules.
+- **File-level violations** (missing file, bad directory name) naturally have no
+  line number — that's fine.
+- **Missing fields:** Don't fabricate a line number (e.g. hardcoding `line=1`).
+  If a field is missing, there's no line to point to — omit the line number.
+
+When in doubt, report the line. An approximate line is better than no line.

--- a/.github/workflows/self-lint.yml
+++ b/.github/workflows/self-lint.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 permissions:
-  security-events: write
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   self-lint:
@@ -17,34 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: ./
         with:
-          python-version: "3.11"
-
-      - name: Install skillsaw
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-
-      - name: Lint .claude directory
-        run: |
-          skillsaw \
-            --format text \
-            --output results.sarif \
-            --output results.html \
-            .
-
-      - name: Upload SARIF to GitHub Code Scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-          category: skillsaw
-
-      - name: Upload HTML report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: skillsaw-report
-          path: results.html
+          strict: false

--- a/.github/workflows/self-lint.yml
+++ b/.github/workflows/self-lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,4 +1,4 @@
-name: Self-lint .claude
+name: Test Action
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -19,4 +19,4 @@ jobs:
 
       - uses: ./
         with:
-          strict: false
+          strict: true

--- a/README.md
+++ b/README.md
@@ -295,29 +295,75 @@ rules:
 
 ## CI/CD Integration
 
-### GitHub Actions
+### GitHub Action (recommended)
+
+The built-in GitHub Action installs skillsaw, runs it, and posts violations as
+inline PR comments with automatic deduplication. Fixed violations have their
+comment threads resolved.
 
 ```yaml
-name: Lint Agent Skills
+name: Lint
 
-on: [pull_request, push]
+on: [pull_request]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  lint:
+  skillsaw:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: stbenjam/skillsaw@v0
         with:
-          python-version: '3.x'
+          strict: true
+```
 
-      - name: Install skillsaw
-        run: pip install skillsaw
+#### Inputs
 
-      - name: Run linter
-        run: skillsaw --strict
+| Input | Description | Default |
+|-------|-------------|---------|
+| `path` | Path to lint | `.` |
+| `version` | Specific skillsaw version to install | latest |
+| `strict` | Treat warnings as errors | `false` |
+| `verbose` | Include info-level violations | `false` |
+| `token` | GitHub token for posting PR comments | `${{ github.token }}` |
+
+#### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `exit-code` | skillsaw exit code (0=pass, 1=errors, 2=strict+warnings) |
+| `errors` | Number of errors found |
+| `warnings` | Number of warnings found |
+| `report` | Full JSON report |
+
+#### PR comment behavior
+
+- Each violation gets its own inline comment on the relevant line or file
+- Comments are deduplicated across re-runs using content fingerprinting
+- When a violation is fixed, its comment thread is automatically resolved
+- Comments with human replies are preserved
+
+> **Permissions:** `contents: write` is required for resolving comment threads
+> via GraphQL. `pull-requests: write` is required for posting comments.
+
+### GitHub Actions (manual)
+
+```yaml
+- uses: actions/checkout@v5
+
+- name: Set up Python
+  uses: actions/setup-python@v6
+  with:
+    python-version: '3.x'
+
+- name: Install skillsaw
+  run: pip install skillsaw
+
+- name: Run linter
+  run: skillsaw --strict
 ```
 
 ### Docker

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,115 @@
+name: 'skillsaw'
+description: 'Lint agent skills, plugins, and AI coding assistant context'
+branding:
+  icon: 'check-circle'
+  color: 'green'
+
+inputs:
+  path:
+    description: 'Path to lint'
+    required: false
+    default: '.'
+  version:
+    description: 'skillsaw version to install (e.g. "0.4.3"). Empty for latest.'
+    required: false
+    default: ''
+  strict:
+    description: 'Treat warnings as errors'
+    required: false
+    default: 'false'
+  verbose:
+    description: 'Include info-level violations'
+    required: false
+    default: 'false'
+  token:
+    description: 'GitHub token for posting PR review comments'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  exit-code:
+    description: 'skillsaw exit code (0=pass, 1=errors, 2=strict+warnings)'
+    value: ${{ steps.lint.outputs.exit-code }}
+  errors:
+    description: 'Number of errors found'
+    value: ${{ steps.lint.outputs.errors }}
+  warnings:
+    description: 'Number of warnings found'
+    value: ${{ steps.lint.outputs.warnings }}
+  report:
+    description: 'Full JSON report'
+    value: ${{ steps.lint.outputs.report }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install skillsaw
+      shell: bash
+      env:
+        SKILLSAW_VERSION: ${{ inputs.version }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        if [ -n "$SKILLSAW_VERSION" ]; then
+          pip install -q "skillsaw==$SKILLSAW_VERSION"
+        elif [ -f "$ACTION_PATH/pyproject.toml" ]; then
+          pip install -q "$ACTION_PATH"
+        else
+          pip install -q skillsaw
+        fi
+
+    - name: Run skillsaw
+      id: lint
+      shell: bash
+      env:
+        SKILLSAW_PATH: ${{ inputs.path }}
+        SKILLSAW_STRICT: ${{ inputs.strict }}
+        SKILLSAW_VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set +e
+        ARGS="--format json"
+        if [ "$SKILLSAW_STRICT" = "true" ]; then
+          ARGS="$ARGS --strict"
+        fi
+        if [ "$SKILLSAW_VERBOSE" = "true" ]; then
+          ARGS="$ARGS -v"
+        fi
+
+        OUTPUT=$(skillsaw $ARGS "$SKILLSAW_PATH")
+        EXIT_CODE=$?
+
+        echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+        ERRORS=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['summary']['errors'])" 2>/dev/null || echo "0")
+        WARNINGS=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin)['summary']['warnings'])" 2>/dev/null || echo "0")
+        echo "errors=${ERRORS}" >> "$GITHUB_OUTPUT"
+        echo "warnings=${WARNINGS}" >> "$GITHUB_OUTPUT"
+
+        REPORT_FILE=$(mktemp)
+        echo "$OUTPUT" > "$REPORT_FILE"
+        echo "report-file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "report<<SKILLSAW_EOF"
+          echo "$OUTPUT"
+          echo "SKILLSAW_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Post PR review
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: python3 "${{ github.action_path }}/action/review.py"
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        SKILLSAW_REPORT_FILE: ${{ steps.lint.outputs.report-file }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    - name: Exit with skillsaw result
+      shell: bash
+      run: exit ${{ steps.lint.outputs.exit-code }}

--- a/action.yml
+++ b/action.yml
@@ -112,4 +112,6 @@ runs:
 
     - name: Exit with skillsaw result
       shell: bash
-      run: exit ${{ steps.lint.outputs.exit-code }}
+      env:
+        SKILLSAW_EXIT_CODE: ${{ steps.lint.outputs.exit-code }}
+      run: exit "${SKILLSAW_EXIT_CODE}"

--- a/action/review.py
+++ b/action/review.py
@@ -1,0 +1,273 @@
+"""Post skillsaw results as individual GitHub PR comments."""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+FINGERPRINT_RE = re.compile(r"<!-- skillsaw:([a-f0-9]+) -->")
+SEVERITY_ICONS = {"error": "❌", "warning": "⚠️", "info": "ℹ️"}
+API = "https://api.github.com"
+
+
+def github_api(method, path, body=None):
+    token = os.environ["GITHUB_TOKEN"]
+    url = f"{API}{path}" if path.startswith("/") else path
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            resp_body = resp.read().decode()
+            return json.loads(resp_body) if resp_body else None
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        print(f"GitHub API error: {e.code} {e.reason}: {error_body}", file=sys.stderr)
+        raise
+
+
+def graphql(query, variables=None):
+    token = os.environ["GITHUB_TOKEN"]
+    body = {"query": query}
+    if variables:
+        body["variables"] = variables
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{API}/graphql",
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": f"bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read().decode())
+    if result.get("errors"):
+        print(f"GraphQL error: {result['errors']}", file=sys.stderr)
+    return result
+
+
+def get_review_threads(repo, pr_number):
+    """Fetch all review threads and their first comment bodies."""
+    owner, name = repo.split("/")
+    threads = []
+    cursor = None
+    while True:
+        after = f', after: "{cursor}"' if cursor else ""
+        result = graphql(
+            """
+            query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                        reviewThreads(first: 100%s) {
+                            nodes {
+                                id
+                                isResolved
+                                comments(first: 1) {
+                                    nodes { body }
+                                }
+                            }
+                            pageInfo { hasNextPage endCursor }
+                        }
+                    }
+                }
+            }
+            """ % after,
+            {"owner": owner, "repo": name, "pr": int(pr_number)},
+        )
+        pr_data = (result.get("data") or {}).get("repository", {}).get("pullRequest", {})
+        thread_data = pr_data.get("reviewThreads", {})
+        threads.extend(thread_data.get("nodes") or [])
+        page_info = thread_data.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info["endCursor"]
+    return threads
+
+
+def resolve_threads_by_fingerprints(repo, pr_number, fingerprints):
+    """Resolve review threads whose comments match the given fingerprints."""
+    if not fingerprints:
+        return 0
+    threads = get_review_threads(repo, pr_number)
+    resolved = 0
+    for thread in threads:
+        if thread.get("isResolved"):
+            continue
+        comments = (thread.get("comments") or {}).get("nodes") or []
+        if not comments:
+            continue
+        body = comments[0].get("body", "")
+        m = FINGERPRINT_RE.search(body)
+        if m and m.group(1) in fingerprints:
+            result = graphql(
+                """
+                mutation($threadId: ID!) {
+                    resolveReviewThread(input: {threadId: $threadId}) {
+                        thread { isResolved }
+                    }
+                }
+                """,
+                {"threadId": thread["id"]},
+            )
+            if (result.get("data") or {}).get("resolveReviewThread", {}).get("thread", {}).get("isResolved"):
+                resolved += 1
+    return resolved
+
+
+def fingerprint(rule_id, file_path, message):
+    key = f"{rule_id}:{file_path}:{message}"
+    return hashlib.sha256(key.encode()).hexdigest()[:12]
+
+
+def get_diff_lines(repo, pr_number):
+    """Get the set of (path, line) tuples for added/modified lines in the PR."""
+    diff_lines = set()
+    page = 1
+    while True:
+        files = github_api("GET", f"/repos/{repo}/pulls/{pr_number}/files?per_page=100&page={page}")
+        if not files:
+            break
+        for f in files:
+            path = f["filename"]
+            patch = f.get("patch", "")
+            if not patch:
+                continue
+            current_line = 0
+            for line in patch.split("\n"):
+                hunk = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@", line)
+                if hunk:
+                    current_line = int(hunk.group(1))
+                    continue
+                if line.startswith("+"):
+                    diff_lines.add((path, current_line))
+                    current_line += 1
+                elif line.startswith("-"):
+                    pass
+                else:
+                    current_line += 1
+        page += 1
+    return diff_lines
+
+
+def sync_comments(repo, pr_number, new_comments):
+    """Diff existing skillsaw comments against new findings.
+
+    Resolves threads for fixed violations, returns genuinely new comments.
+    """
+    all_comments = []
+    page = 1
+    while True:
+        page_comments = github_api(
+            "GET", f"/repos/{repo}/pulls/{pr_number}/comments?per_page=100&page={page}"
+        )
+        if not page_comments:
+            break
+        all_comments.extend(page_comments)
+        page += 1
+
+    existing = {}
+    for c in all_comments:
+        m = FINGERPRINT_RE.search(c.get("body", ""))
+        if m:
+            existing[m.group(1)] = c
+
+    if not existing:
+        return new_comments
+
+    current_fps = {c["fingerprint"] for c in new_comments}
+    stale_fps = {fp for fp in existing if fp not in current_fps}
+
+    if stale_fps:
+        try:
+            resolved = resolve_threads_by_fingerprints(repo, pr_number, stale_fps)
+            if resolved:
+                print(f"Resolved {resolved} thread(s) for fixed issues.")
+        except Exception as e:
+            print(f"Failed to resolve threads: {e}", file=sys.stderr)
+
+    return [c for c in new_comments if c["fingerprint"] not in existing]
+
+
+def main():
+    report_file = os.environ.get("SKILLSAW_REPORT_FILE", "")
+    if not report_file or not os.path.exists(report_file):
+        print("No skillsaw report found, skipping review.", file=sys.stderr)
+        return
+
+    with open(report_file) as f:
+        content = f.read().strip()
+    if not content:
+        print("Report file is empty, skipping review.", file=sys.stderr)
+        return
+    try:
+        report = json.loads(content)
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse report JSON: {e}", file=sys.stderr)
+        return
+
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pr_number = os.environ["PR_NUMBER"]
+    head_sha = os.environ["HEAD_SHA"]
+
+    violations = report.get("violations", [])
+    if not violations:
+        print("No violations found.")
+        return
+
+    diff_lines = get_diff_lines(repo, pr_number)
+
+    new_comments = []
+    for v in violations:
+        path = v.get("file_path")
+        line = v.get("line")
+        if not path:
+            continue
+
+        fp = fingerprint(v["rule_id"], path, v["message"])
+        icon = SEVERITY_ICONS.get(v["severity"], "")
+        body = (
+            f"{icon} **{v['severity']}** (`{v['rule_id']}`): {v['message']}\n"
+            f"<!-- skillsaw:{fp} -->"
+        )
+
+        comment = {"path": path, "commit_id": head_sha, "body": body, "fingerprint": fp}
+        if line and (path, line) in diff_lines:
+            comment["line"] = line
+            comment["side"] = "RIGHT"
+        else:
+            comment["subject_type"] = "file"
+
+        new_comments.append(comment)
+
+    to_post = sync_comments(repo, pr_number, new_comments)
+
+    posted = 0
+    for comment in to_post:
+        payload = {k: v for k, v in comment.items() if k != "fingerprint"}
+        try:
+            github_api("POST", f"/repos/{repo}/pulls/{pr_number}/comments", payload)
+            posted += 1
+        except urllib.error.HTTPError:
+            pass
+
+    kept = len(new_comments) - len(to_post)
+    print(f"Posted {posted} new comment(s), {kept} unchanged.")
+
+
+if __name__ == "__main__":
+    main()

--- a/action/review.py
+++ b/action/review.py
@@ -271,8 +271,9 @@ def main():
         try:
             github_api("POST", f"/repos/{repo}/pulls/{pr_number}/comments", payload)
             posted += 1
-        except urllib.error.HTTPError:
-            pass
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403, 429):
+                raise
 
     kept = len(new_comments) - len(to_post)
     print(f"Posted {posted} new comment(s), {kept} unchanged.")

--- a/action/review.py
+++ b/action/review.py
@@ -67,10 +67,14 @@ def get_review_threads(repo, pr_number):
     threads = []
     cursor = None
     while True:
-        after = f', after: "{cursor}"' if cursor else ""
+        variables = {"owner": owner, "repo": name, "pr": int(pr_number)}
+        after_decl = ", $after: String" if cursor else ""
+        after_arg = ", after: $after" if cursor else ""
+        if cursor:
+            variables["after"] = cursor
         result = graphql(
             """
-            query($owner: String!, $repo: String!, $pr: Int!) {
+            query($owner: String!, $repo: String!, $pr: Int!%s) {
                 repository(owner: $owner, name: $repo) {
                     pullRequest(number: $pr) {
                         reviewThreads(first: 100%s) {
@@ -86,8 +90,8 @@ def get_review_threads(repo, pr_number):
                     }
                 }
             }
-            """ % after,
-            {"owner": owner, "repo": name, "pr": int(pr_number)},
+            """ % (after_decl, after_arg),
+            variables,
         )
         pr_data = (result.get("data") or {}).get("repository", {}).get("pullRequest", {})
         thread_data = pr_data.get("reviewThreads", {})
@@ -124,7 +128,12 @@ def resolve_threads_by_fingerprints(repo, pr_number, fingerprints):
                 """,
                 {"threadId": thread["id"]},
             )
-            if (result.get("data") or {}).get("resolveReviewThread", {}).get("thread", {}).get("isResolved"):
+            if (
+                (result.get("data") or {})
+                .get("resolveReviewThread", {})
+                .get("thread", {})
+                .get("isResolved")
+            ):
                 resolved += 1
     return resolved
 

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -7,6 +7,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_text
 
 
 class AgentFrontmatterRule(Rule):
@@ -33,12 +34,10 @@ class AgentFrontmatterRule(Rule):
 
             # Check all .md files in agents directory
             for agent_file in agents_dir.glob("*.md"):
-                try:
-                    with open(agent_file, "r") as f:
-                        content = f.read()
-                except IOError as e:
+                content = read_text(agent_file)
+                if content is None:
                     violations.append(
-                        self.violation(f"Failed to read file: {e}", file_path=agent_file)
+                        self.violation(f"Failed to read file: {agent_file}", file_path=agent_file)
                     )
                     continue
 

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -11,6 +11,7 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.rules.builtin.utils import read_text, read_json, frontmatter_key_line
 
 # agentskills.io spec constraints
 NAME_MAX_LENGTH = 64
@@ -21,7 +22,7 @@ CONSECUTIVE_HYPHENS = re.compile(r"--")
 DEFAULT_ALLOWED_DIRS = {"scripts", "references", "assets", "evals"}
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=512)
 def _parse_skill_md(skill_path) -> Tuple[Optional[Dict], Optional[str]]:
     """
     Parse SKILL.md frontmatter from a skill directory.
@@ -33,10 +34,9 @@ def _parse_skill_md(skill_path) -> Tuple[Optional[Dict], Optional[str]]:
     if not skill_md.exists():
         return None, "SKILL.md not found"
 
-    try:
-        content = skill_md.read_text()
-    except IOError as e:
-        return None, f"Failed to read SKILL.md: {e}"
+    content = read_text(skill_md)
+    if content is None:
+        return None, f"Failed to read SKILL.md: {skill_md}"
 
     if not content.startswith("---"):
         return None, "Missing YAML frontmatter (must start with ---)"
@@ -56,25 +56,9 @@ def _parse_skill_md(skill_path) -> Tuple[Optional[Dict], Optional[str]]:
     return frontmatter, None
 
 
-@lru_cache(maxsize=None)
 def _frontmatter_key_line(skill_path, key: str) -> Optional[int]:
     """Find the line number of a top-level key in SKILL.md frontmatter."""
-    skill_md = skill_path / "SKILL.md"
-    try:
-        lines = skill_md.read_text().splitlines()
-    except IOError:
-        return None
-    pattern = re.compile(rf"^{re.escape(key)}\s*:")
-    in_frontmatter = False
-    for i, line in enumerate(lines, 1):
-        if line.strip() == "---":
-            if not in_frontmatter:
-                in_frontmatter = True
-                continue
-            break
-        if in_frontmatter and pattern.match(line):
-            return i
-    return None
+    return frontmatter_key_line(skill_path / "SKILL.md", key)
 
 
 class AgentSkillValidRule(Rule):
@@ -472,16 +456,10 @@ class AgentSkillEvalsRule(Rule):
                 )
                 continue
 
-            try:
-                data = json.loads(evals_json.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            data, error = read_json(evals_json)
+            if error:
                 violations.append(
-                    self.violation(f"Invalid JSON in evals.json: {e}", file_path=evals_json)
-                )
-                continue
-            except IOError as e:
-                violations.append(
-                    self.violation(f"Failed to read evals.json: {e}", file_path=evals_json)
+                    self.violation(f"Invalid JSON in evals.json: {error}", file_path=evals_json)
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -56,6 +56,27 @@ def _parse_skill_md(skill_path) -> Tuple[Optional[Dict], Optional[str]]:
     return frontmatter, None
 
 
+@lru_cache(maxsize=None)
+def _frontmatter_key_line(skill_path, key: str) -> Optional[int]:
+    """Find the line number of a top-level key in SKILL.md frontmatter."""
+    skill_md = skill_path / "SKILL.md"
+    try:
+        lines = skill_md.read_text().splitlines()
+    except IOError:
+        return None
+    pattern = re.compile(rf"^{re.escape(key)}\s*:")
+    in_frontmatter = False
+    for i, line in enumerate(lines, 1):
+        if line.strip() == "---":
+            if not in_frontmatter:
+                in_frontmatter = True
+                continue
+            break
+        if in_frontmatter and pattern.match(line):
+            return i
+    return None
+
+
 class AgentSkillValidRule(Rule):
     """Validate SKILL.md exists with required frontmatter fields"""
 
@@ -94,12 +115,19 @@ class AgentSkillValidRule(Rule):
                     self.violation("Missing required 'name' field", file_path=skill_md)
                 )
             elif not isinstance(name, str):
-                violations.append(self.violation("'name' must be a string", file_path=skill_md))
+                violations.append(
+                    self.violation(
+                        "'name' must be a string",
+                        file_path=skill_md,
+                        line=_frontmatter_key_line(skill_path, "name"),
+                    )
+                )
             elif len(name) > NAME_MAX_LENGTH:
                 violations.append(
                     self.violation(
                         f"'name' exceeds {NAME_MAX_LENGTH} characters ({len(name)})",
                         file_path=skill_md,
+                        line=_frontmatter_key_line(skill_path, "name"),
                     )
                 )
 
@@ -110,7 +138,11 @@ class AgentSkillValidRule(Rule):
                 )
             elif not isinstance(desc, str):
                 violations.append(
-                    self.violation("'description' must be a string", file_path=skill_md)
+                    self.violation(
+                        "'description' must be a string",
+                        file_path=skill_md,
+                        line=_frontmatter_key_line(skill_path, "description"),
+                    )
                 )
 
             if "license" in frontmatter and not isinstance(frontmatter["license"], str):
@@ -209,11 +241,14 @@ class AgentSkillNameRule(Rule):
             if not name or not isinstance(name, str):
                 continue
 
+            name_line = _frontmatter_key_line(skill_path, "name")
+
             if not NAME_PATTERN.match(name):
                 violations.append(
                     self.violation(
                         f"Name '{name}' must contain only lowercase letters, numbers, and hyphens",
                         file_path=skill_md,
+                        line=name_line,
                     )
                 )
                 continue
@@ -223,6 +258,7 @@ class AgentSkillNameRule(Rule):
                     self.violation(
                         f"Name '{name}' must not end with a hyphen",
                         file_path=skill_md,
+                        line=name_line,
                     )
                 )
 
@@ -231,15 +267,16 @@ class AgentSkillNameRule(Rule):
                     self.violation(
                         f"Name '{name}' must not contain consecutive hyphens",
                         file_path=skill_md,
+                        line=name_line,
                     )
                 )
 
-            # Name must match parent directory (skip if skill is at repo root)
             if skill_path != context.root_path and name != skill_path.name:
                 violations.append(
                     self.violation(
                         f"Name '{name}' does not match directory name '{skill_path.name}'",
                         file_path=skill_md,
+                        line=name_line,
                     )
                 )
 
@@ -281,10 +318,15 @@ class AgentSkillDescriptionRule(Rule):
             if not desc or not isinstance(desc, str):
                 continue
 
+            desc_line = _frontmatter_key_line(skill_path, "description")
             stripped = desc.strip()
             if not stripped:
                 violations.append(
-                    self.violation("Description is empty or whitespace-only", file_path=skill_md)
+                    self.violation(
+                        "Description is empty or whitespace-only",
+                        file_path=skill_md,
+                        line=desc_line,
+                    )
                 )
                 continue
 
@@ -293,6 +335,7 @@ class AgentSkillDescriptionRule(Rule):
                     self.violation(
                         f"Description exceeds {DESCRIPTION_MAX_LENGTH} characters ({len(stripped)})",
                         file_path=skill_md,
+                        line=desc_line,
                     )
                 )
 

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -8,6 +8,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_text, heading_line
 
 
 class CommandNamingRule(Rule):
@@ -71,12 +72,10 @@ class CommandFrontmatterRule(Rule):
                 continue
 
             for cmd_file in commands_dir.glob("*.md"):
-                try:
-                    with open(cmd_file, "r") as f:
-                        content = f.read()
-                except IOError as e:
+                content = read_text(cmd_file)
+                if content is None:
                     violations.append(
-                        self.violation(f"Failed to read file: {e}", file_path=cmd_file)
+                        self.violation(f"Failed to read file: {cmd_file}", file_path=cmd_file)
                     )
                     continue
 
@@ -129,10 +128,8 @@ class CommandSectionsRule(Rule):
                 continue
 
             for cmd_file in commands_dir.glob("*.md"):
-                try:
-                    with open(cmd_file, "r") as f:
-                        content = f.read()
-                except IOError:
+                content = read_text(cmd_file)
+                if content is None:
                     continue
 
                 for section in required_sections:
@@ -175,10 +172,8 @@ class CommandNameFormatRule(Rule):
                 cmd_name = cmd_file.stem
                 expected_name = f"{plugin_name}:{cmd_name}"
 
-                try:
-                    with open(cmd_file, "r") as f:
-                        content = f.read()
-                except IOError:
+                content = read_text(cmd_file)
+                if content is None:
                     continue
 
                 # Find Name section
@@ -186,10 +181,12 @@ class CommandNameFormatRule(Rule):
                 if name_match:
                     name_content = name_match.group(1).strip()
                     if expected_name not in name_content:
+                        name_line = heading_line(cmd_file, "Name")
                         violations.append(
                             self.violation(
                                 f"Name section should contain '{expected_name}', found: '{name_content}'",
                                 file_path=cmd_file,
+                                line=name_line,
                             )
                         )
 

--- a/src/skillsaw/rules/builtin/hooks.py
+++ b/src/skillsaw/rules/builtin/hooks.py
@@ -2,11 +2,11 @@
 Rules for validating hook configuration
 """
 
-import json
 from typing import List, Dict, Any
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_json
 
 # Valid hook event types
 _VALID_HOOK_EVENTS = {
@@ -125,14 +125,9 @@ class HooksJsonValidRule(Rule):
                 continue
 
             # Try to parse JSON
-            try:
-                with open(hooks_json, "r") as f:
-                    data = json.load(f)
-            except json.JSONDecodeError as e:
-                violations.append(self.violation(f"Invalid JSON: {e}", file_path=hooks_json))
-                continue
-            except IOError as e:
-                violations.append(self.violation(f"Failed to read file: {e}", file_path=hooks_json))
+            data, error = read_json(hooks_json)
+            if error:
+                violations.append(self.violation(f"Invalid JSON: {error}", file_path=hooks_json))
                 continue
 
             # Validate structure

--- a/src/skillsaw/rules/builtin/marketplace.py
+++ b/src/skillsaw/rules/builtin/marketplace.py
@@ -43,9 +43,7 @@ class MarketplaceJsonValidRule(Rule):
         # Try to parse
         marketplace, error = read_json(marketplace_file)
         if error:
-            violations.append(
-                self.violation(f"Invalid JSON: {error}", file_path=marketplace_file)
-            )
+            violations.append(self.violation(f"Invalid JSON: {error}", file_path=marketplace_file))
             return violations
 
         # Validate that marketplace is a dictionary

--- a/src/skillsaw/rules/builtin/marketplace.py
+++ b/src/skillsaw/rules/builtin/marketplace.py
@@ -2,11 +2,11 @@
 Rules for validating marketplace structure
 """
 
-import json
 from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.rules.builtin.utils import read_json
 
 
 class MarketplaceJsonValidRule(Rule):
@@ -41,15 +41,10 @@ class MarketplaceJsonValidRule(Rule):
             return violations
 
         # Try to parse
-        try:
-            with open(marketplace_file, "r") as f:
-                marketplace = json.load(f)
-        except json.JSONDecodeError as e:
-            violations.append(self.violation(f"Invalid JSON: {e}", file_path=marketplace_file))
-            return violations
-        except IOError as e:
+        marketplace, error = read_json(marketplace_file)
+        if error:
             violations.append(
-                self.violation(f"Failed to read file: {e}", file_path=marketplace_file)
+                self.violation(f"Invalid JSON: {error}", file_path=marketplace_file)
             )
             return violations
 

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -2,12 +2,12 @@
 Rules for validating MCP (Model Context Protocol) configuration
 """
 
-import json
 from typing import List, Dict, Any
 from pathlib import Path
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_json
 
 
 class McpValidJsonRule(Rule):
@@ -48,14 +48,9 @@ class McpValidJsonRule(Rule):
         violations = []
 
         # Try to parse JSON
-        try:
-            with open(mcp_json, "r") as f:
-                data = json.load(f)
-        except json.JSONDecodeError as e:
-            violations.append(self.violation(f"Invalid JSON: {e}", file_path=mcp_json))
-            return violations
-        except IOError as e:
-            violations.append(self.violation(f"Failed to read file: {e}", file_path=mcp_json))
+        data, error = read_json(mcp_json)
+        if error:
+            violations.append(self.violation(f"Invalid JSON: {error}", file_path=mcp_json))
             return violations
 
         # Validate structure
@@ -67,10 +62,8 @@ class McpValidJsonRule(Rule):
         """Validate mcpServers field in plugin.json"""
         violations = []
 
-        try:
-            with open(plugin_json, "r") as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, IOError):
+        data, error = read_json(plugin_json)
+        if error:
             # If plugin.json is invalid, plugin-json-valid rule will catch it
             return violations
 
@@ -281,29 +274,27 @@ class McpProhibitedRule(Rule):
         """Check .mcp.json for non-allowlisted servers"""
         violations = []
 
-        try:
-            with open(mcp_json, "r") as f:
-                data = json.load(f)
+        data, error = read_json(mcp_json)
+        if error:
+            return violations
 
-            if "mcpServers" in data:
-                prohibited = self._get_prohibited_servers(data["mcpServers"], allowlist)
-                if prohibited:
-                    if allowlist:
-                        violations.append(
-                            self.violation(
-                                f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
-                                file_path=mcp_json,
-                            )
+        if "mcpServers" in data:
+            prohibited = self._get_prohibited_servers(data["mcpServers"], allowlist)
+            if prohibited:
+                if allowlist:
+                    violations.append(
+                        self.violation(
+                            f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
+                            file_path=mcp_json,
                         )
-                    else:
-                        violations.append(
-                            self.violation(
-                                "Plugin defines MCP servers in .mcp.json",
-                                file_path=mcp_json,
-                            )
+                    )
+                else:
+                    violations.append(
+                        self.violation(
+                            "Plugin defines MCP servers in .mcp.json",
+                            file_path=mcp_json,
                         )
-        except (json.JSONDecodeError, IOError):
-            pass
+                    )
 
         return violations
 
@@ -311,29 +302,27 @@ class McpProhibitedRule(Rule):
         """Check plugin.json for non-allowlisted servers"""
         violations = []
 
-        try:
-            with open(plugin_json, "r") as f:
-                data = json.load(f)
+        data, error = read_json(plugin_json)
+        if error:
+            return violations
 
-            if "mcpServers" in data:
-                prohibited = self._get_prohibited_servers(data["mcpServers"], allowlist)
-                if prohibited:
-                    if allowlist:
-                        violations.append(
-                            self.violation(
-                                f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
-                                file_path=plugin_json,
-                            )
+        if "mcpServers" in data:
+            prohibited = self._get_prohibited_servers(data["mcpServers"], allowlist)
+            if prohibited:
+                if allowlist:
+                    violations.append(
+                        self.violation(
+                            f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
+                            file_path=plugin_json,
                         )
-                    else:
-                        violations.append(
-                            self.violation(
-                                "Plugin defines MCP servers in plugin.json",
-                                file_path=plugin_json,
-                            )
+                    )
+                else:
+                    violations.append(
+                        self.violation(
+                            "Plugin defines MCP servers in plugin.json",
+                            file_path=plugin_json,
                         )
-        except (json.JSONDecodeError, IOError):
-            pass
+                    )
 
         return violations
 

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -2,12 +2,12 @@
 Rules for validating plugin structure
 """
 
-import json
 import re
 from pathlib import Path
 from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
+from skillsaw.rules.builtin.utils import read_json
 from skillsaw.context import RepositoryContext, RepositoryType
 
 PLUGIN_REPO_TYPES = {RepositoryType.SINGLE_PLUGIN, RepositoryType.MARKETPLACE}
@@ -84,15 +84,10 @@ class PluginJsonValidRule(Rule):
                 continue  # Handled by plugin-json-required rule
 
             # Try to parse JSON
-            try:
-                with open(plugin_json, "r") as f:
-                    data = json.load(f)
-            except json.JSONDecodeError as e:
-                violations.append(self.violation(f"Invalid JSON: {e}", file_path=plugin_json))
-                continue
-            except IOError as e:
+            data, error = read_json(plugin_json)
+            if error:
                 violations.append(
-                    self.violation(f"Failed to read file: {e}", file_path=plugin_json)
+                    self.violation(f"Invalid JSON: {error}", file_path=plugin_json)
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -86,9 +86,7 @@ class PluginJsonValidRule(Rule):
             # Try to parse JSON
             data, error = read_json(plugin_json)
             if error:
-                violations.append(
-                    self.violation(f"Invalid JSON: {error}", file_path=plugin_json)
-                )
+                violations.append(self.violation(f"Invalid JSON: {error}", file_path=plugin_json))
                 continue
 
             # Check required fields

--- a/src/skillsaw/rules/builtin/rules_dir.py
+++ b/src/skillsaw/rules/builtin/rules_dir.py
@@ -106,8 +106,7 @@ class RulesValidRule(Rule):
                 for key in sorted(unknown_keys):
                     violations.append(
                         self.violation(
-                            f"Unknown frontmatter key '{key}'. "
-                            f"Only 'paths' is supported",
+                            f"Unknown frontmatter key '{key}'. " f"Only 'paths' is supported",
                             file_path=file_path,
                             line=frontmatter_key_line(file_path, key),
                             severity=Severity.WARNING,

--- a/src/skillsaw/rules/builtin/rules_dir.py
+++ b/src/skillsaw/rules/builtin/rules_dir.py
@@ -10,6 +10,7 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.rules.builtin.utils import read_text, frontmatter_key_line
 
 
 def _parse_frontmatter(content: str):
@@ -85,10 +86,11 @@ class RulesValidRule(Rule):
                 )
                 continue
 
-            try:
-                content = file_path.read_text(encoding="utf-8")
-            except (IOError, UnicodeDecodeError) as e:
-                violations.append(self.violation(f"Failed to read file: {e}", file_path=file_path))
+            content = read_text(file_path)
+            if content is None:
+                violations.append(
+                    self.violation(f"Failed to read file: {file_path}", file_path=file_path)
+                )
                 continue
 
             frontmatter, error = _parse_frontmatter(content)
@@ -101,24 +103,28 @@ class RulesValidRule(Rule):
 
             unknown_keys = set(frontmatter.keys()) - _VALID_FRONTMATTER_KEYS
             if unknown_keys:
-                violations.append(
-                    self.violation(
-                        f"Unknown frontmatter key(s): {', '.join(sorted(unknown_keys))}. "
-                        f"Only 'paths' is supported",
-                        file_path=file_path,
-                        severity=Severity.WARNING,
+                for key in sorted(unknown_keys):
+                    violations.append(
+                        self.violation(
+                            f"Unknown frontmatter key '{key}'. "
+                            f"Only 'paths' is supported",
+                            file_path=file_path,
+                            line=frontmatter_key_line(file_path, key),
+                            severity=Severity.WARNING,
+                        )
                     )
-                )
 
             if "paths" not in frontmatter:
                 continue
 
+            paths_line = frontmatter_key_line(file_path, "paths")
             paths = frontmatter["paths"]
             if not isinstance(paths, list):
                 violations.append(
                     self.violation(
                         "'paths' must be a list of glob patterns",
                         file_path=file_path,
+                        line=paths_line,
                     )
                 )
                 continue
@@ -129,6 +135,7 @@ class RulesValidRule(Rule):
                         self.violation(
                             f"paths[{i}]: must be a string, got {type(pattern).__name__}",
                             file_path=file_path,
+                            line=paths_line,
                         )
                     )
                     continue
@@ -138,6 +145,7 @@ class RulesValidRule(Rule):
                         self.violation(
                             f"paths[{i}]: empty glob pattern",
                             file_path=file_path,
+                            line=paths_line,
                         )
                     )
                     continue
@@ -145,8 +153,9 @@ class RulesValidRule(Rule):
                 if pattern.startswith("/") or pattern.startswith("\\"):
                     violations.append(
                         self.violation(
-                            f"paths[{i}]: '{pattern}' must be a relative path, " f"not absolute",
+                            f"paths[{i}]: '{pattern}' must be a relative path, not absolute",
                             file_path=file_path,
+                            line=paths_line,
                         )
                     )
 
@@ -157,6 +166,7 @@ class RulesValidRule(Rule):
                         self.violation(
                             f"paths[{i}]: '{pattern}' must not contain '..' segments",
                             file_path=file_path,
+                            line=paths_line,
                         )
                     )
 

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -7,6 +7,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_text
 
 
 class SkillFrontmatterRule(Rule):
@@ -40,12 +41,10 @@ class SkillFrontmatterRule(Rule):
                     violations.append(self.violation("Missing SKILL.md", file_path=skill_dir))
                     continue
 
-                try:
-                    with open(skill_md, "r") as f:
-                        content = f.read()
-                except IOError as e:
+                content = read_text(skill_md)
+                if content is None:
                     violations.append(
-                        self.violation(f"Failed to read file: {e}", file_path=skill_md)
+                        self.violation(f"Failed to read file: {skill_md}", file_path=skill_md)
                     )
                     continue
 

--- a/src/skillsaw/rules/builtin/utils.py
+++ b/src/skillsaw/rules/builtin/utils.py
@@ -1,0 +1,61 @@
+"""Shared utilities for builtin rules."""
+
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+@lru_cache(maxsize=512)
+def read_text(file_path: Path) -> Optional[str]:
+    """Cached file read. Returns None on I/O or encoding errors."""
+    try:
+        return file_path.read_text(encoding="utf-8")
+    except (IOError, UnicodeDecodeError):
+        return None
+
+
+@lru_cache(maxsize=512)
+def read_json(file_path: Path) -> Tuple[Optional[object], Optional[str]]:
+    """Cached JSON file read. Returns (data, error)."""
+    content = read_text(file_path)
+    if content is None:
+        return None, f"Failed to read {file_path.name}"
+    try:
+        return json.loads(content), None
+    except json.JSONDecodeError as e:
+        return None, str(e)
+
+
+@lru_cache(maxsize=512)
+def frontmatter_key_line(file_path: Path, key: str) -> Optional[int]:
+    """Find the line number of a top-level key in YAML frontmatter."""
+    content = read_text(file_path)
+    if content is None:
+        return None
+    pattern = re.compile(rf"^{re.escape(key)}\s*:")
+    in_frontmatter = False
+    for i, line in enumerate(content.splitlines(), 1):
+        if line.strip() == "---":
+            if not in_frontmatter:
+                in_frontmatter = True
+                continue
+            break
+        if in_frontmatter and pattern.match(line):
+            return i
+    return None
+
+
+@lru_cache(maxsize=512)
+def heading_line(file_path: Path, heading: str, level: int = 2) -> Optional[int]:
+    """Find the line number of a markdown heading."""
+    content = read_text(file_path)
+    if content is None:
+        return None
+    prefix = "#" * level
+    pattern = re.compile(rf"^{prefix}\s+{re.escape(heading)}\s*$")
+    for i, line in enumerate(content.splitlines(), 1):
+        if pattern.match(line):
+            return i
+    return None

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -178,6 +178,8 @@ def test_missing_name_fails(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillValidRule().check(context)
     assert any("name" in v.message for v in violations)
+    v = [v for v in violations if "name" in v.message][0]
+    assert v.line is None
 
 
 def test_missing_description_fails(temp_dir):
@@ -199,6 +201,8 @@ def test_name_too_long_fails(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillValidRule().check(context)
     assert any("exceeds" in v.message and "64" in v.message for v in violations)
+    v = [v for v in violations if "exceeds" in v.message][0]
+    assert v.line == 2
 
 
 def test_description_too_long_checked_by_description_rule(temp_dir):
@@ -259,6 +263,7 @@ def test_name_uppercase_fails(temp_dir):
     violations = AgentSkillNameRule().check(context)
     assert len(violations) >= 1
     assert any("lowercase" in v.message for v in violations)
+    assert violations[0].line == 2
 
 
 def test_name_consecutive_hyphens_fails(temp_dir):
@@ -269,6 +274,7 @@ def test_name_consecutive_hyphens_fails(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillNameRule().check(context)
     assert any("consecutive" in v.message for v in violations)
+    assert violations[0].line == 2
 
 
 def test_name_trailing_hyphen_fails(temp_dir):
@@ -291,6 +297,8 @@ def test_name_dir_mismatch_fails(temp_dir):
     context = RepositoryContext(repo)
     violations = AgentSkillNameRule().check(context)
     assert any("does not match directory" in v.message for v in violations)
+    v = [v for v in violations if "does not match directory" in v.message][0]
+    assert v.line == 2
 
 
 def test_name_at_root_skips_dir_check(temp_dir):
@@ -328,6 +336,7 @@ def test_description_whitespace_only_fails(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillDescriptionRule().check(context)
     assert any("empty" in v.message for v in violations)
+    assert violations[0].line == 3
 
 
 def test_description_over_limit_warns(temp_dir):
@@ -339,6 +348,7 @@ def test_description_over_limit_warns(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillDescriptionRule().check(context)
     assert any("exceeds" in v.message for v in violations)
+    assert violations[0].line == 3
 
 
 # --- agentskill-structure ---

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -140,7 +140,14 @@ def test_self_lint():
     config = LinterConfig.default()
     linter = Linter(context, config)
 
+    # Exclude intentional test fixtures (PR #29: code scanning test)
+    test_fixtures = {"Bad_Skill"}
     violations = linter.run()
-    errors = [v for v in violations if v.severity.value == "error"]
+    errors = [
+        v
+        for v in violations
+        if v.severity.value == "error"
+        and not any(part in str(v.file_path) for part in test_fixtures)
+    ]
 
     assert len(errors) == 0, f"Self-lint found errors: {errors}"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -16,6 +16,7 @@ from skillsaw.rules.builtin.plugin_structure import (
 from skillsaw.rules.builtin.command_format import (
     CommandNamingRule,
     CommandFrontmatterRule,
+    CommandNameFormatRule,
 )
 from skillsaw.rules.builtin.marketplace import (
     MarketplaceRegistrationRule,
@@ -225,3 +226,29 @@ def test_plugin_json_missing_name_is_error(temp_dir):
     assert "name" in errors[0].message
     # version and author are missing -> 2 warnings
     assert len(warnings) == 2
+
+
+def test_command_name_format_reports_line_number(temp_dir):
+    """CommandNameFormatRule should report the line of the ## Name heading"""
+    import json
+
+    plugin_dir = temp_dir / "my-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "my-plugin"}, f)
+
+    commands_dir = plugin_dir / "commands"
+    commands_dir.mkdir()
+
+    (commands_dir / "do-thing.md").write_text(
+        "---\ndescription: Does a thing\n---\n\n## Name\nwrong-name:do-thing\n\n## Synopsis\nUsage\n"
+    )
+
+    context = RepositoryContext(plugin_dir)
+    violations = CommandNameFormatRule().check(context)
+    assert len(violations) == 1
+    assert "my-plugin:do-thing" in violations[0].message
+    assert violations[0].line == 5

--- a/tests/test_rules_dir.py
+++ b/tests/test_rules_dir.py
@@ -127,7 +127,7 @@ def test_frontmatter_not_a_mapping(dot_claude_with_rules):
 
 
 def test_unknown_frontmatter_key_warns(dot_claude_with_rules):
-    """Unknown frontmatter keys produce a warning"""
+    """Unknown frontmatter keys produce a warning with correct line number"""
     content = "---\npaths:\n  - '**/*.ts'\ntitle: My Rule\n---\n\n# Rules\n"
     _write_rule(dot_claude_with_rules, "extra.md", content)
 
@@ -137,10 +137,11 @@ def test_unknown_frontmatter_key_warns(dot_claude_with_rules):
     assert len(violations) == 1
     assert violations[0].severity == Severity.WARNING
     assert "title" in violations[0].message
+    assert violations[0].line == 4
 
 
 def test_paths_not_a_list(dot_claude_with_rules):
-    """paths field that isn't a list produces an error"""
+    """paths field that isn't a list produces an error with line number"""
     content = '---\npaths: "**/*.ts"\n---\n\n# Rules\n'
     _write_rule(dot_claude_with_rules, "scalar.md", content)
 
@@ -149,6 +150,7 @@ def test_paths_not_a_list(dot_claude_with_rules):
     violations = rule.check(context)
     assert len(violations) == 1
     assert "must be a list" in violations[0].message
+    assert violations[0].line == 2
 
 
 def test_paths_entry_not_string(dot_claude_with_rules):
@@ -177,7 +179,7 @@ def test_empty_glob_pattern(dot_claude_with_rules):
 
 
 def test_absolute_path_pattern(dot_claude_with_rules):
-    """Absolute path in pattern produces an error"""
+    """Absolute path in pattern produces an error with paths line number"""
     content = '---\npaths:\n  - "/etc/config/**"\n---\n\n# Rules\n'
     _write_rule(dot_claude_with_rules, "absolute.md", content)
 
@@ -186,6 +188,7 @@ def test_absolute_path_pattern(dot_claude_with_rules):
     violations = rule.check(context)
     assert len(violations) == 1
     assert "relative path" in violations[0].message
+    assert violations[0].line == 2
 
 
 def test_parent_traversal_pattern(dot_claude_with_rules):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,95 @@
+"""
+Tests for builtin rule utilities (read_text, read_json, frontmatter_key_line, heading_line)
+"""
+
+from pathlib import Path
+
+from skillsaw.rules.builtin.utils import read_text, read_json, frontmatter_key_line, heading_line
+
+
+def test_read_text_returns_content(temp_dir):
+    f = temp_dir / "hello.txt"
+    f.write_text("hello world", encoding="utf-8")
+    assert read_text(f) == "hello world"
+
+
+def test_read_text_returns_none_on_missing(temp_dir):
+    assert read_text(temp_dir / "missing.txt") is None
+
+
+def test_read_json_parses_valid(temp_dir):
+    f = temp_dir / "data.json"
+    f.write_text('{"key": "value"}', encoding="utf-8")
+    data, error = read_json(f)
+    assert data == {"key": "value"}
+    assert error is None
+
+
+def test_read_json_returns_error_on_invalid(temp_dir):
+    f = temp_dir / "bad.json"
+    f.write_text("{not valid", encoding="utf-8")
+    data, error = read_json(f)
+    assert data is None
+    assert error is not None
+
+
+def test_read_json_returns_error_on_missing(temp_dir):
+    data, error = read_json(temp_dir / "missing.json")
+    assert data is None
+    assert "Failed to read" in error
+
+
+def test_frontmatter_key_line_finds_key(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("---\nname: test\ndescription: A thing\n---\n", encoding="utf-8")
+    assert frontmatter_key_line(f, "name") == 2
+    assert frontmatter_key_line(f, "description") == 3
+
+
+def test_frontmatter_key_line_returns_none_for_missing_key(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("---\nname: test\n---\n", encoding="utf-8")
+    assert frontmatter_key_line(f, "description") is None
+
+
+def test_frontmatter_key_line_returns_none_without_frontmatter(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("# Just markdown\n", encoding="utf-8")
+    assert frontmatter_key_line(f, "name") is None
+
+
+def test_frontmatter_key_line_returns_none_on_missing_file(temp_dir):
+    assert frontmatter_key_line(temp_dir / "nope.md", "name") is None
+
+
+def test_frontmatter_key_line_ignores_keys_outside_frontmatter(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("---\ntitle: hello\n---\nname: not-in-frontmatter\n", encoding="utf-8")
+    assert frontmatter_key_line(f, "name") is None
+    assert frontmatter_key_line(f, "title") == 2
+
+
+def test_heading_line_finds_heading(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("---\nfoo: bar\n---\n\n## Name\nSome content\n\n## Description\nMore\n")
+    assert heading_line(f, "Name") == 5
+    assert heading_line(f, "Description") == 8
+
+
+def test_heading_line_returns_none_for_missing(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("## Name\nContent\n")
+    assert heading_line(f, "Synopsis") is None
+
+
+def test_heading_line_respects_level(temp_dir):
+    f = temp_dir / "doc.md"
+    f.write_text("# Top\n## Sub\n### Deep\n")
+    assert heading_line(f, "Top", level=1) == 1
+    assert heading_line(f, "Sub", level=2) == 2
+    assert heading_line(f, "Deep", level=3) == 3
+    assert heading_line(f, "Top", level=2) is None
+
+
+def test_heading_line_returns_none_on_missing_file(temp_dir):
+    assert heading_line(temp_dir / "nope.md", "Name") is None


### PR DESCRIPTION
## Summary
- Adds a reusable composite GitHub Action (`action.yml`) that installs and runs skillsaw, then posts violations as individual PR comments
- Fingerprint-based deduplication: unchanged findings keep their comments, new findings get new comments, fixed findings have their threads resolved (not deleted)
- Line-scoped violations appear inline in the diff, file-scoped violations appear as file-level comments
- Inputs passed via `env:` to prevent command injection
- Line number reporting for SKILL.md frontmatter violations (`_frontmatter_key_line` with `@lru_cache`)
- Self-lint workflow simplified to use the action directly

## Test plan
- [x] CI passes with no violations on clean `.claude/`
- [x] Introduce a violation, verify inline comment appears
- [x] Fix the violation, verify thread is resolved (not deleted)
- [x] Push with no changes, verify no duplicate comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)