### PR TITLE
Use github_token to skip OIDC app token exchange

### DIFF
--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -29,14 +29,13 @@ jobs:
           fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
-        env:
-          OVERRIDE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: |
             Use the skillsaw-review-panel skill. Follow every step in the skill.
 
             Review PR #${{ github.event.pull_request.number }}.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Glob,Grep,TaskCreate,TaskUpdate,TaskList,TaskGet


### PR DESCRIPTION
Per anthropics/claude-code-action#721, providing github_token explicitly bypasses the GitHub App OIDC flow that fails on pull_request_target.