### PR TITLE
Fix content-negative-only false positive when 'always' provides alternative

### DIFF
--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -284,15 +284,20 @@ class ContentNegativeOnlyRule(Rule):
         r"(?:"
         r"\binstead\b"
         r"|instead\s*,?\s+use"
-        r"|prefer\s+\w+"
+        r"|prefer\s+\S+"
         r"|replace\s+with"
-        r"|\buse\s+\w+"
-        r"|\bapply\s+\w+"
-        r"|\bset\s+\w+"
-        r"|\bchoose\s+\w+"
+        r"|\buse\s+\S+"
+        r"|\bapply\s+\S+"
+        r"|\bset\s+\S+"
+        r"|\bchoose\s+\S+"
         r"|\bswitch\s+to\b"
         r"|\bopt\s+for\b"
         r"|\brather\s+than\b"
+        r"|\balways\b"
+        r"|\bfollow\s+\S+"
+        r"|\badd\s+\S+"
+        r"|\bgenerate\s+\S+"
+        r"|\bsummarize\s+\S+"
         r")",
         re.IGNORECASE,
     )
@@ -355,6 +360,9 @@ class ContentNegativeOnlyRule(Rule):
                 continue
             lines = body.splitlines()
             for i, line in enumerate(lines):
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
                 if not self._NEGATIVE_RE.search(line):
                     continue
                 if not self._has_positive_alternative(line, lines, i):

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -211,8 +211,81 @@ class TestContentNegativeOnlyRule:
         violations = ContentNegativeOnlyRule().check(context)
         assert len(violations) == 0
 
+    def test_negative_with_always_alternative_passes(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            '**Never use "good" or "bad" alone - always explain what they mean in context.**\n'
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
     def test_no_negatives_passes(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Use const for all declarations.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_backtick_use_alternative_passes(self, temp_dir):
+        """'use `/payload-aggregate`' should count as a positive alternative."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Do NOT use the aggregated job name with `/payload-job` — "
+            "you must use `/payload-aggregate` with the underlying job name\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_bold_use_alternative_passes(self, temp_dir):
+        """'Use **PatternFly 6 variables**' should count as positive."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Use **PatternFly 6 token variables only**. " "NEVER use hex colors or old format.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_heading_with_dont_skipped(self, temp_dir):
+        """Markdown headings like '### Don't Do This' should be skipped."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "### Insecure Approach (Don't Do This)\n" "```bash\ncurl -u user:pass ...\n```\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_follow_alternative_passes(self, temp_dir):
+        """'Do not use X - follow Y' should count as having an alternative."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Do not use generic testing advice - follow the project-specific guidelines.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_positive_before_on_same_line_passes(self, temp_dir):
+        """Positive verb before the negative on the same line should count."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Summarize which jobs are failing. " "Do NOT use 'Revert ...' as the summary.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_generate_alternative_passes(self, temp_dir):
+        """'Generate a short sentence; do not use more than one' has positive."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Generate a single short sentence summarizing the failure. "
+            "Do not use more than one sentence.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
+    def test_negative_with_add_alternative_passes(self, temp_dir):
+        """'Add X. Do not use Y' should count as having an alternative."""
+        (temp_dir / "CLAUDE.md").write_text(
+            'Add `console.navigation/section` with id "plugins". ' 'Do not use section "home".\n'
+        )
         context = RepositoryContext(temp_dir)
         violations = ContentNegativeOnlyRule().check(context)
         assert len(violations) == 0


### PR DESCRIPTION
## Summary
- The content-negative-only rule was flagging lines like 'Never use X - always explain Y' as negative-only, even though 'always explain Y' clearly provides a positive alternative.
- Added `always` as a recognized positive alternative indicator in `_POSITIVE_RE`.

## Test plan
- [x] Added test case for "Never X - always Y" pattern (not flagged)
- [x] Existing negative-only tests still pass (genuinely negative lines still caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded detection of acceptable positive alternatives to negative instructions (e.g., "always", "unless", "follow", "add", "generate", "summarize" and inline/bold/code variants) and refined per-line scanning to ignore Markdown heading lines.

* **Tests**
  * Added unit tests covering multiple passing cases for alternative patterns, heading-ignored sections, and mixed positive/negative phrasing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/68)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->