### PR TITLE
Add serial review panel skill and GitHub Action

### DIFF
--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -1,7 +1,7 @@
 name: Skillsaw Review Panel
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 concurrency:


### PR DESCRIPTION
## Summary

- Adds a serial-only multi-specialist review panel skill (`.apm/skills/skillsaw-review-panel/`) with 5 specialists: Architecture, Python Expert, Security & Supply Chain, QA Engineer, Technical Writer, plus a Panel Arbiter
- Includes a verdict template for consistent PR comment formatting
- Adds a GitHub Action (`.github/workflows/skillsaw-review-panel.yml`) triggered by the `panel-review` label via `pull_request_target`
- Marks `.claude/` as `linguist-generated` so GitHub collapses generated diffs

## Test plan

- [ ] Merge this PR, then add `panel-review` label to an open PR to verify the workflow triggers
- [ ] Verify the skill can also be invoked locally via `/skillsaw-review-panel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)