### PR TITLE
Fix .claude false-positive plugin detection in marketplace repos

### DIFF
--- a/.apm/instructions/python.instructions.md
+++ b/.apm/instructions/python.instructions.md
@@ -1,0 +1,11 @@
+---
+description: How to run Python and skillsaw in this project
+globs: "*.py"
+---
+
+This project uses a `.venv` virtualenv. Never invoke bare `python` or
+`python3` — the system interpreter won't have skillsaw installed. Use:
+
+- `.venv/bin/skillsaw` to run the linter directly
+- `.venv/bin/python3` when you need the project's interpreter
+- `make` targets when they exist (`make test`, `make lint`, `make format`)

--- a/.claude/rules/python.md
+++ b/.claude/rules/python.md
@@ -1,0 +1,6 @@
+This project uses a `.venv` virtualenv. Never invoke bare `python` or
+`python3` — the system interpreter won't have skillsaw installed. Use:
+
+- `.venv/bin/skillsaw` to run the linter directly
+- `.venv/bin/python3` when you need the project's interpreter
+- `make` targets when they exist (`make test`, `make lint`, `make format`)

--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -1,0 +1,10 @@
+---
+description: How to run Python and skillsaw in this project
+---
+
+This project uses a `.venv` virtualenv. Never invoke bare `python` or
+`python3` — the system interpreter won't have skillsaw installed. Use:
+
+- `.venv/bin/skillsaw` to run the linter directly
+- `.venv/bin/python3` when you need the project's interpreter
+- `make` targets when they exist (`make test`, `make lint`, `make format`)

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,11 @@
+---
+description: How to run Python and skillsaw in this project
+globs: "*.py"
+---
+
+This project uses a `.venv` virtualenv. Never invoke bare `python` or
+`python3` — the system interpreter won't have skillsaw installed. Use:
+
+- `.venv/bin/skillsaw` to run the linter directly
+- `.venv/bin/python3` when you need the project's interpreter
+- `make` targets when they exist (`make test`, `make lint`, `make format`)

--- a/.github/workflows/test-llm-integration.yml
+++ b/.github/workflows/test-llm-integration.yml
@@ -2,6 +2,10 @@ name: LLM Integration Tests
 
 on:
   pull_request:
+    paths:
+      - 'tests/test_llm_integration.py'
+      - 'tests/test_parallel.py'
+      - 'src/skillsaw/llm/**'
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
           r = json.load(sys.stdin)
           assert r['stats']['plugins'] > 0, 'no plugins scanned'
           assert r['stats']['rules_run'] > 0, 'no rules ran'
