### PR TITLE
Unify CLI as proper subcommands

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,5 +56,5 @@ jobs:
         run: |
           docker build -t test-image .
           docker run test-image --version
-          docker run test-image --list-rules
+          docker run test-image list-rules
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,13 +115,13 @@ jobs:
       - name: Test --version
         run: skillsaw --version
 
-      - name: Test --list-rules
-        run: skillsaw --list-rules
+      - name: Test list-rules
+        run: skillsaw list-rules
 
-      - name: Test --init
+      - name: Test init
         run: |
           cd /tmp
-          skillsaw --init
+          skillsaw init
           test -f .skillsaw.yaml
 
       - name: Test claudelint shim

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: $(VENV)/bin/activate
 
 generate-example: $(VENV)/bin/activate
 	rm -f .skillsaw.yaml.example
-	$(VENV)/bin/skillsaw --init
+	$(VENV)/bin/skillsaw init
 	mv .skillsaw.yaml .skillsaw.yaml.example
 
 generate-docs: $(VENV)/bin/activate

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ skillsaw -v
 skillsaw --strict
 
 # Generate default config
-skillsaw --init
+skillsaw init
 
 # List all available rules
-skillsaw --list-rules
+skillsaw list-rules
 
 # Generate documentation
 skillsaw docs
@@ -266,7 +266,7 @@ Plugins from `plugins/`, custom paths, and remote sources can coexist in one mar
 Generate a default `.skillsaw.yaml` in your repository root:
 
 ```bash
-skillsaw --init
+skillsaw init
 ```
 
 This creates a config file with all builtin rules, their defaults, and

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -13,97 +13,83 @@ from .linter import Linter
 from .formatters import format_report, get_counts, infer_format, FORMATS
 from . import __version__
 
+_SUBCOMMANDS = {"lint", "init", "list-rules", "docs", "add"}
+
+
+def _get_version() -> str:
+    try:
+        return version("skillsaw")
+    except PackageNotFoundError:
+        return __version__
+
 
 def main():
-    # Check if the first positional arg is a known subcommand.
-    # If so, dispatch to subcommand-specific parsing.
-    # Otherwise, fall through to the original flat-flag lint CLI.
-    if len(sys.argv) > 1 and sys.argv[1] == "docs":
-        return _run_docs_cli()
-
+    # When no subcommand is given (or the first arg looks like a path/flag),
+    # default to "lint" so bare `skillsaw` and `skillsaw /path` keep working.
+    # `add` has its own argparse — dispatch before the main parser sees the args.
     if len(sys.argv) > 1 and sys.argv[1] == "add":
         from .marketplace.cli import _run_add_cli
 
         return _run_add_cli()
 
-    _run_lint_cli()
+    if len(sys.argv) < 2 or sys.argv[1] not in _SUBCOMMANDS | {"--version", "-h", "--help"}:
+        sys.argv.insert(1, "lint")
 
