### PR TITLE
Fix review comments for files not in PR diff

### DIFF
--- a/action/review.py
+++ b/action/review.py
@@ -143,8 +143,13 @@ def fingerprint(rule_id, file_path, message):
     return hashlib.sha256(key.encode()).hexdigest()[:12]
 
 
-def get_diff_lines(repo, pr_number):
-    """Get the set of (path, line) tuples for added/modified lines in the PR."""
+def get_diff_info(repo, pr_number):
+    """Get diff files and added/modified line numbers.
+
+    Returns (diff_files, diff_lines) where diff_files is a set of file paths
+    and diff_lines is a set of (path, line) tuples.
+    """
+    diff_files = set()
     diff_lines = set()
     page = 1
     while True:
@@ -153,6 +158,7 @@ def get_diff_lines(repo, pr_number):
             break
         for f in files:
             path = f["filename"]
+            diff_files.add(path)
             patch = f.get("patch", "")
             if not patch:
                 continue
@@ -170,7 +176,7 @@ def get_diff_lines(repo, pr_number):
                 else:
                     current_line += 1
         page += 1
-    return diff_lines
+    return diff_files, diff_lines
 
 
 def sync_comments(repo, pr_number, new_comments):
@@ -238,13 +244,18 @@ def main():
         print("No violations found.")
         return
 
-    diff_lines = get_diff_lines(repo, pr_number)
+    diff_files, diff_lines = get_diff_info(repo, pr_number)
 
     new_comments = []
+    skipped = 0
     for v in violations:
         path = v.get("file_path")
         line = v.get("line")
         if not path:
+            continue
+
+        if path not in diff_files:
+            skipped += 1
             continue
 
         fp = fingerprint(v["rule_id"], path, v["message"])
@@ -263,20 +274,45 @@ def main():
 
         new_comments.append(comment)
 
-    to_post = sync_comments(repo, pr_number, new_comments)
+    if skipped:
+        print(f"Skipped {skipped} violation(s) on files not in the diff.")
+
+    try:
+        to_post = sync_comments(repo, pr_number, new_comments)
+    except urllib.error.HTTPError as e:
+        if e.code == 403:
+            print(
+                "Cannot read PR comments (fork PR with read-only token). "
+                "Skipping inline review comments.",
+                file=sys.stderr,
+            )
+            return
+        raise
 
     posted = 0
+    failed = 0
     for comment in to_post:
         payload = {k: v for k, v in comment.items() if k != "fingerprint"}
         try:
             github_api("POST", f"/repos/{repo}/pulls/{pr_number}/comments", payload)
             posted += 1
         except urllib.error.HTTPError as e:
-            if e.code in (401, 403, 429):
+            if e.code == 403:
+                print(
+                    "Cannot post PR comments (fork PR with read-only token). "
+                    "Skipping inline review comments.",
+                    file=sys.stderr,
+                )
+                return
+            if e.code in (401, 429):
                 raise
+            failed += 1
 
     kept = len(new_comments) - len(to_post)
-    print(f"Posted {posted} new comment(s), {kept} unchanged.")
+    parts = [f"Posted {posted} new comment(s)", f"{kept} unchanged"]
+    if failed:
+        parts.append(f"{failed} failed")
+    print(", ".join(parts) + ".")
 
 
 if __name__ == "__main__":

--- a/action/review.py
+++ b/action/review.py
@@ -9,6 +9,7 @@ import urllib.error
 import urllib.request
 
 FINGERPRINT_RE = re.compile(r"<!-- skillsaw:([a-f0-9]+) -->")
+SUMMARY_MARKER = "<!-- skillsaw:summary -->"
 SEVERITY_ICONS = {"error": "❌", "warning": "⚠️", "info": "ℹ️"}
 API = "https://api.github.com"
 
@@ -218,6 +219,49 @@ def sync_comments(repo, pr_number, new_comments):
     return [c for c in new_comments if c["fingerprint"] not in existing]
 
 