-          assert r['stats']['errors'] == 0, f\"unexpected errors: {r['stats']['errors']}\"
+          assert r['summary']['errors'] == 0, f\"unexpected errors: {r['summary']['errors']}\"
           print(f\"Scanned {r['stats']['plugins']} plugins, {r['stats']['skills']} skills, {r['stats']['rules_run']} rules\")
           "
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,7 @@ jobs:
           r = json.load(sys.stdin)
           assert r['stats']['plugins'] > 0, 'no plugins scanned'
           assert r['stats']['rules_run'] > 0, 'no rules ran'
+          assert r['stats']['errors'] == 0, f\"unexpected errors: {r['stats']['errors']}\"
           print(f\"Scanned {r['stats']['plugins']} plugins, {r['stats']['skills']} skills, {r['stats']['rules_run']} rules\")
           "
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ generate-docs: $(VENV)/bin/activate
 generate-claude-readme: $(VENV)/bin/activate
 	$(VENV)/bin/skillsaw docs --format markdown -o .claude/README.md
 
-update: apm generate-example generate-docs generate-claude-readme format
+self-lint: $(VENV)/bin/activate
+	$(VENV)/bin/skillsaw lint .
+
+update: apm generate-example generate-docs generate-claude-readme format self-lint
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -750,8 +750,9 @@ def _run_docs(args):
     if config_path:
         try:
             config = LinterConfig.from_file(config_path)
-        except ValueError:
-            config = LinterConfig.default()
+        except ValueError as e:
+            print(f"Error loading config: {e}", file=sys.stderr)
+            sys.exit(1)
     else:
         config = LinterConfig.default()
     context.exclude_patterns = config.exclude_patterns

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -746,6 +746,17 @@ def _run_docs(args):
             file=sys.stderr,
         )
 
+    config_path = find_config(args.path)
+    if config_path:
+        try:
+            config = LinterConfig.from_file(config_path)
+        except ValueError:
+            config = LinterConfig.default()
+    else:
+        config = LinterConfig.default()
+    context.exclude_patterns = config.exclude_patterns
+    context.apply_excludes()
+
     from .docs import extract_docs, render_html, render_markdown
 
     docs_output = extract_docs(context, title=args.title)

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -395,7 +395,10 @@ class RepositoryContext:
             plugins.append(self.root_path)
             discovered_paths.add(self.root_path.resolve())
 
-        if RepositoryType.DOT_CLAUDE in self.repo_types:
+        if (
+            RepositoryType.DOT_CLAUDE in self.repo_types
+            and RepositoryType.MARKETPLACE not in self.repo_types
+        ):
             claude_dir = (
                 self.root_path if self.root_path.name == ".claude" else self.root_path / ".claude"
             )

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -3,7 +3,7 @@
 import json
 from typing import List
 
-from ..rule import Rule, RuleViolation
+from ..rule import Rule, RuleViolation, Severity
 from . import get_counts, relative_path
 
 
@@ -47,6 +47,7 @@ def format_json(
                 "line": v.line,
             }
             for v in violations
+            if verbose or v.severity != Severity.INFO
         ],
         "summary": {
             "errors": errors,

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -3,7 +3,7 @@
 import json
 from typing import List
 
-from ..rule import Rule, RuleViolation
+from ..rule import Rule, RuleViolation, Severity
 from . import relative_path
 
 _SEVERITY_MAP = {
@@ -29,7 +29,8 @@ def format_sarif(
             }
 
     results = []
-    for v in violations:
+    filtered = violations if verbose else [v for v in violations if v.severity != Severity.INFO]
+    for v in filtered:
         result = {
             "ruleId": v.rule_id,
             "level": _SEVERITY_MAP.get(v.severity.value, "warning"),

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -252,7 +252,7 @@ def test_json_violations_serialized(valid_plugin):
     context = RepositoryContext(valid_plugin)
     violations = _make_violations()
 
-    output = format_json(violations, context, [], "1.0.0")
+    output = format_json(violations, context, [], "1.0.0", verbose=True)
     data = json.loads(output)
 
     assert len(data["violations"]) == 3
@@ -261,6 +261,18 @@ def test_json_violations_serialized(valid_plugin):
     assert data["violations"][1]["line"] == 3
     assert data["summary"]["errors"] == 1
     assert data["summary"]["warnings"] == 1
+    assert data["summary"]["info"] == 1
+
+
+def test_json_excludes_info_without_verbose(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_json(violations, context, [], "1.0.0", verbose=False)
+    data = json.loads(output)
+
+    assert len(data["violations"]) == 2
+    assert all(v["severity"] != "info" for v in data["violations"])
     assert data["summary"]["info"] == 1
 
 
@@ -303,7 +315,7 @@ def test_sarif_severity_mapping(valid_plugin):
     context = RepositoryContext(valid_plugin)
     violations = _make_violations()
 
-    output = format_sarif(violations, context, [], "1.0.0")
+    output = format_sarif(violations, context, [], "1.0.0", verbose=True)
     data = json.loads(output)
 
     results = data["runs"][0]["results"]
@@ -312,6 +324,18 @@ def test_sarif_severity_mapping(valid_plugin):
     assert levels["plugin-json-required"] == "error"
     assert levels["command-naming"] == "warning"
     assert levels["plugin-json-valid"] == "note"
+
+
+def test_sarif_excludes_info_without_verbose(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_sarif(violations, context, [], "1.0.0", verbose=False)
+    data = json.loads(output)
+
+    results = data["runs"][0]["results"]
+    assert len(results) == 2
+    assert all(r["level"] != "note" for r in results)
 
 
 def test_sarif_locations(valid_plugin):


### PR DESCRIPTION
## Summary
- Skip DOT_CLAUDE plugin discovery when MARKETPLACE is also detected — `.claude` is repo config, not a plugin (fixes #71)
- Apply exclude patterns in `skillsaw docs` command so excluded paths don't leak into generated documentation
- Harden ai-helpers CI integration test to assert zero errors (pipe was discarding skillsaw's exit code)
- Add `.apm/instructions/python.instructions.md` for using `.venv/bin/` instead of bare python

## Test plan
- [x] `skillsaw lint ~/git/ai-helpers` — 0 errors (was 2 false positives)
- [x] `skillsaw lint .` — self-lint clean
- [x] `make test` — 816 passed, 14 skipped
- [x] `make lint` — formatting clean
- [x] `make update` — `.claude/README.md` no longer contains `{{SKILL_ID}}` template leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Python virtualenv guidance and usage instructions for running project tools.

* **Bug Fixes**
  * Prevented marketplace repositories from incorrectly loading dot-claude plugins.

* **Behavior Changes**
  * JSON and SARIF outputs now omit informational-level findings by default; verbose mode restores them.

* **Chores**
  * Added a self-lint step to the update workflow.

* **CI / Tests**
  * CI asserts zero scan errors; tests updated to cover verbose vs non-verbose formatter behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/74)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->