### PR TITLE
Lint .coderabbit.yaml instruction fields with content rules

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,4 +1,4 @@
-# skillsaw
+# agent-a2c9f10f768c5389e
 
 ## Skills
 
@@ -60,6 +60,44 @@ Claude Code plugins, and plugin marketplaces.
 Rules MUST report line numbers in violations whenever the violation can be
 traced to a specific line in a file. This enables the GitHub Action to post
 inli
+
+## Skills
+
+### skillsaw-ecosystem-scout
+
+Survey the AI coding assistant and agentic tool ecosystem, assess skillsaw's competitive position, identify emerging patterns and missing capabilities, and produce a prioritized strategic report as a GitHub issue.
+
+**Compatibility:** Requires git, gh CLI, and internet access (WebFetch, WebSearch)
+
+### skillsaw-issue-solver
+
+Pick up open GitHub issues from collaborators and create PRs to solve them. Use when triaging and resolving reported bugs or feature requests.
+
+**Compatibility:** Requires git, gh CLI, and internet access
+
+### skillsaw-maintenance
+
+Analyze upstream specs (agentskills.io, Claude Code plugin/marketplace format) for changes, identify gaps in skillsaw's rule coverage, and create or update PRs to close those gaps. Use when performing periodic maintenance on the skillsaw linter.
+
+**Compatibility:** Requires git, gh CLI, and internet access
+
+### skillsaw-pr-review
+
+Review open PRs in skillsaw, fix failing CI, address reviewer feedback, and push updates. Use for triaging and fixing up existing pull requests.
+
+**Compatibility:** Requires git, gh CLI, and internet access
+
+### skillsaw-release
+
+Bump the version, generate release notes, and publish a new skillsaw release to PyPI. Use when cutting a new release.
+
+**Compatibility:** Requires git, gh CLI, and internet access
+
+### skillsaw-review-panel
+
+Serial multi-specialist code review panel for skillsaw PRs. Runs 5 specialist reviewers (Architecture, Python Expert, Security & Supply Chain, QA Engineer, Technical Writer) inline then synthesizes a single verdict.
+
+**Compatibility:** Requires git, gh CLI, and internet access
 
 
 ---

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,5 +1,3 @@
-# agent-a2c9f10f768c5389e
-
 ## Skills
 
 ### skillsaw-ecosystem-scout

--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -209,6 +209,16 @@ rules:
     enabled: auto
     severity: info
 
+  # .coderabbit.yaml must be valid YAML
+  coderabbit-yaml-valid:
+    enabled: auto
+    severity: error
+
+  # Check .coderabbit.yaml instruction fields for content quality issues
+  coderabbit-instructions:
+    enabled: auto
+    severity: warning
+
 # Load custom rules from these files
 custom-rules: []
 

--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -214,11 +214,6 @@ rules:
     enabled: auto
     severity: error
 
-  # Check .coderabbit.yaml instruction fields for content quality issues
-  coderabbit-instructions:
-    enabled: auto
-    severity: warning
-
 # Load custom rules from these files
 custom-rules: []
 

--- a/README.md
+++ b/README.md
@@ -428,12 +428,11 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 
 ### CodeRabbit
 
-Validates `.coderabbit.yaml` config files. Checks YAML syntax and scans instruction text fields (`reviews.instructions`, per-path instructions, per-tool instructions, `chat.instructions`) for content quality issues such as weak/hedge language. Auto-enabled when `.coderabbit.yaml` is detected.
+Validates `.coderabbit.yaml` config files for YAML syntax. Instruction text fields (`reviews.instructions`, per-path instructions, per-tool instructions, `chat.instructions`) are automatically checked by the content-* rules above. Auto-enabled when `.coderabbit.yaml` is detected.
 
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
 | `coderabbit-yaml-valid` | .coderabbit.yaml must be valid YAML | error (auto) | - |
-| `coderabbit-instructions` | Check .coderabbit.yaml instruction fields for content quality issues | warning (auto) | - |
 
 <!-- END GENERATED RULES -->
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,15 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 | `banned` | Additional banned patterns as list of {pattern, message} dicts | `[]` |
 | `skip-builtins` | Disable built-in deprecated model/API checks | `false` |
 
+### CodeRabbit
+
+Validates `.coderabbit.yaml` config files. Checks YAML syntax and scans instruction text fields (`reviews.instructions`, per-path instructions, per-tool instructions, `chat.instructions`) for content quality issues such as weak/hedge language. Auto-enabled when `.coderabbit.yaml` is detected.
+
+| Rule ID | Description | Default Severity |
+|---------|-------------|------------------|
+| `coderabbit-yaml-valid` | .coderabbit.yaml must be valid YAML | error (auto) |
+| `coderabbit-instructions` | Check .coderabbit.yaml instruction fields for content quality issues | warning (auto) |
+
 <!-- END GENERATED RULES -->
 
 ## Autofixing

--- a/README.md
+++ b/README.md
@@ -430,10 +430,10 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 
 Validates `.coderabbit.yaml` config files. Checks YAML syntax and scans instruction text fields (`reviews.instructions`, per-path instructions, per-tool instructions, `chat.instructions`) for content quality issues such as weak/hedge language. Auto-enabled when `.coderabbit.yaml` is detected.
 
-| Rule ID | Description | Default Severity |
-|---------|-------------|------------------|
-| `coderabbit-yaml-valid` | .coderabbit.yaml must be valid YAML | error (auto) |
-| `coderabbit-instructions` | Check .coderabbit.yaml instruction fields for content quality issues | warning (auto) |
+| Rule ID | Description | Default Severity | Autofix |
+|---------|-------------|------------------|---------|
+| `coderabbit-yaml-valid` | .coderabbit.yaml must be valid YAML | error (auto) | - |
+| `coderabbit-instructions` | Check .coderabbit.yaml instruction fields for content quality issues | warning (auto) | - |
 
 <!-- END GENERATED RULES -->
 

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -109,6 +109,15 @@ RULE_GROUPS = [
         "[docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) "
         "for the full research basis behind each rule.",
     ),
+    (
+        "CodeRabbit",
+        ["coderabbit-yaml-valid", "coderabbit-instructions"],
+        "Validates `.coderabbit.yaml` config files. Checks YAML syntax and "
+        "scans instruction text fields (`reviews.instructions`, per-path "
+        "instructions, per-tool instructions, `chat.instructions`) for "
+        "content quality issues such as weak/hedge language. Auto-enabled "
+        "when `.coderabbit.yaml` is detected.",
+    ),
 ]
 
 

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -111,11 +111,11 @@ RULE_GROUPS = [
     ),
     (
         "CodeRabbit",
-        ["coderabbit-yaml-valid", "coderabbit-instructions"],
-        "Validates `.coderabbit.yaml` config files. Checks YAML syntax and "
-        "scans instruction text fields (`reviews.instructions`, per-path "
-        "instructions, per-tool instructions, `chat.instructions`) for "
-        "content quality issues such as weak/hedge language. Auto-enabled "
+        ["coderabbit-yaml-valid"],
+        "Validates `.coderabbit.yaml` config files for YAML syntax. "
+        "Instruction text fields (`reviews.instructions`, per-path "
+        "instructions, per-tool instructions, `chat.instructions`) are "
+        "automatically checked by the content-* rules above. Auto-enabled "
         "when `.coderabbit.yaml` is detected.",
     ),
 ]

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -120,6 +120,15 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Write output to FILE (format inferred from extension: .json, .sarif, .html). "
         "Can be specified multiple times.",
     )
+    lint_parser.add_argument(
+        "--type",
+        dest="repo_types",
+        action="append",
+        default=[],
+        metavar="TYPE",
+        help="Override auto-detected repository type (repeatable). "
+        "Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit.",
+    )
 
     # --- fix ---
     fix_parser = subparsers.add_parser(
@@ -265,6 +274,21 @@ def _run_lint(args):
     if args.fmt == "text":
         print(f"Linting: {args.path}\n")
     context = RepositoryContext(args.path)
+
+    # Override repo_types if --type was provided
+    if args.repo_types:
+        type_map = {t.value: t for t in RepositoryType}
+        override_types = set()
+        for val in args.repo_types:
+            if val not in type_map:
+                print(
+                    f"Error: Unknown repository type '{val}'. "
+                    f"Valid types: {', '.join(sorted(type_map.keys()))}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            override_types.add(type_map[val])
+        context.repo_types = override_types
 
     if context.repo_type == RepositoryType.UNKNOWN:
         print("Warning: Directory doesn't appear to be a recognized repository", file=sys.stderr)

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -149,7 +149,6 @@ class LinterConfig:
                 "content-inconsistent-terminology": {"enabled": "auto", "severity": "info"},
                 # CodeRabbit config
                 "coderabbit-yaml-valid": {"enabled": "auto", "severity": "error"},
-                "coderabbit-instructions": {"enabled": "auto", "severity": "warning"},
             }
         )
 

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -221,7 +221,7 @@ class LinterConfig:
         if enabled == "auto":
             if repo_types is None and formats is None:
                 return True
-            if repo_types is not None and context.repo_type in repo_types:
+            if repo_types is not None and repo_types & context.repo_types:
                 return True
             if formats is not None and formats & context.detected_formats:
                 return True

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -147,6 +147,9 @@ class LinterConfig:
                 "content-embedded-secrets": {"enabled": "auto", "severity": "error"},
                 "content-banned-references": {"enabled": "auto", "severity": "warning"},
                 "content-inconsistent-terminology": {"enabled": "auto", "severity": "info"},
+                # CodeRabbit config
+                "coderabbit-yaml-valid": {"enabled": "auto", "severity": "error"},
+                "coderabbit-instructions": {"enabled": "auto", "severity": "warning"},
             }
         )
 

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -31,6 +31,7 @@ HAS_GEMINI = "HAS_GEMINI"
 HAS_AGENTS_MD = "HAS_AGENTS_MD"
 HAS_KIRO = "HAS_KIRO"
 HAS_CLAUDE_MD = "HAS_CLAUDE_MD"