+def upsert_summary_comment(repo, pr_number, non_diff_violations):
+    """Create or update a single issue comment for violations outside the diff."""
+    page = 1
+    existing_id = None
+    while True:
+        comments = github_api(
+            "GET", f"/repos/{repo}/issues/{pr_number}/comments?per_page=100&page={page}"
+        )
+        if not comments:
+            break
+        for c in comments:
+            if SUMMARY_MARKER in c.get("body", ""):
+                existing_id = c["id"]
+                break
+        if existing_id:
+            break
+        page += 1
+
+    if not non_diff_violations and existing_id:
+        github_api("DELETE", f"/repos/{repo}/issues/comments/{existing_id}")
+        return
+
+    if not non_diff_violations:
+        return
+
+    lines = ["### skillsaw: violations outside this diff\n"]
+    lines.append("| Severity | Rule | File | Message |")
+    lines.append("|----------|------|------|---------|")
+    for v in non_diff_violations:
+        icon = SEVERITY_ICONS.get(v["severity"], "")
+        path = v.get("file_path", "")
+        line = v.get("line")
+        loc = f"`{path}:{line}`" if line else f"`{path}`"
+        lines.append(f"| {icon} {v['severity']} | `{v['rule_id']}` | {loc} | {v['message']} |")
+    lines.append(f"\n{SUMMARY_MARKER}")
+    body = "\n".join(lines)
+
+    if existing_id:
+        github_api("PATCH", f"/repos/{repo}/issues/comments/{existing_id}", {"body": body})
+    else:
+        github_api("POST", f"/repos/{repo}/issues/{pr_number}/comments", {"body": body})
+
+
 def main():
     report_file = os.environ.get("SKILLSAW_REPORT_FILE", "")
     if not report_file or not os.path.exists(report_file):
@@ -247,7 +291,7 @@ def main():
     diff_files, diff_lines = get_diff_info(repo, pr_number)
 
     new_comments = []
-    skipped = 0
+    non_diff_violations = []
     for v in violations:
         path = v.get("file_path")
         line = v.get("line")
@@ -255,7 +299,7 @@ def main():
             continue
 
         if path not in diff_files:
-            skipped += 1
+            non_diff_violations.append(v)
             continue
 
         fp = fingerprint(v["rule_id"], path, v["message"])
@@ -274,8 +318,12 @@ def main():
 
         new_comments.append(comment)
 
-    if skipped:
-        print(f"Skipped {skipped} violation(s) on files not in the diff.")
+    try:
+        upsert_summary_comment(repo, pr_number, non_diff_violations)
+        if non_diff_violations:
+            print(f"Posted summary comment with {len(non_diff_violations)} violation(s) outside the diff.")
+    except Exception as e:
+        print(f"Failed to post summary comment: {e}", file=sys.stderr)
 
     try:
         to_post = sync_comments(repo, pr_number, new_comments)

--- a/action/review.py
+++ b/action/review.py
@@ -288,7 +288,17 @@ def main():
         print("No violations found.")
         return
 
-    diff_files, diff_lines = get_diff_info(repo, pr_number)
+    try:
+        diff_files, diff_lines = get_diff_info(repo, pr_number)
+    except urllib.error.HTTPError as e:
+        if e.code == 403:
+            print(
+                "Cannot read PR files (insufficient token permissions). "
+                "Skipping inline review comments.",
+                file=sys.stderr,
+            )
+            return
+        raise
 
     new_comments = []
     non_diff_violations = []


### PR DESCRIPTION
## Summary
- Track which files are in the PR diff and skip violations on paths not present (fixes 422 "path could not be resolved" errors)
- Report failed comment count separately instead of silently swallowing errors
- Gracefully handle 403 on fork PRs (read-only token)

## Context
Tested on [openshift-eng/ai-helpers#456](https://github.com/openshift-eng/ai-helpers/pull/456) — violations on `.claude-plugin/marketplace.json` (not in diff) and `plugins/Oops` (directory path) caused 422 errors from GitHub's PR comment API.

## Test plan
- [ ] CI passes
- [ ] Re-test against ai-helpers PR after merging and updating v0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)