### PR TITLE
Skip content-critical-position for .coderabbit.yaml

### DIFF
--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -159,6 +159,8 @@ class ContentCriticalPositionRule(Rule):
         violations = []
         analyzer = CriticalPositionAnalyzer()
         for cf in gather_all_content_files(context):
+            if cf.category == "coderabbit":
+                continue
             for issue in analyzer.analyze(cf.path):
                 violations.append(
                     self.violation(


### PR DESCRIPTION
## Summary
- Skip `content-critical-position` rule for `.coderabbit.yaml` files
- CodeRabbit scopes instructions per-tool/per-path, so each `instructions:` block is its own context window — position within the overall file is meaningless
- The rule was producing false positives by treating the whole file as a single document

## Test plan
- [x] `make test` — 816 passed
- [x] Verified against `~/git/sippy` — no more false critical-position warnings on `.coderabbit.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Critical position analysis now excludes files from the coderabbit category, reducing false positive violations in code reviews.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/69)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->