### PR TITLE
Bypass OIDC for pull_request_target in review panel

### DIFF
--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -1,7 +1,7 @@
 name: Skillsaw Review Panel
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 concurrency:
@@ -29,6 +29,8 @@ jobs:
           fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          OVERRIDE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: |
             Use the skillsaw-review-panel skill. Follow every step in the skill.


### PR DESCRIPTION
## Summary

- Set `OVERRIDE_GITHUB_TOKEN` to skip OIDC token exchange which fails on `pull_request_target` events
- Restore `pull_request_target` trigger (required for label events to fire)

## Test plan

- [ ] Merge, add `panel-review` label to a PR, verify it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)