### PR TITLE
Fix content-instruction-budget: scope per file instead of aggregating across all files

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -159,7 +159,7 @@ rules:
     enabled: auto
     severity: warning
 
-  # Check if total instruction count across all files exceeds LLM instruction budget (~150)
+  # Check if instruction count in a file exceeds LLM instruction budget (~150)
   content-instruction-budget:
     enabled: auto
     severity: warning

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 | `content-tautological` | Detect tautological instructions that the model already follows by default | warning (auto) | llm |
 | `content-critical-position` | Detect critical instructions in the middle of files where LLM attention is lowest | warning (auto) | llm |
 | `content-redundant-with-tooling` | Detect instructions that duplicate .editorconfig, ESLint, Prettier, or tsconfig settings | warning (auto) | llm |
-| `content-instruction-budget` | Check if total instruction count across all files exceeds LLM instruction budget (~150) | warning (auto) | llm |
+| `content-instruction-budget` | Check if instruction count in a file exceeds LLM instruction budget (~150) | warning (auto) | llm |
 | `content-negative-only` | Detect prohibitions without a positive alternative (agent has no path forward) | warning (auto) | llm |
 | `content-section-length` | Warn about markdown sections longer than ~500 tokens | info (auto) | llm |
 | `content-contradiction` | Detect likely contradictions within instruction files using keyword-pair heuristics | warning (auto) | llm |

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -405,21 +405,23 @@ class InstructionBudgetAnalyzer:
     )
     BUDGET = 150
 
-    def analyze(self, paths: List[Path]) -> InstructionBudget:
+    def analyze_file(self, path: Path) -> InstructionBudget:
+        content = _get_body(path)
+        if not content:
+            return InstructionBudget(
+                total_count=0,
+                files_counted=[],
+                budget_remaining=self.BUDGET,
+                over_budget=False,
+            )
         total = 0
-        counted: List[Path] = []
-        for path in paths:
-            content = _get_body(path)
-            if not content:
-                continue
-            counted.append(path)
-            for line in content.splitlines():
-                if self._IMPERATIVE_RE.match(line):
-                    total += 1
+        for line in content.splitlines():
+            if self._IMPERATIVE_RE.match(line):
+                total += 1
         remaining = self.BUDGET - total
         return InstructionBudget(
             total_count=total,
-            files_counted=counted,
+            files_counted=[path],
             budget_remaining=max(0, remaining),
             over_budget=total > self.BUDGET,
         )

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -228,7 +228,7 @@ class ContentInstructionBudgetRule(Rule):
 
     @property
     def description(self) -> str:
-        return "Check if total instruction count across all files exceeds LLM instruction budget (~150)"
+        return "Check if instruction count in a file exceeds LLM instruction budget (~150)"
 
     def default_severity(self) -> Severity:
         return Severity.WARNING
@@ -236,9 +236,9 @@ class ContentInstructionBudgetRule(Rule):
     @property
     def llm_fix_prompt(self):
         return (
-            "You are reducing the instruction count in AI coding assistant "
-            "instruction files. The total number of imperative instructions "
-            "across all files exceeds the recommended budget.\n\n"
+            "You are reducing the instruction count in an AI coding assistant "
+            "instruction file. The number of imperative instructions in this "
+            "file exceeds the recommended budget.\n\n"
             "Rules:\n"
             "- Merge duplicate or near-duplicate instructions\n"
             "- Remove tautological instructions the model follows by default\n"
@@ -253,20 +253,22 @@ class ContentInstructionBudgetRule(Rule):
         if not content_files:
             return []
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([cf.path for cf in content_files])
         violations = []
-        if budget.total_count >= 120:
-            sev = Severity.ERROR if budget.over_budget else Severity.WARNING
-            msg = (
-                f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions across {len(budget.files_counted)} files "
-                f"({budget.budget_remaining} remaining)"
-            )
-            for fpath in budget.files_counted:
-                violations.append(self.violation(msg, file_path=fpath, severity=sev))
-        elif budget.total_count >= 80:
-            msg = f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions across {len(budget.files_counted)} files — approaching limit"
-            for fpath in budget.files_counted:
-                violations.append(self.violation(msg, file_path=fpath, severity=Severity.INFO))
+        for cf in content_files:
+            budget = analyzer.analyze_file(cf.path)
+            if budget.total_count >= 120:
+                sev = Severity.ERROR if budget.over_budget else Severity.WARNING
+                msg = (
+                    f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions "
+                    f"({budget.budget_remaining} remaining)"
+                )
+                violations.append(self.violation(msg, file_path=cf.path, severity=sev))
+            elif budget.total_count >= 80:
+                msg = (
+                    f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions "
+                    f"— approaching limit"
+                )
+                violations.append(self.violation(msg, file_path=cf.path, severity=Severity.INFO))
         return violations
 
 

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -318,7 +318,7 @@ class TestInstructionBudgetAnalyzer:
         content = "- Use 4-space indentation\n- Run tests before commits\n- Check for errors\nSome description.\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([temp_dir / "CLAUDE.md"])
+        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
         assert budget.total_count == 3
         assert not budget.over_budget
 
@@ -326,30 +326,29 @@ class TestInstructionBudgetAnalyzer:
         lines = [f"- Use tool_{i}" for i in range(160)]
         (temp_dir / "CLAUDE.md").write_text("\n".join(lines) + "\n")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([temp_dir / "CLAUDE.md"])
+        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
         assert budget.over_budget
         assert budget.budget_remaining == 0
 
     def test_empty_file(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([temp_dir / "CLAUDE.md"])
+        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
         assert budget.total_count == 0
         assert not budget.over_budget
 
-    def test_multiple_files(self, temp_dir):
+    def test_single_file_counted(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("- Use X\n- Run Y\n")
-        (temp_dir / "AGENTS.md").write_text("- Check Z\n- Avoid W\n")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([temp_dir / "CLAUDE.md", temp_dir / "AGENTS.md"])
-        assert budget.total_count == 4
-        assert len(budget.files_counted) == 2
+        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        assert budget.total_count == 2
+        assert len(budget.files_counted) == 1
 
     def test_non_imperative_not_counted(self, temp_dir):
         content = "# Instructions\n\nThis project is a web app.\nIt was built in 2024.\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze([temp_dir / "CLAUDE.md"])
+        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
         assert budget.total_count == 0
 
 


### PR DESCRIPTION
## Summary
- The content-instruction-budget rule was counting imperative instructions across ALL content files and reporting the aggregate on every file. This is incorrect because skills and commands are hot-loaded individually — they're not all in the context window at once.
- Changed to per-file analysis: each file gets its own instruction count checked against the budget independently.
- A repo with 245 content files no longer reports "1737/150 instructions across 245 files" on each file.

## Test plan
- [ ] Existing tests pass (instruction budget test case uses 135 lines in a single file, still triggers)
- [ ] Run against openshift-eng/ai-helpers — verify reasonable per-file violations instead of 245 duplicate aggregate violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Instruction budget checking now evaluates each content file independently against an approximate ~150-instruction limit, emitting per-file warnings/errors as thresholds are reached.

* **Documentation**
  * Configuration example and README updated to describe per-file instruction budget validation.

* **Tests**
  * Test suite updated to validate the new per-file budget analysis and expected per-file outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/67)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->