+HAS_CODERABBIT = "HAS_CODERABBIT"
 ALL_INSTRUCTION_FORMATS = frozenset(
     {
         HAS_CURSOR,
@@ -39,6 +40,7 @@ ALL_INSTRUCTION_FORMATS = frozenset(
         HAS_AGENTS_MD,
         HAS_KIRO,
         HAS_CLAUDE_MD,
+        HAS_CODERABBIT,
     }
 )
 
@@ -114,6 +116,8 @@ class RepositoryContext:
             formats.add(HAS_KIRO)
         if (self.root_path / "CLAUDE.md").exists():
             formats.add(HAS_CLAUDE_MD)
+        if (self.root_path / ".coderabbit.yaml").exists():
+            formats.add(HAS_CODERABBIT)
         return formats
 
     _WALK_SKIP_DIRS = frozenset(

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -21,6 +21,7 @@ class RepositoryType(Enum):
     MARKETPLACE = "marketplace"  # Marketplace with multiple plugins
     AGENTSKILLS = "agentskills"  # agentskills.io skill repo
     DOT_CLAUDE = "dot-claude"  # .claude/ directory with commands, skills, hooks, etc.
+    CODERABBIT = "coderabbit"  # Repository with .coderabbit.yaml
     UNKNOWN = "unknown"  # Not a recognized repo type
 
 
@@ -51,6 +52,14 @@ class RepositoryContext:
 
     _INSTRUCTION_FILENAMES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md")
 
+    _TYPE_PRIORITY = [
+        RepositoryType.MARKETPLACE,
+        RepositoryType.SINGLE_PLUGIN,
+        RepositoryType.DOT_CLAUDE,
+        RepositoryType.AGENTSKILLS,
+        RepositoryType.CODERABBIT,
+    ]
+
     def __init__(self, root_path: Path):
         """
         Initialize repository context
@@ -59,7 +68,7 @@ class RepositoryContext:
             root_path: Root directory of the repository
         """
         self.root_path = root_path.resolve()
-        self.repo_type = self._detect_type()
+        self.repo_types: Set[RepositoryType] = self._detect_types()
         self.marketplace_data = self._load_marketplace() if self.has_marketplace() else None
         self.plugin_metadata: Dict[Path, Dict[str, Any]] = (
             {}
@@ -70,6 +79,14 @@ class RepositoryContext:
         self.detected_formats: Set[str] = self._detect_formats()
         self.content_paths: List[str] = []
         self.exclude_patterns: List[str] = []
+
+    @property
+    def repo_type(self) -> RepositoryType:
+        """Primary repo type for backward compatibility."""
+        for t in self._TYPE_PRIORITY:
+            if t in self.repo_types:
+                return t
+        return RepositoryType.UNKNOWN
 
     def _discover_instruction_files(self) -> List[Path]:
         """Discover instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) at the repo root."""
@@ -121,29 +138,39 @@ class RepositoryContext:
                 return True
         return False
 
-    def _detect_type(self) -> RepositoryType:
-        """Detect the type of repository"""
-        # Check for marketplace
+    def _detect_types(self) -> Set[RepositoryType]:
+        """Detect all applicable repository types.
+
+        A repository may match multiple types simultaneously (e.g. a marketplace
+        that also has a .coderabbit.yaml).  SINGLE_PLUGIN and MARKETPLACE are
+        mutually exclusive (elif chain), but everything else is independent.
+        """
+        types: Set[RepositoryType] = set()
+
+        # Marketplace / single-plugin (mutually exclusive)
         if (self.root_path / ".claude-plugin" / "marketplace.json").exists():
-            return RepositoryType.MARKETPLACE
+            types.add(RepositoryType.MARKETPLACE)
+        elif (self.root_path / ".claude-plugin").exists():
+            types.add(RepositoryType.SINGLE_PLUGIN)
+        elif (self.root_path / "plugins").exists():
+            types.add(RepositoryType.MARKETPLACE)
 
-        # Check for single plugin at root (even without plugin.json so we can validate it)
-        if (self.root_path / ".claude-plugin").exists():
-            return RepositoryType.SINGLE_PLUGIN
-
-        # Check for plugins directory (marketplace without registration)
-        if (self.root_path / "plugins").exists():
-            return RepositoryType.MARKETPLACE
-
-        # Check for .claude/ directory (before agentskills, since .claude/ with skills is DOT_CLAUDE)
-        if self._is_dot_claude():
-            return RepositoryType.DOT_CLAUDE
-
-        # Check for agentskills.io skill repo
+        # Agentskills
         if self._is_agentskills_repo():
-            return RepositoryType.AGENTSKILLS
+            types.add(RepositoryType.AGENTSKILLS)
 
-        return RepositoryType.UNKNOWN
+        # CodeRabbit
+        if (self.root_path / ".coderabbit.yaml").exists():
+            types.add(RepositoryType.CODERABBIT)
+
+        # DOT_CLAUDE
+        if self._is_dot_claude():
+            types.add(RepositoryType.DOT_CLAUDE)
+
+        if not types:
+            types.add(RepositoryType.UNKNOWN)
+
+        return types
 
     def _is_agentskills_repo(self) -> bool:
         """Check if this looks like an agentskills.io skill repository"""
@@ -302,22 +329,25 @@ class RepositoryContext:
         1. Single plugin at repository root
         2. Traditional plugins/ directory (backward compatibility)
         3. Marketplace.json-defined sources (flat structures, custom paths, remote)
+
+        Multiple types can contribute plugins simultaneously.
         """
         plugins: List[Path] = []
         discovered_paths: Set[Path] = set()
 
-        if self.repo_type == RepositoryType.SINGLE_PLUGIN:
+        if RepositoryType.SINGLE_PLUGIN in self.repo_types:
             plugins.append(self.root_path)
             discovered_paths.add(self.root_path.resolve())
 
-        elif self.repo_type == RepositoryType.DOT_CLAUDE:
+        if RepositoryType.DOT_CLAUDE in self.repo_types:
             claude_dir = (
                 self.root_path if self.root_path.name == ".claude" else self.root_path / ".claude"
             )
-            plugins.append(claude_dir)
-            discovered_paths.add(claude_dir.resolve())
+            if claude_dir.resolve() not in discovered_paths:
+                plugins.append(claude_dir)
+                discovered_paths.add(claude_dir.resolve())
 
-        elif self.repo_type == RepositoryType.MARKETPLACE:
+        if RepositoryType.MARKETPLACE in self.repo_types:
             # Discover from plugins/ directory (backward compatibility)
             self._discover_from_plugins_dir(plugins, discovered_paths)
 
@@ -461,7 +491,7 @@ class RepositoryContext:
         skills: List[Path] = []
         discovered: Set[Path] = set()
 
-        if self.repo_type == RepositoryType.AGENTSKILLS:
+        if RepositoryType.AGENTSKILLS in self.repo_types:
             # Single skill at root
             if (self.root_path / "SKILL.md").exists():
                 skills.append(self.root_path)

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -30,7 +30,7 @@ def extract_docs(
     plugins = [_extract_plugin(context, p) for p in context.plugins]
 
     marketplace = None
-    if context.repo_type == RepositoryType.MARKETPLACE and context.marketplace_data:
+    if RepositoryType.MARKETPLACE in context.repo_types and context.marketplace_data:
         md = context.marketplace_data
         marketplace = MarketplaceDoc(
             name=md.get("name", ""),
@@ -39,7 +39,7 @@ def extract_docs(
         )
 
     standalone_skills: List[SkillDoc] = []
-    if context.repo_type == RepositoryType.AGENTSKILLS:
+    if RepositoryType.AGENTSKILLS in context.repo_types:
         plugin_skill_paths = {s.dir_path.resolve() for p in plugins for s in p.skills}
         for skill_path in context.skills:
             if skill_path.resolve() not in plugin_skill_paths:
@@ -65,7 +65,7 @@ def _default_title(
 ) -> str:
     if marketplace and marketplace.name:
         return marketplace.name
-    if context.repo_type == RepositoryType.DOT_CLAUDE:
+    if RepositoryType.DOT_CLAUDE in context.repo_types:
         return context.root_path.name
     if len(plugins) == 1 and plugins[0].name:
         return plugins[0].name

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -66,7 +66,7 @@ def _default_title(
     if marketplace and marketplace.name:
         return marketplace.name
     if RepositoryType.DOT_CLAUDE in context.repo_types:
-        return context.root_path.name
+        return ""
     if len(plugins) == 1 and plugins[0].name:
         return plugins[0].name
     return context.repo_type.value.replace("-", " ").title() + " Documentation"

--- a/src/skillsaw/docs/markdown_renderer.py
+++ b/src/skillsaw/docs/markdown_renderer.py
@@ -30,7 +30,9 @@ def render_markdown(docs: DocsOutput) -> Dict[str, str]:
 
 
 def _render_single_page(docs: DocsOutput) -> str:
-    lines: List[str] = [f"# {docs.title}", ""]
+    lines: List[str] = []
+    if docs.title:
+        lines += [f"# {docs.title}", ""]
     plugin = docs.plugins[0] if docs.plugins else None
 
     if plugin:

--- a/src/skillsaw/docs/markdown_renderer.py
+++ b/src/skillsaw/docs/markdown_renderer.py
@@ -175,7 +175,7 @@ def _append_command(lines: List[str], cmd: CommandDoc) -> None:
 def _append_skills_section(lines: List[str], skills: List[SkillDoc]) -> None:
     lines.append("## Skills")
     lines.append("")
-    for skill in skills:
+    for skill in sorted(skills, key=lambda s: s.name.lower()):
         lines.append(f"### {skill.name}")
         lines.append("")
         if skill.description:

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -16,9 +16,12 @@ def format_json(
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
+    repo_types_list = sorted(t.value for t in context.repo_types)
+
     if verbose:
         stats = {
             "repo_type": context.repo_type.value,
+            "repo_types": repo_types_list,
             "plugins": [str(p) for p in context.plugins],
             "skills": [str(s) for s in context.skills],
             "rules_run": [r.rule_id for r in rules],
@@ -26,6 +29,7 @@ def format_json(
     else:
         stats = {
             "repo_type": context.repo_type.value,
+            "repo_types": repo_types_list,
             "plugins": len(context.plugins),
             "skills": len(context.skills),
             "rules_run": len(rules),

--- a/src/skillsaw/rules/builtin/__init__.py
+++ b/src/skillsaw/rules/builtin/__init__.py
@@ -81,6 +81,11 @@ from .content_rules import (
     ContentInconsistentTerminologyRule,
 )
 
+from .coderabbit import (
+    CoderabbitYamlValidRule,
+    CoderabbitInstructionsRule,
+)
+
 # All builtin rules
 BUILTIN_RULES = [
     # Plugin structure
@@ -136,6 +141,9 @@ BUILTIN_RULES = [
     ContentEmbeddedSecretsRule,
     ContentBannedReferencesRule,
     ContentInconsistentTerminologyRule,
+    # CodeRabbit
+    CoderabbitYamlValidRule,
+    CoderabbitInstructionsRule,
 ]
 
 
@@ -182,4 +190,6 @@ __all__ = [
     "ContentEmbeddedSecretsRule",
     "ContentBannedReferencesRule",
     "ContentInconsistentTerminologyRule",
+    "CoderabbitYamlValidRule",
+    "CoderabbitInstructionsRule",
 ]

--- a/src/skillsaw/rules/builtin/__init__.py
+++ b/src/skillsaw/rules/builtin/__init__.py
@@ -83,7 +83,6 @@ from .content_rules import (
 
 from .coderabbit import (
     CoderabbitYamlValidRule,
-    CoderabbitInstructionsRule,
 )
 
 # All builtin rules
@@ -143,7 +142,6 @@ BUILTIN_RULES = [
     ContentInconsistentTerminologyRule,
     # CodeRabbit
     CoderabbitYamlValidRule,
-    CoderabbitInstructionsRule,
 ]
 
 
@@ -191,5 +189,4 @@ __all__ = [
     "ContentBannedReferencesRule",
     "ContentInconsistentTerminologyRule",
     "CoderabbitYamlValidRule",
-    "CoderabbitInstructionsRule",
 ]

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import yaml
 
@@ -28,7 +28,13 @@ _WEAK_LANGUAGE_PATTERNS: List[Tuple[re.Pattern, str]] = [
     (re.compile(r"\btry to\b", re.IGNORECASE), "try to"),
     (re.compile(r"\bmight want to\b", re.IGNORECASE), "might want to"),
     (re.compile(r"\bcould potentially\b", re.IGNORECASE), "could potentially"),
-    (re.compile(r"\bconsider\b", re.IGNORECASE), "consider"),
+    (
+        re.compile(
+            r"\bconsider\s+(?:using|adding|implementing|creating|setting|enabling|disabling|replacing|switching|migrating|wrapping|converting)\b",
+            re.IGNORECASE,
+        ),
+        "consider",
+    ),
     (re.compile(r"\bif possible\b", re.IGNORECASE), "if possible"),
     (re.compile(r"\bwhen feasible\b", re.IGNORECASE), "when feasible"),
     (re.compile(r"\bit would be nice\b", re.IGNORECASE), "it would be nice"),
@@ -253,8 +259,8 @@ class CoderabbitInstructionsRule(Rule):
     # Content checks
     # ------------------------------------------------------------------
 
-    @staticmethod
     def _check_weak_language(
+        self,
         file_path: Path,
         location: str,
         text: str,
@@ -271,9 +277,7 @@ class CoderabbitInstructionsRule(Rule):
             phrases = ", ".join(f"'{p}'" for p in found[:3])
             suffix = f" (and {len(found) - 3} more)" if len(found) > 3 else ""
             violations.append(
-                RuleViolation(
-                    rule_id="coderabbit-instructions",
-                    severity=Severity.WARNING,
+                self.violation(
                     message=(
                         f"Weak/hedge language in {location}: {phrases}{suffix}. "
                         "Use direct, imperative language in LLM instructions."

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -1,0 +1,284 @@
+"""
+Rules for validating .coderabbit.yaml configuration files.
+
+CodeRabbit config files contain ``instructions`` fields consumed by an LLM.
+These rules validate the YAML structure and check the instruction text for
+common content quality issues (weak/hedge language, empty instructions).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from skillsaw.rule import Rule, RuleViolation, Severity
+from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.utils import read_text
+
+# ---------------------------------------------------------------------------
+# Weak / hedge language patterns
+# ---------------------------------------------------------------------------
+
+_WEAK_LANGUAGE_PATTERNS: List[Tuple[re.Pattern, str]] = [
+    (re.compile(r"\bmaybe\b", re.IGNORECASE), "maybe"),
+    (re.compile(r"\bperhaps\b", re.IGNORECASE), "perhaps"),
+    (re.compile(r"\btry to\b", re.IGNORECASE), "try to"),
+    (re.compile(r"\bmight want to\b", re.IGNORECASE), "might want to"),
+    (re.compile(r"\bcould potentially\b", re.IGNORECASE), "could potentially"),
+    (re.compile(r"\bconsider\b", re.IGNORECASE), "consider"),
+    (re.compile(r"\bif possible\b", re.IGNORECASE), "if possible"),
+    (re.compile(r"\bwhen feasible\b", re.IGNORECASE), "when feasible"),
+    (re.compile(r"\bit would be nice\b", re.IGNORECASE), "it would be nice"),
+]
+
+# ---------------------------------------------------------------------------
+# Instruction extraction helpers
+# ---------------------------------------------------------------------------
+
+_CODERABBIT_FILENAME = ".coderabbit.yaml"
+
+
+def _find_yaml_key_line(raw: str, key: str) -> Optional[int]:
+    """Find the line number of a YAML key in raw text.
+
+    Scans line-by-line for ``key:`` at any indentation level.  Returns
+    the 1-based line number of the *last* occurrence so that nested keys
+    such as ``instructions`` resolve to the most specific location when
+    the caller is walking a particular branch of the tree.  For
+    top-level unique keys the result is the same either way.
+    """
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    last: Optional[int] = None
+    for i, line in enumerate(raw.splitlines(), 1):
+        if pattern.match(line):
+            last = i
+    return last
+
+
+def _find_yaml_key_line_after(raw: str, key: str, after_line: int) -> Optional[int]:
+    """Find the line number of a YAML key occurring after a given line."""
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    for i, line in enumerate(raw.splitlines(), 1):
+        if i > after_line and pattern.match(line):
+            return i
+    return None
+
+
+def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
+    """Find the line number of the *n*-th (0-based) occurrence of *key*."""
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    count = 0
+    for i, line in enumerate(raw.splitlines(), 1):
+        if pattern.match(line):
+            if count == n:
+                return i
+            count += 1
+    return None
+
+
+def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
+    """Extract all instruction text fields from a parsed CodeRabbit config.
+
+    Returns a list of ``(location_label, text, line_number)`` tuples.
+    """
+    results: List[Tuple[str, str, Optional[int]]] = []
+    if not isinstance(data, dict):
+        return results
+
+    # reviews.instructions
+    reviews = data.get("reviews")
+    if isinstance(reviews, dict):
+        instr = reviews.get("instructions")
+        if isinstance(instr, str) and instr.strip():
+            # Find the "instructions" key that appears after "reviews"
+            reviews_line = _find_yaml_key_line(raw, "reviews")
+            line = None
+            if reviews_line is not None:
+                line = _find_yaml_key_line_after(raw, "instructions", reviews_line)
+            if line is None:
+                line = _find_yaml_key_line(raw, "instructions")
+            results.append(("reviews.instructions", instr, line))
+
+        # reviews.path_instructions[].instructions
+        path_instructions = reviews.get("path_instructions")
+        if isinstance(path_instructions, list):
+            for idx, entry in enumerate(path_instructions):
+                if not isinstance(entry, dict):
+                    continue
+                pi = entry.get("instructions")
+                if isinstance(pi, str) and pi.strip():
+                    path_val = entry.get("path", f"[{idx}]")
+                    line = _find_nth_key_line(raw, "instructions", len(results))
+                    results.append(
+                        (f"reviews.path_instructions[{path_val}].instructions", pi, line)
+                    )
+
+        # reviews.tools.<tool>.instructions
+        tools = reviews.get("tools")
+        if isinstance(tools, dict):
+            for tool_name, tool_cfg in tools.items():
+                if not isinstance(tool_cfg, dict):
+                    continue
+                ti = tool_cfg.get("instructions")
+                if isinstance(ti, str) and ti.strip():
+                    tool_line = _find_yaml_key_line(raw, tool_name)
+                    line = None
+                    if tool_line is not None:
+                        line = _find_yaml_key_line_after(raw, "instructions", tool_line)
+                    results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
+
+    # chat.instructions
+    chat = data.get("chat")
+    if isinstance(chat, dict):
+        ci = chat.get("instructions")
+        if isinstance(ci, str) and ci.strip():
+            chat_line = _find_yaml_key_line(raw, "chat")
+            line = None
+            if chat_line is not None:
+                line = _find_yaml_key_line_after(raw, "instructions", chat_line)
+            if line is None:
+                line = _find_yaml_key_line(raw, "instructions")
+            results.append(("chat.instructions", ci, line))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+
+class CoderabbitYamlValidRule(Rule):
+    """Validate that .coderabbit.yaml is valid YAML"""
+
+    @property
+    def rule_id(self) -> str:
+        return "coderabbit-yaml-valid"
+
+    @property
+    def description(self) -> str:
+        return ".coderabbit.yaml must be valid YAML"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations: List[RuleViolation] = []
+        cr_path = context.root_path / _CODERABBIT_FILENAME
+
+        if not cr_path.exists():
+            return violations
+
+        raw = read_text(cr_path)
+        if raw is None:
+            violations.append(
+                self.violation(
+                    f"Failed to read {_CODERABBIT_FILENAME} (invalid encoding or I/O error)",
+                    file_path=cr_path,
+                )
+            )
+            return violations
+
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            line: Optional[int] = None
+            if hasattr(exc, "problem_mark") and exc.problem_mark is not None:
+                line = exc.problem_mark.line + 1  # 0-based → 1-based
+            violations.append(
+                self.violation(
+                    f"Invalid YAML in {_CODERABBIT_FILENAME}: {exc}",
+                    file_path=cr_path,
+                    line=line,
+                )
+            )
+            return violations
+
+        if not isinstance(data, dict):
+            violations.append(
+                self.violation(
+                    f"{_CODERABBIT_FILENAME} must be a YAML mapping at the top level",
+                    file_path=cr_path,
+                )
+            )
+
+        return violations
+
+
+class CoderabbitInstructionsRule(Rule):
+    """Check instruction text in .coderabbit.yaml for content quality issues"""
+
+    @property
+    def rule_id(self) -> str:
+        return "coderabbit-instructions"
+
+    @property
+    def description(self) -> str:
+        return "Check .coderabbit.yaml instruction fields for content quality issues"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations: List[RuleViolation] = []
+        cr_path = context.root_path / _CODERABBIT_FILENAME
+
+        if not cr_path.exists():
+            return violations
+
+        raw = read_text(cr_path)
+        if raw is None:
+            return violations
+
+        try:
+            data = yaml.safe_load(raw)
+        except yaml.YAMLError:
+            # Invalid YAML is caught by CoderabbitYamlValidRule
+            return violations
+
+        if not isinstance(data, dict):
+            return violations
+
+        instructions = _extract_instructions(data, raw)
+
+        for location, text, line in instructions:
+            self._check_weak_language(cr_path, location, text, line, violations)
+
+        return violations
+
+    # ------------------------------------------------------------------
+    # Content checks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_weak_language(
+        file_path: Path,
+        location: str,
+        text: str,
+        line: Optional[int],
+        violations: List[RuleViolation],
+    ) -> None:
+        """Flag hedge / weak language in instruction text."""
+        found: List[str] = []
+        for pattern, label in _WEAK_LANGUAGE_PATTERNS:
+            if pattern.search(text):
+                found.append(label)
+
+        if found:
+            phrases = ", ".join(f"'{p}'" for p in found[:3])
+            suffix = f" (and {len(found) - 3} more)" if len(found) > 3 else ""
+            violations.append(
+                RuleViolation(
+                    rule_id="coderabbit-instructions",
+                    severity=Severity.WARNING,
+                    message=(
+                        f"Weak/hedge language in {location}: {phrases}{suffix}. "
+                        "Use direct, imperative language in LLM instructions."
+                    ),
+                    file_path=file_path,
+                    line=line,
+                )
+            )

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -85,6 +85,26 @@ def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
     return None
 
 
+def _find_nth_list_item_key_line(raw: str, key: str, n: int, after_line: int = 0) -> Optional[int]:
+    """Find the *n*-th (0-based) YAML list-item key (``- key:``) after *after_line*.
+
+    In YAML sequences the first key of each item is prefixed with ``- ``,
+    e.g. ``  - name: value``.  The standard ``_find_nth_key_line`` helper
+    doesn't match these because ``-`` is not whitespace.  This variant
+    matches both ``- key:`` and bare ``key:`` lines.
+    """
+    pattern = re.compile(rf"^\s*-\s+{re.escape(key)}\s*:")
+    count = 0
+    for i, line in enumerate(raw.splitlines(), 1):
+        if i <= after_line:
+            continue
+        if pattern.match(line):
+            if count == n:
+                return i
+            count += 1
+    return None
+
+
 def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
     """Extract all instruction text fields from a parsed CodeRabbit config.
 
@@ -135,6 +155,35 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
                     if tool_line is not None:
                         line = _find_yaml_key_line_after(raw, "instructions", tool_line)
                     results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
+
+        # reviews.pre_merge_checks.custom_checks[].instructions
+        pre_merge = reviews.get("pre_merge_checks")
+        if isinstance(pre_merge, dict):
+            custom_checks = pre_merge.get("custom_checks")
+            if isinstance(custom_checks, list):
+                # Find the "custom_checks" key so we only look within it.
+                custom_checks_line = _find_yaml_key_line(raw, "custom_checks") or 0
+                for idx, check in enumerate(custom_checks):
+                    if not isinstance(check, dict):
+                        continue
+                    ci = check.get("instructions")
+                    if isinstance(ci, str) and ci.strip():
+                        check_name = check.get("name", f"[{idx}]")
+                        # Find the nth list-item "- name:" after custom_checks,
+                        # then the "instructions" key following it.
+                        name_line = _find_nth_list_item_key_line(
+                            raw, "name", idx, after_line=custom_checks_line
+                        )
+                        line = None
+                        if name_line is not None:
+                            line = _find_yaml_key_line_after(raw, "instructions", name_line)
+                        results.append(
+                            (
+                                f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
+                                ci,
+                                line,
+                            )
+                        )
 
     # chat.instructions
     chat = data.get("chat")

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -2,15 +2,13 @@
 Rules for validating .coderabbit.yaml configuration files.
 
 CodeRabbit config files contain ``instructions`` fields consumed by an LLM.
-These rules validate the YAML structure and check the instruction text for
-common content quality issues (weak/hedge language, empty instructions).
+The YAML structure is validated here; instruction text quality is checked by
+the shared content-* rules via ``_get_body()`` in ``content_analysis.py``.
 """
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional
 
 import yaml
 
@@ -19,187 +17,10 @@ from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rules.builtin.utils import read_text
 
 # ---------------------------------------------------------------------------
-# Weak / hedge language patterns
-# ---------------------------------------------------------------------------
-
-_WEAK_LANGUAGE_PATTERNS: List[Tuple[re.Pattern, str]] = [
-    (re.compile(r"\bmaybe\b", re.IGNORECASE), "maybe"),
-    (re.compile(r"\bperhaps\b", re.IGNORECASE), "perhaps"),
-    (re.compile(r"\btry to\b", re.IGNORECASE), "try to"),
-    (re.compile(r"\bmight want to\b", re.IGNORECASE), "might want to"),
-    (re.compile(r"\bcould potentially\b", re.IGNORECASE), "could potentially"),
-    (
-        re.compile(
-            r"\bconsider\s+(?:using|adding|implementing|creating|setting|enabling|disabling|replacing|switching|migrating|wrapping|converting)\b",
-            re.IGNORECASE,
-        ),
-        "consider",
-    ),
-    (re.compile(r"\bif possible\b", re.IGNORECASE), "if possible"),
-    (re.compile(r"\bwhen feasible\b", re.IGNORECASE), "when feasible"),
-    (re.compile(r"\bit would be nice\b", re.IGNORECASE), "it would be nice"),
-]
-
-# ---------------------------------------------------------------------------
-# Instruction extraction helpers
+# Constants
 # ---------------------------------------------------------------------------
 
 _CODERABBIT_FILENAME = ".coderabbit.yaml"
-
-
-def _find_yaml_key_line(raw: str, key: str) -> Optional[int]:
-    """Find the line number of a YAML key in raw text.
-
-    Scans line-by-line for ``key:`` at any indentation level.  Returns
-    the 1-based line number of the *last* occurrence so that nested keys
-    such as ``instructions`` resolve to the most specific location when
-    the caller is walking a particular branch of the tree.  For
-    top-level unique keys the result is the same either way.
-    """
-    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
-    last: Optional[int] = None
-    for i, line in enumerate(raw.splitlines(), 1):
-        if pattern.match(line):
-            last = i
-    return last
-
-
-def _find_yaml_key_line_after(raw: str, key: str, after_line: int) -> Optional[int]:
-    """Find the line number of a YAML key occurring after a given line."""
-    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
-    for i, line in enumerate(raw.splitlines(), 1):
-        if i > after_line and pattern.match(line):
-            return i
-    return None
-
-
-def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
-    """Find the line number of the *n*-th (0-based) occurrence of *key*."""
-    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
-    count = 0
-    for i, line in enumerate(raw.splitlines(), 1):
-        if pattern.match(line):
-            if count == n:
-                return i
-            count += 1
-    return None
-
-
-def _find_nth_list_item_key_line(raw: str, key: str, n: int, after_line: int = 0) -> Optional[int]:
-    """Find the *n*-th (0-based) YAML list-item key (``- key:``) after *after_line*.
-
-    In YAML sequences the first key of each item is prefixed with ``- ``,
-    e.g. ``  - name: value``.  The standard ``_find_nth_key_line`` helper
-    doesn't match these because ``-`` is not whitespace.  This variant
-    matches both ``- key:`` and bare ``key:`` lines.
-    """
-    pattern = re.compile(rf"^\s*-\s+{re.escape(key)}\s*:")
-    count = 0
-    for i, line in enumerate(raw.splitlines(), 1):
-        if i <= after_line:
-            continue
-        if pattern.match(line):
-            if count == n:
-                return i
-            count += 1
-    return None
-
-
-def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
-    """Extract all instruction text fields from a parsed CodeRabbit config.
-
-    Returns a list of ``(location_label, text, line_number)`` tuples.
-    """
-    results: List[Tuple[str, str, Optional[int]]] = []
-    if not isinstance(data, dict):
-        return results
-
-    # reviews.instructions
-    reviews = data.get("reviews")
-    if isinstance(reviews, dict):
-        instr = reviews.get("instructions")
-        if isinstance(instr, str) and instr.strip():
-            # Find the "instructions" key that appears after "reviews"
-            reviews_line = _find_yaml_key_line(raw, "reviews")
-            line = None
-            if reviews_line is not None:
-                line = _find_yaml_key_line_after(raw, "instructions", reviews_line)
-            if line is None:
-                line = _find_yaml_key_line(raw, "instructions")
-            results.append(("reviews.instructions", instr, line))
-
-        # reviews.path_instructions[].instructions
-        path_instructions = reviews.get("path_instructions")
-        if isinstance(path_instructions, list):
-            for idx, entry in enumerate(path_instructions):
-                if not isinstance(entry, dict):
-                    continue
-                pi = entry.get("instructions")
-                if isinstance(pi, str) and pi.strip():
-                    path_val = entry.get("path", f"[{idx}]")
-                    line = _find_nth_key_line(raw, "instructions", len(results))
-                    results.append(
-                        (f"reviews.path_instructions[{path_val}].instructions", pi, line)
-                    )
-
-        # reviews.tools.<tool>.instructions
-        tools = reviews.get("tools")
-        if isinstance(tools, dict):
-            for tool_name, tool_cfg in tools.items():
-                if not isinstance(tool_cfg, dict):
-                    continue
-                ti = tool_cfg.get("instructions")
-                if isinstance(ti, str) and ti.strip():
-                    tool_line = _find_yaml_key_line(raw, tool_name)
-                    line = None
-                    if tool_line is not None:
-                        line = _find_yaml_key_line_after(raw, "instructions", tool_line)
-                    results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
-
-        # reviews.pre_merge_checks.custom_checks[].instructions
-        pre_merge = reviews.get("pre_merge_checks")
-        if isinstance(pre_merge, dict):
-            custom_checks = pre_merge.get("custom_checks")
-            if isinstance(custom_checks, list):
-                # Find the "custom_checks" key so we only look within it.
-                custom_checks_line = _find_yaml_key_line(raw, "custom_checks") or 0
-                for idx, check in enumerate(custom_checks):
-                    if not isinstance(check, dict):
-                        continue
-                    ci = check.get("instructions")
-                    if isinstance(ci, str) and ci.strip():
-                        check_name = check.get("name", f"[{idx}]")
-                        # Find the nth list-item "- name:" after custom_checks,
-                        # then the "instructions" key following it.
-                        name_line = _find_nth_list_item_key_line(
-                            raw, "name", idx, after_line=custom_checks_line
-                        )
-                        line = None
-                        if name_line is not None:
-                            line = _find_yaml_key_line_after(raw, "instructions", name_line)
-                        results.append(
-                            (
-                                f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
-                                ci,
-                                line,
-                            )
-                        )
-
-    # chat.instructions
-    chat = data.get("chat")
-    if isinstance(chat, dict):
-        ci = chat.get("instructions")
-        if isinstance(ci, str) and ci.strip():
-            chat_line = _find_yaml_key_line(raw, "chat")
-            line = None
-            if chat_line is not None:
-                line = _find_yaml_key_line_after(raw, "instructions", chat_line)
-            if line is None:
-                line = _find_yaml_key_line(raw, "instructions")
-            results.append(("chat.instructions", ci, line))
-
-    return results
-
 
 # ---------------------------------------------------------------------------
 # Rules
@@ -263,79 +84,3 @@ class CoderabbitYamlValidRule(Rule):
             )
 
         return violations
-
-
-class CoderabbitInstructionsRule(Rule):
-    """Check instruction text in .coderabbit.yaml for content quality issues"""
-
-    repo_types = {RepositoryType.CODERABBIT}
-
-    @property
-    def rule_id(self) -> str:
-        return "coderabbit-instructions"
-
-    @property
-    def description(self) -> str:
-        return "Check .coderabbit.yaml instruction fields for content quality issues"
-
-    def default_severity(self) -> Severity:
-        return Severity.WARNING
-
-    def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        violations: List[RuleViolation] = []
-        cr_path = context.root_path / _CODERABBIT_FILENAME
-
-        if not cr_path.exists():
-            return violations
-
-        raw = read_text(cr_path)
-        if raw is None:
-            return violations
-
-        try:
-            data = yaml.safe_load(raw)
-        except yaml.YAMLError:
-            # Invalid YAML is caught by CoderabbitYamlValidRule
-            return violations
-
-        if not isinstance(data, dict):
-            return violations
-
-        instructions = _extract_instructions(data, raw)
-
-        for location, text, line in instructions:
-            self._check_weak_language(cr_path, location, text, line, violations)
-
-        return violations
-
-    # ------------------------------------------------------------------
-    # Content checks
-    # ------------------------------------------------------------------
-
-    def _check_weak_language(
-        self,
-        file_path: Path,
-        location: str,
-        text: str,
-        line: Optional[int],
-        violations: List[RuleViolation],
-    ) -> None:
-        """Flag hedge / weak language in instruction text."""
-        found: List[str] = []
-        for pattern, label in _WEAK_LANGUAGE_PATTERNS:
-            if pattern.search(text):
-                found.append(label)
-
-        if found:
-            phrases = ", ".join(f"'{p}'" for p in found[:3])
-            suffix = f" (and {len(found) - 3} more)" if len(found) > 3 else ""
-            violations.append(
-                self.violation(
-                    message=(
-                        f"Weak/hedge language in {location}: {phrases}{suffix}. "
-                        "Use direct, imperative language in LLM instructions."
-                    ),
-                    file_path=file_path,
-                    line=line,
-                )
-            )

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional, Tuple
 import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
-from skillsaw.context import RepositoryContext
+from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rules.builtin.utils import read_text
 
 # ---------------------------------------------------------------------------
@@ -209,6 +209,8 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
 class CoderabbitYamlValidRule(Rule):
     """Validate that .coderabbit.yaml is valid YAML"""
 
+    repo_types = {RepositoryType.CODERABBIT}
+
     @property
     def rule_id(self) -> str:
         return "coderabbit-yaml-valid"
@@ -265,6 +267,8 @@ class CoderabbitYamlValidRule(Rule):
 
 class CoderabbitInstructionsRule(Rule):
     """Check instruction text in .coderabbit.yaml for content quality issues"""
+
+    repo_types = {RepositoryType.CODERABBIT}
 
     @property
     def rule_id(self) -> str:

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -3,14 +3,16 @@ Shared content analyzers for instruction file intelligence rules.
 
 These analyzers are called by content-* rules to detect quality issues
 in instruction files across all formats (CLAUDE.md, AGENTS.md, GEMINI.md,
-.cursorrules, copilot-instructions.md, .cursor/rules/*.mdc).
+.cursorrules, copilot-instructions.md, .cursor/rules/*.mdc, .coderabbit.yaml).
 """
 
 import fnmatch
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import Any, List, Optional, Set, Tuple
+
+import yaml
 
 from skillsaw.context import RepositoryContext
 from skillsaw.rules.builtin.utils import read_text, parse_frontmatter
@@ -217,6 +219,8 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
             for rule_file in sorted(rules_dir.rglob("*.md")):
                 _add(rule_file, "rule")
 
+    _add(context.root_path / ".coderabbit.yaml", "coderabbit")
+
     for glob_pattern in getattr(context, "content_paths", []):
         for extra in sorted(context.root_path.glob(glob_pattern)):
             if extra.is_file():
@@ -234,17 +238,201 @@ def gather_all_instruction_files(context: RepositoryContext) -> List[Path]:
 
 
 def _get_body(path: Path, *, strip_code_blocks: bool = True) -> Optional[str]:
-    """Read file and strip YAML frontmatter if present."""
+    """Read file and return the instruction body text.
+
+    Handles special file types:
+    - ``.mdc``: strips YAML frontmatter.
+    - ``.coderabbit.yaml``: extracts and concatenates all ``instructions``
+      field values so content analyzers see only instruction text.
+    """
     content = read_text(path)
     if content is None:
         return None
-    if path.suffix == ".mdc":
+    if path.name == ".coderabbit.yaml":
+        body = _extract_coderabbit_instructions_body(content)
+    elif path.suffix == ".mdc":
         _, body = parse_frontmatter(content)
     else:
         body = content
     if strip_code_blocks:
         body = _strip_fenced_code_blocks(body)
     return body
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit instruction extraction helpers
+# ---------------------------------------------------------------------------
+
+_CODERABBIT_FILENAME = ".coderabbit.yaml"
+
+
+def _find_yaml_key_line(raw: str, key: str) -> Optional[int]:
+    """Find the line number of a YAML key in raw text.
+
+    Scans line-by-line for ``key:`` at any indentation level.  Returns
+    the 1-based line number of the *last* occurrence so that nested keys
+    such as ``instructions`` resolve to the most specific location when
+    the caller is walking a particular branch of the tree.  For
+    top-level unique keys the result is the same either way.
+    """
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    last: Optional[int] = None
+    for i, line in enumerate(raw.splitlines(), 1):
+        if pattern.match(line):
+            last = i
+    return last
+
+
+def _find_yaml_key_line_after(raw: str, key: str, after_line: int) -> Optional[int]:
+    """Find the line number of a YAML key occurring after a given line."""
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    for i, line in enumerate(raw.splitlines(), 1):
+        if i > after_line and pattern.match(line):
+            return i
+    return None
+
+
+def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
+    """Find the line number of the *n*-th (0-based) occurrence of *key*."""
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*:")
+    count = 0
+    for i, line in enumerate(raw.splitlines(), 1):
+        if pattern.match(line):
+            if count == n:
+                return i
+            count += 1
+    return None
+
+
+def _find_nth_list_item_key_line(raw: str, key: str, n: int, after_line: int = 0) -> Optional[int]:
+    """Find the *n*-th (0-based) YAML list-item key (``- key:``) after *after_line*.
+
+    In YAML sequences the first key of each item is prefixed with ``- ``,
+    e.g. ``  - name: value``.  The standard ``_find_nth_key_line`` helper
+    doesn't match these because ``-`` is not whitespace.  This variant
+    matches both ``- key:`` and bare ``key:`` lines.
+    """
+    pattern = re.compile(rf"^\s*-\s+{re.escape(key)}\s*:")
+    count = 0
+    for i, line in enumerate(raw.splitlines(), 1):
+        if i <= after_line:
+            continue
+        if pattern.match(line):
+            if count == n:
+                return i
+            count += 1
+    return None
+
+
+def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
+    """Extract all instruction text fields from a parsed CodeRabbit config.
+
+    Returns a list of ``(location_label, text, line_number)`` tuples.
+    """
+    results: List[Tuple[str, str, Optional[int]]] = []
+    if not isinstance(data, dict):
+        return results
+
+    # reviews.instructions
+    reviews = data.get("reviews")
+    if isinstance(reviews, dict):
+        instr = reviews.get("instructions")
+        if isinstance(instr, str) and instr.strip():
+            # Find the "instructions" key that appears after "reviews"
+            reviews_line = _find_yaml_key_line(raw, "reviews")
+            line = None
+            if reviews_line is not None:
+                line = _find_yaml_key_line_after(raw, "instructions", reviews_line)
+            if line is None:
+                line = _find_yaml_key_line(raw, "instructions")
+            results.append(("reviews.instructions", instr, line))
+
+        # reviews.path_instructions[].instructions
+        path_instructions = reviews.get("path_instructions")
+        if isinstance(path_instructions, list):
+            for idx, entry in enumerate(path_instructions):
+                if not isinstance(entry, dict):
+                    continue
+                pi = entry.get("instructions")
+                if isinstance(pi, str) and pi.strip():
+                    path_val = entry.get("path", f"[{idx}]")
+                    line = _find_nth_key_line(raw, "instructions", len(results))
+                    results.append(
+                        (f"reviews.path_instructions[{path_val}].instructions", pi, line)
+                    )
+
+        # reviews.tools.<tool>.instructions
+        tools = reviews.get("tools")
+        if isinstance(tools, dict):
+            for tool_name, tool_cfg in tools.items():
+                if not isinstance(tool_cfg, dict):
+                    continue
+                ti = tool_cfg.get("instructions")
+                if isinstance(ti, str) and ti.strip():
+                    tool_line = _find_yaml_key_line(raw, tool_name)
+                    line = None
+                    if tool_line is not None:
+                        line = _find_yaml_key_line_after(raw, "instructions", tool_line)
+                    results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
+
+        # reviews.pre_merge_checks.custom_checks[].instructions
+        pre_merge = reviews.get("pre_merge_checks")
+        if isinstance(pre_merge, dict):
+            custom_checks = pre_merge.get("custom_checks")
+            if isinstance(custom_checks, list):
+                # Find the "custom_checks" key so we only look within it.
+                custom_checks_line = _find_yaml_key_line(raw, "custom_checks") or 0
+                for idx, check in enumerate(custom_checks):
+                    if not isinstance(check, dict):
+                        continue
+                    ci = check.get("instructions")
+                    if isinstance(ci, str) and ci.strip():
+                        check_name = check.get("name", f"[{idx}]")
+                        # Find the nth list-item "- name:" after custom_checks,
+                        # then the "instructions" key following it.
+                        name_line = _find_nth_list_item_key_line(
+                            raw, "name", idx, after_line=custom_checks_line
+                        )
+                        line = None
+                        if name_line is not None:
+                            line = _find_yaml_key_line_after(raw, "instructions", name_line)
+                        results.append(
+                            (
+                                f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
+                                ci,
+                                line,
+                            )
+                        )
+
+    # chat.instructions
+    chat = data.get("chat")
+    if isinstance(chat, dict):
+        ci = chat.get("instructions")
+        if isinstance(ci, str) and ci.strip():
+            chat_line = _find_yaml_key_line(raw, "chat")
+            line = None
+            if chat_line is not None:
+                line = _find_yaml_key_line_after(raw, "instructions", chat_line)
+            if line is None:
+                line = _find_yaml_key_line(raw, "instructions")
+            results.append(("chat.instructions", ci, line))
+
+    return results
+
+
+def _extract_coderabbit_instructions_body(raw: str) -> str:
+    """Extract instruction text from raw .coderabbit.yaml content.
+
+    Parses the YAML and concatenates all ``instructions`` field values
+    separated by double newlines so content analyzers see only plain text.
+    Returns an empty string on parse failure or when no instructions exist.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return ""
+    instructions = _extract_instructions(data, raw)
+    return "\n\n".join(text for _, text, _ in instructions)
 
 
 class WeakLanguageDetector:

--- a/src/skillsaw/rules/builtin/marketplace.py
+++ b/src/skillsaw/rules/builtin/marketplace.py
@@ -31,7 +31,7 @@ class MarketplaceJsonValidRule(Rule):
         violations = []
 
         # Only check if marketplace exists
-        if context.repo_type != RepositoryType.MARKETPLACE:
+        if RepositoryType.MARKETPLACE not in context.repo_types:
             return violations
 
         marketplace_file = context.root_path / ".claude-plugin" / "marketplace.json"

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -1,7 +1,7 @@
 """Tests for .coderabbit.yaml linting rules."""
 
 from skillsaw.config import LinterConfig
-from skillsaw.context import RepositoryContext
+from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rule import Severity
 from skillsaw.rules.builtin.coderabbit import (
     CoderabbitYamlValidRule,
@@ -19,7 +19,7 @@ class TestCoderabbitYamlValidRule:
         rule = CoderabbitYamlValidRule()
         assert rule.rule_id == "coderabbit-yaml-valid"
         assert rule.default_severity() == Severity.ERROR
-        assert rule.repo_types is None
+        assert rule.repo_types == {RepositoryType.CODERABBIT}
 
     def test_no_file_passes(self, temp_dir):
         context = RepositoryContext(temp_dir)
@@ -83,7 +83,7 @@ class TestCoderabbitInstructionsRule:
         rule = CoderabbitInstructionsRule()
         assert rule.rule_id == "coderabbit-instructions"
         assert rule.default_severity() == Severity.WARNING
-        assert rule.repo_types is None
+        assert rule.repo_types == {RepositoryType.CODERABBIT}
 
     def test_no_file_passes(self, temp_dir):
         context = RepositoryContext(temp_dir)
@@ -448,6 +448,52 @@ class TestExtractInstructions:
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-type detection
+# ---------------------------------------------------------------------------
+
+
+class TestCoderabbitMultiType:
+    def test_coderabbit_rules_fire_alongside_dot_claude(self, temp_dir):
+        """CodeRabbit rules should fire when .coderabbit.yaml is present alongside .claude/"""
+        claude_dir = temp_dir / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "commands").mkdir()
+        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Maybe be strict.'\n")
+
+        context = RepositoryContext(temp_dir)
+        assert RepositoryType.CODERABBIT in context.repo_types
+        assert RepositoryType.DOT_CLAUDE in context.repo_types
+
+        # The coderabbit rules should still fire
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "weak" in violations[0].message.lower() or "hedge" in violations[0].message.lower()
+
+    def test_coderabbit_rules_auto_enabled_with_coderabbit_type(self, temp_dir):
+        """When repo has CODERABBIT type, auto-enabled coderabbit rules should fire"""
+        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+        context = RepositoryContext(temp_dir)
+        config = LinterConfig.default()
+
+        assert config.is_rule_enabled(
+            "coderabbit-yaml-valid",
+            context,
+            {RepositoryType.CODERABBIT},
+        )
+
+    def test_coderabbit_rules_not_enabled_without_coderabbit_type(self, temp_dir):
+        """Without .coderabbit.yaml, auto-enabled coderabbit rules should not fire"""
+        context = RepositoryContext(temp_dir)
+        config = LinterConfig.default()
+
+        assert not config.is_rule_enabled(
+            "coderabbit-yaml-valid",
+            context,
+            {RepositoryType.CODERABBIT},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -148,6 +148,69 @@ class TestCoderabbitInstructionsRule:
         assert len(violations) == 1
         assert "chat.instructions" in violations[0].message
 
+    def test_weak_language_in_custom_check_instructions(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Go Error Handling'\n"
+            "        mode: warning\n"
+            "        instructions: 'Maybe check for error handling.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "custom_checks" in violations[0].message
+        assert "Go Error Handling" in violations[0].message
+
+    def test_clean_custom_check_instructions_passes(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Go Error Handling'\n"
+            "        mode: warning\n"
+            "        instructions: 'Ensure all errors are wrapped with fmt.Errorf.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_custom_check_instructions_line_number(self, temp_dir):
+        content = (
+            "language: en-US\n"
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Go Error Handling'\n"
+            "        mode: warning\n"
+            "        instructions: 'Maybe check things.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].line == 7
+
+    def test_multiple_custom_checks_with_issues(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Check A'\n"
+            "        instructions: 'Maybe do A.'\n"
+            "      - name: 'Check B'\n"
+            "        instructions: 'Perhaps do B.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 2
+        assert "Check A" in violations[0].message
+        assert "Check B" in violations[1].message
+
     def test_multiple_instruction_fields_with_issues(self, temp_dir):
         content = (
             "reviews:\n"
@@ -304,6 +367,74 @@ class TestExtractInstructions:
 
     def test_non_string_instructions_skipped(self):
         raw = "reviews:\n  instructions:\n    - item1\n    - item2\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 0
+
+    def test_custom_check_instructions(self):
+        raw = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Go Error Handling'\n"
+            "        mode: warning\n"
+            "        instructions: 'Check error handling.'\n"
+            "      - name: 'SQL Injection'\n"
+            "        mode: error\n"
+            "        instructions: 'Prevent SQL injection.'\n"
+        )
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 2
+        assert "Go Error Handling" in result[0][0]
+        assert result[0][1] == "Check error handling."
+        assert "SQL Injection" in result[1][0]
+        assert result[1][1] == "Prevent SQL injection."
+
+    def test_custom_check_instructions_line_numbers(self):
+        raw = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Go Error Handling'\n"
+            "        instructions: 'Check error handling.'\n"
+            "      - name: 'SQL Injection'\n"
+            "        instructions: 'Prevent SQL injection.'\n"
+        )
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 2
+        assert result[0][2] == 5  # line of first instructions key
+        assert result[1][2] == 7  # line of second instructions key
+
+    def test_custom_check_empty_instructions_skipped(self):
+        raw = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Check A'\n"
+            "        instructions: ''\n"
+        )
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 0
+
+    def test_custom_check_no_instructions_field(self):
+        raw = (
+            "reviews:\n"
+            "  pre_merge_checks:\n"
+            "    custom_checks:\n"
+            "      - name: 'Check A'\n"
+            "        mode: warning\n"
+        )
         import yaml
 
         data = yaml.safe_load(raw)

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -1,0 +1,296 @@
+"""Tests for .coderabbit.yaml linting rules."""
+
+from skillsaw.config import LinterConfig
+from skillsaw.context import RepositoryContext
+from skillsaw.rule import Severity
+from skillsaw.rules.builtin.coderabbit import (
+    CoderabbitYamlValidRule,
+    CoderabbitInstructionsRule,
+    _extract_instructions,
+)
+
+# ---------------------------------------------------------------------------
+# CoderabbitYamlValidRule
+# ---------------------------------------------------------------------------
+
+
+class TestCoderabbitYamlValidRule:
+    def test_rule_metadata(self):
+        rule = CoderabbitYamlValidRule()
+        assert rule.rule_id == "coderabbit-yaml-valid"
+        assert rule.default_severity() == Severity.ERROR
+        assert rule.repo_types is None
+
+    def test_no_file_passes(self, temp_dir):
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 0
+
+    def test_valid_yaml_passes(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\nreviews:\n  profile: chill\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 0
+
+    def test_empty_yaml_passes(self, temp_dir):
+        # Empty YAML is valid (loads as None) but top-level must be a mapping
+        (temp_dir / ".coderabbit.yaml").write_text("")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        # yaml.safe_load("") returns None, which is not a dict
+        assert len(violations) == 1
+        assert "mapping" in violations[0].message.lower()
+
+    def test_invalid_yaml_fails(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(":\n  - :\n  bad: [unterminated\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].severity == Severity.ERROR
+        assert "invalid yaml" in violations[0].message.lower()
+
+    def test_invalid_yaml_reports_line(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("good: value\nbad: [unterminated\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].line is not None
+
+    def test_non_mapping_top_level(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("- item1\n- item2\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 1
+        assert "mapping" in violations[0].message.lower()
+
+    def test_unreadable_file(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_bytes(b"\x80\x81\x82\x83")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitYamlValidRule().check(context)
+        assert len(violations) == 1
+        assert (
+            "read" in violations[0].message.lower() or "encoding" in violations[0].message.lower()
+        )
+
+
+# ---------------------------------------------------------------------------
+# CoderabbitInstructionsRule
+# ---------------------------------------------------------------------------
+
+
+class TestCoderabbitInstructionsRule:
+    def test_rule_metadata(self):
+        rule = CoderabbitInstructionsRule()
+        assert rule.rule_id == "coderabbit-instructions"
+        assert rule.default_severity() == Severity.WARNING
+        assert rule.repo_types is None
+
+    def test_no_file_passes(self, temp_dir):
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_no_instructions_passes(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\nreviews:\n  profile: chill\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_clean_instructions_passes(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Always check for null pointers.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_weak_language_in_reviews_instructions(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Maybe check for null pointers if possible.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "weak" in violations[0].message.lower() or "hedge" in violations[0].message.lower()
+        assert "reviews.instructions" in violations[0].message
+
+    def test_weak_language_in_path_instructions(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  path_instructions:\n"
+            "    - path: 'src/**'\n"
+            "      instructions: 'Perhaps validate inputs here.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "path_instructions" in violations[0].message
+
+    def test_weak_language_in_tool_instructions(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  tools:\n"
+            "    biome:\n"
+            "      instructions: 'Try to follow the style guide.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "biome" in violations[0].message
+
+    def test_weak_language_in_chat_instructions(self, temp_dir):
+        content = "chat:\n  instructions: 'You might want to be helpful.'\n"
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "chat.instructions" in violations[0].message
+
+    def test_multiple_instruction_fields_with_issues(self, temp_dir):
+        content = (
+            "reviews:\n"
+            "  instructions: 'Maybe be strict.'\n"
+            "chat:\n"
+            "  instructions: 'Perhaps answer questions.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 2
+
+    def test_invalid_yaml_skipped(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(":\n  bad: [unterminated\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_line_number_reported(self, temp_dir):
+        content = (
+            "language: en-US\n"
+            "reviews:\n"
+            "  profile: chill\n"
+            "  instructions: 'Maybe check things.'\n"
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].line == 4
+
+    def test_file_path_reported(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Maybe do things.'\n")
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].file_path == temp_dir / ".coderabbit.yaml"
+
+
+# ---------------------------------------------------------------------------
+# _extract_instructions helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractInstructions:
+    def test_reviews_instructions(self):
+        raw = "reviews:\n  instructions: 'Do stuff.'\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 1
+        assert result[0][0] == "reviews.instructions"
+        assert result[0][1] == "Do stuff."
+
+    def test_path_instructions(self):
+        raw = (
+            "reviews:\n"
+            "  path_instructions:\n"
+            "    - path: 'src/**'\n"
+            "      instructions: 'Check src.'\n"
+            "    - path: 'tests/**'\n"
+            "      instructions: 'Check tests.'\n"
+        )
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 2
+        assert "src/**" in result[0][0]
+        assert "tests/**" in result[1][0]
+
+    def test_tool_instructions(self):
+        raw = (
+            "reviews:\n"
+            "  tools:\n"
+            "    biome:\n"
+            "      instructions: 'Use biome rules.'\n"
+            "    eslint:\n"
+            "      instructions: 'Use eslint rules.'\n"
+        )
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 2
+        tool_names = [r[0] for r in result]
+        assert any("biome" in t for t in tool_names)
+        assert any("eslint" in t for t in tool_names)
+
+    def test_chat_instructions(self):
+        raw = "chat:\n  instructions: 'Be helpful.'\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 1
+        assert result[0][0] == "chat.instructions"
+        assert result[0][1] == "Be helpful."
+
+    def test_empty_instructions_skipped(self):
+        raw = "reviews:\n  instructions: ''\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 0
+
+    def test_non_string_instructions_skipped(self):
+        raw = "reviews:\n  instructions:\n    - item1\n    - item2\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 0
+
+    def test_no_reviews_no_chat(self):
+        raw = "language: en-US\n"
+        import yaml
+
+        data = yaml.safe_load(raw)
+        result = _extract_instructions(data, raw)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+class TestCoderabbitConfig:
+    def test_yaml_valid_default_auto(self):
+        config = LinterConfig.default()
+        assert config.get_rule_config("coderabbit-yaml-valid").get("enabled") == "auto"
+
+    def test_instructions_default_auto(self):
+        config = LinterConfig.default()
+        assert config.get_rule_config("coderabbit-instructions").get("enabled") == "auto"
+
+    def test_yaml_valid_default_severity_error(self):
+        config = LinterConfig.default()
+        assert config.get_rule_config("coderabbit-yaml-valid").get("severity") == "error"
+
+    def test_instructions_default_severity_warning(self):
+        config = LinterConfig.default()
+        assert config.get_rule_config("coderabbit-instructions").get("severity") == "warning"

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -1,12 +1,22 @@
 """Tests for .coderabbit.yaml linting rules."""
 
+import yaml
+
 from skillsaw.config import LinterConfig
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rule import Severity
 from skillsaw.rules.builtin.coderabbit import (
     CoderabbitYamlValidRule,
-    CoderabbitInstructionsRule,
+)
+from skillsaw.rules.builtin.content_analysis import (
     _extract_instructions,
+    _extract_coderabbit_instructions_body,
+    gather_all_content_files,
+    _get_body,
+)
+from skillsaw.rules.builtin.content_rules import (
+    ContentWeakLanguageRule,
+    ContentTautologicalRule,
 )
 
 # ---------------------------------------------------------------------------
@@ -74,58 +84,76 @@ class TestCoderabbitYamlValidRule:
 
 
 # ---------------------------------------------------------------------------
-# CoderabbitInstructionsRule
+# Content rules on .coderabbit.yaml instructions
 # ---------------------------------------------------------------------------
 
 
-class TestCoderabbitInstructionsRule:
-    def test_rule_metadata(self):
-        rule = CoderabbitInstructionsRule()
-        assert rule.rule_id == "coderabbit-instructions"
-        assert rule.default_severity() == Severity.WARNING
-        assert rule.repo_types == {RepositoryType.CODERABBIT}
+class TestContentRulesOnCoderabbit:
+    """Verify that content-* rules fire on .coderabbit.yaml instruction text."""
 
-    def test_no_file_passes(self, temp_dir):
+    def test_weak_language_detected_in_reviews_instructions(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Try to check for null pointers if possible.'\n"
+        )
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
+        phrases = [v.message for v in coderabbit_violations]
+        assert any("try to" in msg.lower() or "if possible" in msg.lower() for msg in phrases)
 
-    def test_no_instructions_passes(self, temp_dir):
-        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\nreviews:\n  profile: chill\n")
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
-
-    def test_clean_instructions_passes(self, temp_dir):
+    def test_clean_instructions_no_violations(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text(
             "reviews:\n  instructions: 'Always check for null pointers.'\n"
         )
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) == 0
 
-    def test_weak_language_in_reviews_instructions(self, temp_dir):
+    def test_tautological_detected_in_instructions(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text(
-            "reviews:\n  instructions: 'Maybe check for null pointers if possible.'\n"
+            "reviews:\n  instructions: 'Write clean code and follow best practices.'\n"
         )
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "weak" in violations[0].message.lower() or "hedge" in violations[0].message.lower()
-        assert "reviews.instructions" in violations[0].message
+        violations = ContentTautologicalRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
 
-    def test_weak_language_in_path_instructions(self, temp_dir):
-        content = (
-            "reviews:\n"
-            "  path_instructions:\n"
-            "    - path: 'src/**'\n"
-            "      instructions: 'Perhaps validate inputs here.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
+    def test_no_instructions_no_content_violations(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\nreviews:\n  profile: chill\n")
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "path_instructions" in violations[0].message
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) == 0
+
+    def test_invalid_yaml_no_content_violations(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(":\n  bad: [unterminated\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) == 0
+
+    def test_weak_language_in_chat_instructions(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "chat:\n  instructions: 'You might want to be helpful.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
 
     def test_weak_language_in_tool_instructions(self, temp_dir):
         content = (
@@ -136,164 +164,74 @@ class TestCoderabbitInstructionsRule:
         )
         (temp_dir / ".coderabbit.yaml").write_text(content)
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "biome" in violations[0].message
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
 
-    def test_weak_language_in_chat_instructions(self, temp_dir):
-        content = "chat:\n  instructions: 'You might want to be helpful.'\n"
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "chat.instructions" in violations[0].message
 
-    def test_weak_language_in_custom_check_instructions(self, temp_dir):
-        content = (
+# ---------------------------------------------------------------------------
+# _get_body for .coderabbit.yaml
+# ---------------------------------------------------------------------------
+
+
+class TestGetBodyCoderabbit:
+    """Verify _get_body extracts instruction text from .coderabbit.yaml."""
+
+    def test_extracts_review_instructions(self, temp_dir):
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text("reviews:\n  instructions: 'Do stuff.'\n")
+        body = _get_body(cr)
+        assert body is not None
+        assert "Do stuff." in body
+
+    def test_extracts_multiple_instruction_fields(self, temp_dir):
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text(
             "reviews:\n"
-            "  pre_merge_checks:\n"
-            "    custom_checks:\n"
-            "      - name: 'Go Error Handling'\n"
-            "        mode: warning\n"
-            "        instructions: 'Maybe check for error handling.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "custom_checks" in violations[0].message
-        assert "Go Error Handling" in violations[0].message
-
-    def test_clean_custom_check_instructions_passes(self, temp_dir):
-        content = (
-            "reviews:\n"
-            "  pre_merge_checks:\n"
-            "    custom_checks:\n"
-            "      - name: 'Go Error Handling'\n"
-            "        mode: warning\n"
-            "        instructions: 'Ensure all errors are wrapped with fmt.Errorf.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
-
-    def test_custom_check_instructions_line_number(self, temp_dir):
-        content = (
-            "language: en-US\n"
-            "reviews:\n"
-            "  pre_merge_checks:\n"
-            "    custom_checks:\n"
-            "      - name: 'Go Error Handling'\n"
-            "        mode: warning\n"
-            "        instructions: 'Maybe check things.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert violations[0].line == 7
-
-    def test_multiple_custom_checks_with_issues(self, temp_dir):
-        content = (
-            "reviews:\n"
-            "  pre_merge_checks:\n"
-            "    custom_checks:\n"
-            "      - name: 'Check A'\n"
-            "        instructions: 'Maybe do A.'\n"
-            "      - name: 'Check B'\n"
-            "        instructions: 'Perhaps do B.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 2
-        assert "Check A" in violations[0].message
-        assert "Check B" in violations[1].message
-
-    def test_multiple_instruction_fields_with_issues(self, temp_dir):
-        content = (
-            "reviews:\n"
-            "  instructions: 'Maybe be strict.'\n"
+            "  instructions: 'Review stuff.'\n"
             "chat:\n"
-            "  instructions: 'Perhaps answer questions.'\n"
+            "  instructions: 'Chat stuff.'\n"
         )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 2
+        body = _get_body(cr)
+        assert body is not None
+        assert "Review stuff." in body
+        assert "Chat stuff." in body
 
-    def test_truncation_with_many_weak_phrases(self, temp_dir):
-        """When 4+ weak-language matches are found, the message should truncate with '(and N more)'."""
-        (temp_dir / ".coderabbit.yaml").write_text(
-            "reviews:\n"
-            "  instructions: |\n"
-            "    Maybe check for nulls.\n"
-            "    Perhaps validate inputs.\n"
-            "    Try to follow the style guide.\n"
-            "    You might want to add tests.\n"
-            "    Could potentially break things.\n"
-        )
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "(and 2 more)" in violations[0].message
+    def test_returns_empty_for_no_instructions(self, temp_dir):
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text("language: en-US\n")
+        body = _get_body(cr)
+        assert body == ""
 
-    def test_consider_with_action_verb_flagged(self, temp_dir):
-        """'consider using' should be flagged as weak language."""
-        (temp_dir / ".coderabbit.yaml").write_text(
-            "reviews:\n  instructions: 'Consider using type hints everywhere.'\n"
-        )
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "consider" in violations[0].message.lower()
+    def test_returns_empty_for_invalid_yaml(self, temp_dir):
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text(":\n  bad: [unterminated\n")
+        body = _get_body(cr)
+        assert body == ""
 
-    def test_consider_without_action_verb_passes(self, temp_dir):
-        """'consider the following' should NOT be flagged -- it is legitimate."""
-        (temp_dir / ".coderabbit.yaml").write_text(
-            "reviews:\n  instructions: 'Consider the following constraints when reviewing.'\n"
-        )
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
 
-    def test_severity_override_respected(self, temp_dir):
-        """User severity overrides from config should apply to weak-language violations."""
-        (temp_dir / ".coderabbit.yaml").write_text(
-            "reviews:\n  instructions: 'Maybe check for null pointers.'\n"
-        )
-        context = RepositoryContext(temp_dir)
-        rule = CoderabbitInstructionsRule(config={"severity": "error"})
-        violations = rule.check(context)
-        assert len(violations) == 1
-        assert violations[0].severity == Severity.ERROR
+# ---------------------------------------------------------------------------
+# gather_all_content_files includes .coderabbit.yaml
+# ---------------------------------------------------------------------------
 
-    def test_invalid_yaml_skipped(self, temp_dir):
-        (temp_dir / ".coderabbit.yaml").write_text(":\n  bad: [unterminated\n")
-        context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 0
 
-    def test_line_number_reported(self, temp_dir):
-        content = (
-            "language: en-US\n"
-            "reviews:\n"
-            "  profile: chill\n"
-            "  instructions: 'Maybe check things.'\n"
-        )
-        (temp_dir / ".coderabbit.yaml").write_text(content)
+class TestGatherContentFilesCoderabbit:
+    def test_includes_coderabbit_yaml(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Do stuff.'\n")
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert violations[0].line == 4
+        files = gather_all_content_files(context)
+        paths = [cf.path for cf in files]
+        assert temp_dir / ".coderabbit.yaml" in paths
+        categories = {cf.category for cf in files if cf.path == temp_dir / ".coderabbit.yaml"}
+        assert "coderabbit" in categories
 
-    def test_file_path_reported(self, temp_dir):
-        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Maybe do things.'\n")
+    def test_not_included_when_absent(self, temp_dir):
         context = RepositoryContext(temp_dir)
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert violations[0].file_path == temp_dir / ".coderabbit.yaml"
+        files = gather_all_content_files(context)
+        paths = [cf.path for cf in files]
+        assert temp_dir / ".coderabbit.yaml" not in paths
 
 
 # ---------------------------------------------------------------------------
@@ -304,8 +242,6 @@ class TestCoderabbitInstructionsRule:
 class TestExtractInstructions:
     def test_reviews_instructions(self):
         raw = "reviews:\n  instructions: 'Do stuff.'\n"
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 1
@@ -321,8 +257,6 @@ class TestExtractInstructions:
             "    - path: 'tests/**'\n"
             "      instructions: 'Check tests.'\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
@@ -338,8 +272,6 @@ class TestExtractInstructions:
             "    eslint:\n"
             "      instructions: 'Use eslint rules.'\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
@@ -349,8 +281,6 @@ class TestExtractInstructions:
 
     def test_chat_instructions(self):
         raw = "chat:\n  instructions: 'Be helpful.'\n"
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 1
@@ -359,16 +289,12 @@ class TestExtractInstructions:
 
     def test_empty_instructions_skipped(self):
         raw = "reviews:\n  instructions: ''\n"
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
 
     def test_non_string_instructions_skipped(self):
         raw = "reviews:\n  instructions:\n    - item1\n    - item2\n"
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
@@ -385,8 +311,6 @@ class TestExtractInstructions:
             "        mode: error\n"
             "        instructions: 'Prevent SQL injection.'\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
@@ -405,8 +329,6 @@ class TestExtractInstructions:
             "      - name: 'SQL Injection'\n"
             "        instructions: 'Prevent SQL injection.'\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
@@ -421,8 +343,6 @@ class TestExtractInstructions:
             "      - name: 'Check A'\n"
             "        instructions: ''\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
@@ -435,16 +355,12 @@ class TestExtractInstructions:
             "      - name: 'Check A'\n"
             "        mode: warning\n"
         )
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
 
     def test_no_reviews_no_chat(self):
         raw = "language: en-US\n"
-        import yaml
-
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 0
@@ -461,16 +377,20 @@ class TestCoderabbitMultiType:
         claude_dir = temp_dir / ".claude"
         claude_dir.mkdir()
         (claude_dir / "commands").mkdir()
-        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Maybe be strict.'\n")
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Try to be strict.'\n"
+        )
 
         context = RepositoryContext(temp_dir)
         assert RepositoryType.CODERABBIT in context.repo_types
         assert RepositoryType.DOT_CLAUDE in context.repo_types
 
-        # The coderabbit rules should still fire
-        violations = CoderabbitInstructionsRule().check(context)
-        assert len(violations) == 1
-        assert "weak" in violations[0].message.lower() or "hedge" in violations[0].message.lower()
+        # Content weak-language rule should fire on the coderabbit instruction text
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
 
     def test_coderabbit_rules_auto_enabled_with_coderabbit_type(self, temp_dir):
         """When repo has CODERABBIT type, auto-enabled coderabbit rules should fire"""
@@ -506,14 +426,6 @@ class TestCoderabbitConfig:
         config = LinterConfig.default()
         assert config.get_rule_config("coderabbit-yaml-valid").get("enabled") == "auto"
 
-    def test_instructions_default_auto(self):
-        config = LinterConfig.default()
-        assert config.get_rule_config("coderabbit-instructions").get("enabled") == "auto"
-
     def test_yaml_valid_default_severity_error(self):
         config = LinterConfig.default()
         assert config.get_rule_config("coderabbit-yaml-valid").get("severity") == "error"
-
-    def test_instructions_default_severity_warning(self):
-        config = LinterConfig.default()
-        assert config.get_rule_config("coderabbit-instructions").get("severity") == "warning"

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -160,6 +160,52 @@ class TestCoderabbitInstructionsRule:
         violations = CoderabbitInstructionsRule().check(context)
         assert len(violations) == 2
 
+    def test_truncation_with_many_weak_phrases(self, temp_dir):
+        """When 4+ weak-language matches are found, the message should truncate with '(and N more)'."""
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n"
+            "  instructions: |\n"
+            "    Maybe check for nulls.\n"
+            "    Perhaps validate inputs.\n"
+            "    Try to follow the style guide.\n"
+            "    You might want to add tests.\n"
+            "    Could potentially break things.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "(and 2 more)" in violations[0].message
+
+    def test_consider_with_action_verb_flagged(self, temp_dir):
+        """'consider using' should be flagged as weak language."""
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Consider using type hints everywhere.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 1
+        assert "consider" in violations[0].message.lower()
+
+    def test_consider_without_action_verb_passes(self, temp_dir):
+        """'consider the following' should NOT be flagged -- it is legitimate."""
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Consider the following constraints when reviewing.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = CoderabbitInstructionsRule().check(context)
+        assert len(violations) == 0
+
+    def test_severity_override_respected(self, temp_dir):
+        """User severity overrides from config should apply to weak-language violations."""
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n  instructions: 'Maybe check for null pointers.'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        rule = CoderabbitInstructionsRule(config={"severity": "error"})
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert violations[0].severity == Severity.ERROR
+
     def test_invalid_yaml_skipped(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text(":\n  bad: [unterminated\n")
         context = RepositoryContext(temp_dir)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ from skillsaw.context import (
     HAS_AGENTS_MD,
     HAS_KIRO,
     HAS_CLAUDE_MD,
+    HAS_CODERABBIT,
 )
 
 
@@ -442,3 +443,61 @@ def test_multi_type_dot_claude_and_agentskills(temp_dir):
     assert RepositoryType.AGENTSKILLS in context.repo_types
     # DOT_CLAUDE has higher priority than AGENTSKILLS for backward compat
     assert context.repo_type == RepositoryType.DOT_CLAUDE
+
+
+def test_detected_formats_coderabbit(temp_dir):
+    """Detect .coderabbit.yaml sets HAS_CODERABBIT format flag"""
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+    context = RepositoryContext(temp_dir)
+    assert HAS_CODERABBIT in context.detected_formats
+
+
+def test_coderabbit_only_repo_gets_content_rules(temp_dir):
+    """A coderabbit-only repo with instruction text should trigger content rules"""
+    from skillsaw.config import LinterConfig
+    from skillsaw.linter import Linter
+
+    (temp_dir / ".coderabbit.yaml").write_text(
+        "reviews:\n  instructions: |\n    Try to use consistent formatting.\n"
+    )
+    context = RepositoryContext(temp_dir)
+    config = LinterConfig.default()
+    linter = Linter(context, config)
+    violations = linter.run()
+    weak = [v for v in violations if v.rule_id == "content-weak-language"]
+    assert len(weak) >= 1, "content-weak-language should fire on coderabbit instruction text"
+
+
+def test_coderabbit_repo_no_command_violations(temp_dir):
+    """A coderabbit-only repo should produce no command/skill violations"""
+    from skillsaw.config import LinterConfig
+    from skillsaw.linter import Linter
+
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+    context = RepositoryContext(temp_dir)
+    config = LinterConfig.default()
+    linter = Linter(context, config)
+    violations = linter.run()
+    irrelevant = [
+        v
+        for v in violations
+        if v.rule_id
+        in {
+            "command-naming",
+            "command-frontmatter",
+            "skill-frontmatter",
+            "agent-frontmatter",
+            "hooks-json-valid",
+            "mcp-valid-json",
+        }
+    ]
+    assert len(irrelevant) == 0, f"Should have no command/skill violations: {irrelevant}"
+
+
+def test_coderabbit_with_claude_md_gets_both_formats(temp_dir):
+    """Repo with both .coderabbit.yaml and CLAUDE.md has both format flags"""
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+    (temp_dir / "CLAUDE.md").write_text("# Instructions\n")
+    context = RepositoryContext(temp_dir)
+    assert HAS_CODERABBIT in context.detected_formats
+    assert HAS_CLAUDE_MD in context.detected_formats

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -368,3 +368,77 @@ def test_apm_dir_does_not_override_marketplace(temp_dir):
     (claude_plugin / "marketplace.json").write_text('{"name": "test", "plugins": []}')
     context = RepositoryContext(temp_dir)
     assert context.repo_type == RepositoryType.MARKETPLACE
+
+
+# --- Multi-type detection tests ---
+
+
+def test_multi_type_coderabbit_and_dot_claude(temp_dir):
+    """Repo with both .coderabbit.yaml and .claude/ gets both CODERABBIT and DOT_CLAUDE types"""
+    claude_dir = temp_dir / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "commands").mkdir()
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.CODERABBIT in context.repo_types
+    assert RepositoryType.DOT_CLAUDE in context.repo_types
+    # Primary type should be DOT_CLAUDE (higher priority than CODERABBIT)
+    assert context.repo_type == RepositoryType.DOT_CLAUDE
+
+
+def test_multi_type_coderabbit_and_marketplace(temp_dir):
+    """Repo with .coderabbit.yaml and marketplace gets both types"""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text('{"name": "test", "plugins": []}')
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.CODERABBIT in context.repo_types
+    assert RepositoryType.MARKETPLACE in context.repo_types
+    # Primary type should be MARKETPLACE (highest priority)
+    assert context.repo_type == RepositoryType.MARKETPLACE
+
+
+def test_multi_type_coderabbit_alone(temp_dir):
+    """Repo with only .coderabbit.yaml is just CODERABBIT"""
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.CODERABBIT in context.repo_types
+    assert RepositoryType.UNKNOWN not in context.repo_types
+    assert context.repo_type == RepositoryType.CODERABBIT
+
+
+def test_multi_type_repo_types_set(temp_dir):
+    """repo_types is a set, repo_type is backward-compat property"""
+    (temp_dir / "SKILL.md").write_text("---\nname: skill\ndescription: A skill\n---\n")
+    (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+
+    context = RepositoryContext(temp_dir)
+    assert isinstance(context.repo_types, set)
+    assert RepositoryType.AGENTSKILLS in context.repo_types
+    assert RepositoryType.CODERABBIT in context.repo_types
+
+
+def test_multi_type_unknown_only_when_empty(temp_dir):
+    """UNKNOWN is only set when no other type matches"""
+    context = RepositoryContext(temp_dir)
+    assert context.repo_types == {RepositoryType.UNKNOWN}
+    assert context.repo_type == RepositoryType.UNKNOWN
+
+
+def test_multi_type_dot_claude_and_agentskills(temp_dir):
+    """Repo with .claude/skills/ has both DOT_CLAUDE and AGENTSKILLS in repo_types"""
+    claude_dir = temp_dir / ".claude"
+    claude_dir.mkdir()
+    skill_dir = claude_dir / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: Test\n---\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.DOT_CLAUDE in context.repo_types
+    assert RepositoryType.AGENTSKILLS in context.repo_types
+    # DOT_CLAUDE has higher priority than AGENTSKILLS for backward compat
+    assert context.repo_type == RepositoryType.DOT_CLAUDE


### PR DESCRIPTION
## Summary

- Add `coderabbit-yaml-valid` rule to validate `.coderabbit.yaml` YAML syntax (severity: error, auto-enabled)
- Add `coderabbit-instructions` rule to check instruction text fields for content quality issues like weak/hedge language (severity: warning, auto-enabled)
- Extract and lint instruction text from `reviews.instructions`, `reviews.path_instructions[].instructions`, `reviews.tools.<tool>.instructions`, and `chat.instructions`
- Line numbers are reported for violations when possible

Fixes #64

## Test plan

- [x] `make test` -- 495 tests pass
- [x] `make lint` -- formatting clean
- [x] `make update` -- generated files regenerated
- [x] `python -m skillsaw .` -- no false positives on skillsaw repo (which has a `.coderabbit.yaml`)
- [x] Test against `openshift-eng/ai-helpers` -- exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two auto-enabled CodeRabbit checks for `.coderabbit.yaml`: YAML validity (error) and instruction content-quality scanning (warning).
  * CLI: allow explicitly overriding detected repository type via a repeatable option.
  * Repo detection now supports multiple simultaneous types and uses that set across discovery and linting.
  * Formatter: verbose JSON output includes the list of detected repo types.

* **Documentation**
  * README and examples updated to document the new CodeRabbit rule group.

* **Tests**
  * Added comprehensive tests for CodeRabbit rules, multi-type detection, and defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/66)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->