-
-def _run_lint_cli():
     parser = argparse.ArgumentParser(
-        description="Lint agent skills, plugins, and AI coding assistant context",
+        prog="skillsaw",
+        description="Keep your skills sharp.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Lint current directory
-  skillsaw
-
-  # Lint specific directory
-  skillsaw /path/to/skills
-
-  # Use custom config
-  skillsaw --config .skillsaw.yaml
-
-  # Verbose output
-  skillsaw -v
-
-  # Strict mode (warnings as errors)
-  skillsaw --strict
-
-  # JSON output to stdout
-  skillsaw --format json
-
-  # Text to stdout, SARIF + HTML to files
-  skillsaw --output results.sarif --output report.html
-
-  # Generate default config
-  skillsaw --init
-
-  # Generate documentation
-  skillsaw docs
-
-  # Create a new marketplace
-  skillsaw add marketplace --name my-plugins --owner myuser
-
-  # Add a plugin to a marketplace
-  skillsaw add plugin my-plugin
+  skillsaw                        # Lint current directory
+  skillsaw lint /path/to/skills   # Lint specific directory
+  skillsaw init                   # Generate default config
+  skillsaw list-rules             # List available rules
+  skillsaw docs                   # Generate documentation
+  skillsaw add marketplace        # Scaffold a new marketplace
 
 For more information, visit: https://github.com/stbenjam/skillsaw
         """,
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {_get_version()}")
 
-    parser.add_argument(
+    subparsers = parser.add_subparsers(dest="command")
+
+    # --- lint ---
+    lint_parser = subparsers.add_parser(
+        "lint",
+        help="Lint agent skills, plugins, and AI coding assistant context",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    lint_parser.add_argument(
         "path",
         nargs="?",
         type=Path,
         default=Path.cwd(),
         help="Path to skill, plugin, or marketplace directory (default: current directory)",
     )
-
-    parser.add_argument(
+    lint_parser.add_argument(
         "-c",
         "--config",
         type=Path,
         help="Path to .skillsaw.yaml config file (default: auto-discover)",
     )
-
-    parser.add_argument("-v", "--verbose", action="store_true", help="Show info-level messages")
-
-    parser.add_argument(
+    lint_parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Show info-level messages"
+    )
+    lint_parser.add_argument(
         "--strict",
         action="store_true",
         help="Treat warnings as errors (exit with error code if warnings exist)",
     )
-
-    parser.add_argument(
+    lint_parser.add_argument(
         "--format",
         dest="fmt",
         default="text",
         choices=FORMATS,
         help="Output format for stdout (default: text)",
     )
-
-    parser.add_argument(
+    lint_parser.add_argument(
         "--output",
         dest="outputs",
         action="append",
@@ -113,50 +99,74 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         "Can be specified multiple times.",
     )
 
-    parser.add_argument(
-        "--init", action="store_true", help="Generate a default .skillsaw.yaml config file"
+    # --- init ---
+    init_parser = subparsers.add_parser(
+        "init", help="Generate a default .skillsaw.yaml config file"
+    )
+    init_parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+        help="Directory to create config in (default: current directory)",
     )
 
-    parser.add_argument(
-        "--list-rules", action="store_true", help="List all available builtin rules"
+    # --- list-rules ---
+    subparsers.add_parser("list-rules", help="List all available builtin rules")
+
+    # --- docs ---
+    docs_parser = subparsers.add_parser(
+        "docs",
+        help="Generate documentation for a plugin, marketplace, or .claude repository",
+        description="Generate documentation for a plugin, marketplace, or .claude repository",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    docs_parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to repository (default: current directory)",
+    )
+    docs_parser.add_argument(
+        "--format",
+        dest="fmt",
+        default="html",
+        choices=["html", "markdown"],
+        help="Output format (default: html)",
+    )
+    docs_parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file or directory (default: skillsaw-docs/). "
+        "If it ends with .html/.md, writes a single file directly.",
+    )
+    docs_parser.add_argument("--title", default=None, help="Custom title for the documentation")
 
-    # Get version from package metadata, fall back to __version__
-    try:
-        cli_version = version("skillsaw")
-    except PackageNotFoundError:
-        cli_version = __version__
-
-    parser.add_argument("--version", action="version", version=f"%(prog)s {cli_version}")
+    # --- add ---
+    subparsers.add_parser(
+        "add",
+        help="Scaffold marketplaces, plugins, skills, commands, agents, and hooks",
+        add_help=False,
+    )
 
     args = parser.parse_args()
 
-    # Handle --init
-    if args.init:
-        config_path = args.path / ".skillsaw.yaml"
-        if config_path.exists():
-            print(f"Config file already exists: {config_path}")
-            sys.exit(1)
+    if args.command == "lint":
+        _run_lint(args)
+    elif args.command == "init":
+        _run_init(args)
+    elif args.command == "list-rules":
+        _run_list_rules()
+    elif args.command == "docs":
+        _run_docs(args)
 
-        config = LinterConfig.default()
-        config.save(config_path)
-        print(f"Created default config: {config_path}")
-        sys.exit(0)
 
-    # Handle --list-rules
-    if args.list_rules:
-        from skillsaw.rules.builtin import BUILTIN_RULES
+def _run_lint(args):
+    cli_version = _get_version()
 
-        print("Available builtin rules:\n")
-        for rule_class in BUILTIN_RULES:
-            rule = rule_class()
-            print(f"  {rule.rule_id}")
-            print(f"    {rule.description}")
-            print(f"    Default severity: {rule.default_severity().value}")
-            print()
-        sys.exit(0)
-
-    # Validate --output extensions early
     output_formats = {}
     for output_path in args.outputs:
         try:
@@ -165,17 +175,14 @@ For more information, visit: https://github.com/stbenjam/skillsaw
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
 
-    # Validate path
     if not args.path.exists():
         print(f"Error: Path not found: {args.path}", file=sys.stderr)
         sys.exit(1)
 
-    # Create repository context
     if args.fmt == "text":
         print(f"Linting: {args.path}\n")
     context = RepositoryContext(args.path)
 
-    # Show repository type
     if context.repo_type == RepositoryType.UNKNOWN:
         print("Warning: Directory doesn't appear to be a recognized repository", file=sys.stderr)
         print(
@@ -183,14 +190,12 @@ For more information, visit: https://github.com/stbenjam/skillsaw
             file=sys.stderr,
         )
 
-    # Load config
     if args.config:
         config_path = args.config
         if not config_path.exists():
             print(f"Error: Config file not found: {config_path}", file=sys.stderr)
             sys.exit(1)
     else:
-        # Auto-discover config
         config_path = find_config(args.path)
 
     if config_path:
@@ -204,21 +209,17 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     else:
         config = LinterConfig.default()
 
-    # Apply strict mode from CLI
     if args.strict:
         config.strict = True
 
-    # Create and run linter
     linter = Linter(context, config)
     violations = linter.run()
 
-    # Format and print to stdout
     stdout_output = format_report(
         args.fmt, violations, context, linter.rules, cli_version, verbose=args.verbose
     )
     print(stdout_output)
 
-    # Write to output files
     report_cache = {}
     for output_path, fmt in output_formats.items():
         if fmt not in report_cache:
@@ -229,7 +230,6 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(report_cache[fmt], encoding="utf-8")
 
-    # Exit with appropriate code
     errors, warnings_count, info = get_counts(violations)
 
     if errors > 0:
@@ -240,64 +240,32 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         sys.exit(0)
 
 
-def _run_docs_cli():
-    parser = argparse.ArgumentParser(
-        prog="skillsaw docs",
-        description="Generate documentation for a plugin, marketplace, or .claude repository",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Generate HTML docs for current directory
-  skillsaw docs
+def _run_init(args):
+    config_path = args.path / ".skillsaw.yaml"
+    if config_path.exists():
+        print(f"Config file already exists: {config_path}")
+        sys.exit(1)
 
-  # Generate markdown docs
-  skillsaw docs --format markdown
+    config = LinterConfig.default()
+    config.save(config_path)
+    print(f"Created default config: {config_path}")
+    sys.exit(0)
 
-  # Write to a specific directory
-  skillsaw docs -o my-docs/
 
-  # Write a single file directly
-  skillsaw docs --format markdown -o README.md
+def _run_list_rules():
+    from skillsaw.rules.builtin import BUILTIN_RULES
 
-  # Generate docs for a specific path with custom title
-  skillsaw docs /path/to/repo --title "My Plugins"
-        """,
-    )
+    print("Available builtin rules:\n")
+    for rule_class in BUILTIN_RULES:
+        rule = rule_class()
+        print(f"  {rule.rule_id}")
+        print(f"    {rule.description}")
+        print(f"    Default severity: {rule.default_severity().value}")
+        print()
+    sys.exit(0)
 
