### PR TITLE
Fix macOS test failures and apply excludes to all rule inputs

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -8,3 +8,4 @@ exclude:
   - ".opencode/*"
   - ".agents/*"
   - ".github/instructions/*"
+  - "src/skillsaw/marketplace/templates/*"

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -4,6 +4,7 @@ Repository context detection and management
 
 from __future__ import annotations
 
+import fnmatch
 from enum import Enum
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Set
@@ -96,6 +97,25 @@ class RepositoryContext:
             if t in self.repo_types:
                 return t
         return RepositoryType.UNKNOWN
+
+    def apply_excludes(self) -> None:
+        """Filter plugins, skills, and instruction_files by exclude_patterns.
+
+        Must be called after exclude_patterns is set (e.g. from config).
+        """
+        if not self.exclude_patterns:
+            return
+
+        def _excluded(p: Path) -> bool:
+            try:
+                rel = str(p.resolve().relative_to(self.root_path))
+            except ValueError:
+                return False
+            return any(fnmatch.fnmatch(rel, pat) for pat in self.exclude_patterns)
+
+        self.plugins = [p for p in self.plugins if not _excluded(p)]
+        self.skills = [p for p in self.skills if not _excluded(p)]
+        self.instruction_files = [p for p in self.instruction_files if not _excluded(p)]
 
     def _discover_instruction_files(self) -> List[Path]:
         """Discover instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) at the repo root."""

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -98,6 +98,16 @@ class RepositoryContext:
                 return t
         return RepositoryType.UNKNOWN
 
+    def is_path_excluded(self, path: Path) -> bool:
+        """Check if a path matches any exclude pattern."""
+        if not self.exclude_patterns:
+            return False
+        try:
+            rel = str(path.resolve().relative_to(self.root_path))
+        except ValueError:
+            return False
+        return any(fnmatch.fnmatch(rel, pat) for pat in self.exclude_patterns)
+
     def apply_excludes(self) -> None:
         """Filter plugins, skills, and instruction_files by exclude_patterns.
 
@@ -105,17 +115,9 @@ class RepositoryContext:
         """
         if not self.exclude_patterns:
             return
-
-        def _excluded(p: Path) -> bool:
-            try:
-                rel = str(p.resolve().relative_to(self.root_path))
-            except ValueError:
-                return False
-            return any(fnmatch.fnmatch(rel, pat) for pat in self.exclude_patterns)
-
-        self.plugins = [p for p in self.plugins if not _excluded(p)]
-        self.skills = [p for p in self.skills if not _excluded(p)]
-        self.instruction_files = [p for p in self.instruction_files if not _excluded(p)]
+        self.plugins = [p for p in self.plugins if not self.is_path_excluded(p)]
+        self.skills = [p for p in self.skills if not self.is_path_excluded(p)]
+        self.instruction_files = [p for p in self.instruction_files if not self.is_path_excluded(p)]
 
     def _discover_instruction_files(self) -> List[Path]:
         """Discover instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) at the repo root."""

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -4,7 +4,6 @@ Main linter orchestration
 
 from __future__ import annotations
 
-import fnmatch
 import importlib.util
 import logging
 import sys
@@ -147,13 +146,9 @@ class Linter:
 
     def _is_excluded(self, violation: RuleViolation) -> bool:
         """Check if a violation's file path matches any exclude pattern."""
-        if not self.config.exclude_patterns or violation.file_path is None:
+        if violation.file_path is None:
             return False