-    parser.add_argument(
-        "path",
-        nargs="?",
-        type=Path,
-        default=Path.cwd(),
-        help="Path to repository (default: current directory)",
-    )
 
-    parser.add_argument(
-        "--format",
-        dest="fmt",
-        default="html",
-        choices=["html", "markdown"],
-        help="Output format (default: html)",
-    )
-
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        default=None,
-        help="Output file or directory (default: skillsaw-docs/). "
-        "If it ends with .html/.md, writes a single file directly.",
-    )
-
-    parser.add_argument(
-        "--title",
-        default=None,
-        help="Custom title for the documentation",
-    )
-
-    # Skip argv[0] (program name) and argv[1] ("docs")
-    args = parser.parse_args(sys.argv[2:])
-
+def _run_docs(args):
     if not args.path.exists():
         print(f"Error: Path not found: {args.path}", file=sys.stderr)
         sys.exit(1)

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -253,7 +253,7 @@ def _run_init(args):
 
 
 def _run_list_rules():
-    from skillsaw.rules.builtin import BUILTIN_RULES
+    from .rules.builtin import BUILTIN_RULES
 
     print("Available builtin rules:\n")
     for rule_class in BUILTIN_RULES:


### PR DESCRIPTION
## Summary

- Replace `--init` and `--list-rules` flags with `skillsaw init` and `skillsaw list-rules` subcommands
- Unify the manual `sys.argv[1]` dispatch for `docs` and `add` into a single argparse subparsers structure
- Bare `skillsaw` continues to default to lint (backward compatible for the common case)
- Update Makefile, README, CI workflows to use new subcommand style

### Before
```
skillsaw --init           # flag
skillsaw --list-rules     # flag  
skillsaw docs             # manual dispatch
skillsaw add plugin       # manual dispatch
```

### After
```
skillsaw init             # subcommand
skillsaw list-rules       # subcommand
skillsaw docs             # subcommand
skillsaw add plugin       # subcommand
skillsaw                  # defaults to lint
skillsaw lint .           # explicit lint
```

## Test plan

- [x] All 418 tests pass
- [x] `skillsaw --version` works
- [x] `skillsaw -h` shows all subcommands
- [x] `skillsaw` (bare) defaults to lint
- [x] `skillsaw lint .` works
- [x] `skillsaw init` creates config
- [x] `skillsaw list-rules` lists rules
- [x] `skillsaw docs` generates docs
- [x] Formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)