-        try:
-            rel = str(violation.file_path.resolve().relative_to(self.context.root_path))
-        except ValueError:
-            return False
-        return any(fnmatch.fnmatch(rel, pat) for pat in self.config.exclude_patterns)
+        return self.context.is_path_excluded(violation.file_path)
 
     def run(self) -> List[RuleViolation]:
         """
@@ -190,20 +185,22 @@ class Linter:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
                 continue
 
-            if rule_violations and rule.supports_autofix:
+            visible = [v for v in rule_violations if not self._is_excluded(v)]
+
+            if visible and rule.supports_autofix:
                 try:
-                    fixes = rule.fix(self.context, rule_violations)
+                    fixes = rule.fix(self.context, visible)
                     all_fixes.extend(fixes)
                     fixed_violations = {id(v) for fix in fixes for v in fix.violations_fixed}
-                    remaining = [v for v in rule_violations if id(v) not in fixed_violations]
+                    remaining = [v for v in visible if id(v) not in fixed_violations]
                     all_violations.extend(remaining)
                 except Exception as e:
                     print(f"Error fixing rule {rule.rule_id}: {e}", file=sys.stderr)
-                    all_violations.extend(rule_violations)
+                    all_violations.extend(visible)
             else:
-                all_violations.extend(rule_violations)
+                all_violations.extend(visible)
 
-        return [v for v in all_violations if not self._is_excluded(v)], all_fixes
+        return all_violations, all_fixes
 
     @staticmethod
     def apply_fixes(

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -4,6 +4,7 @@ Main linter orchestration
 
 from __future__ import annotations
 
+import fnmatch
 import importlib.util
 import logging
 import sys
@@ -52,6 +53,7 @@ class Linter:
         self.config = config or LinterConfig.default()
         self.context.content_paths = self.config.content_paths
         self.context.exclude_patterns = self.config.exclude_patterns
+        self.context.apply_excludes()
         self.rules: List[Rule] = []
         self._load_rules()
 
@@ -143,6 +145,16 @@ class Linter:
                 )
         return warnings
 
+    def _is_excluded(self, violation: RuleViolation) -> bool:
+        """Check if a violation's file path matches any exclude pattern."""
+        if not self.config.exclude_patterns or violation.file_path is None:
+            return False
+        try:
+            rel = str(violation.file_path.resolve().relative_to(self.context.root_path))
+        except ValueError:
+            return False
+        return any(fnmatch.fnmatch(rel, pat) for pat in self.config.exclude_patterns)
+
     def run(self) -> List[RuleViolation]:
         """
         Run all enabled rules
@@ -159,7 +171,7 @@ class Linter:
             except Exception as e:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
 
-        return violations
+        return [v for v in violations if not self._is_excluded(v)]
 
     def fix(self) -> tuple[List[RuleViolation], List[AutofixResult]]:
         """
@@ -191,7 +203,7 @@ class Linter:
             else:
                 all_violations.extend(rule_violations)
 
-        return all_violations, all_fixes
+        return [v for v in all_violations if not self._is_excluded(v)], all_fixes
 
     @staticmethod
     def apply_fixes(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ _load_dotenv()
 def temp_dir():
     """Create a temporary directory for testing"""
     tmp = tempfile.mkdtemp()
-    yield Path(tmp)
+    yield Path(tmp).resolve()
     shutil.rmtree(tmp)
 
 

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -137,7 +137,8 @@ def test_self_lint():
     """Skillsaw's own .claude/ directory should pass linting with no errors"""
     repo_root = Path(__file__).parent.parent
     context = RepositoryContext(repo_root)
-    config = LinterConfig.default()
+    config_path = repo_root / ".skillsaw.yaml"
+    config = LinterConfig.from_file(config_path) if config_path.exists() else LinterConfig.default()
     linter = Linter(context, config)
 
     # Exclude intentional test fixtures (PR #29: code scanning test)

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -330,6 +330,8 @@ class TestLLMFixByRule:
 
         config = LinterConfig.default()
         config.llm.model = os.environ.get("SKILLSAW_MODEL", "openrouter/minimax/minimax-m2.7")
+        if case.rule_config:
+            config.rules.setdefault(case.rule_id, {}).update(case.rule_config)
         context = RepositoryContext(tmp_path)
         linter = Linter(context, config)
 


### PR DESCRIPTION
## Summary
- Resolve temp_dir paths in test fixture to handle macOS `/var` → `/private/var` symlink, fixing 6 CodeRabbit test failures on Python 3.14
- Apply exclude patterns to `context.skills`, `plugins`, and `instruction_files` during `Linter` init so excluded files are never read or processed by any rule
- Filter violations by exclude patterns as a safety net for rules that discover files independently
- Exclude marketplace templates from self-lint via `.skillsaw.yaml`

## Test plan
- [x] All 816 tests pass locally on macOS with Python 3.14
- [x] `make lint` clean
- [ ] CI passes on Python 3.9–3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exclude patterns from config are now applied to repository scanning and lint runs, so specified files/templates are skipped.

* **Bug Fixes**
  * Excluded files are reliably omitted from lint results and from remaining violations after autofix.

* **Tests**
  * Self-lint test respects repository config when present; temp-path fixture yields resolved paths.
  * Live-fix test applies per-case rule configs before running fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/70)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->