### PR TITLE
Fix content rules not running on repos without config

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -87,7 +87,10 @@ class LinterConfig:
     @classmethod
     def default(cls) -> "LinterConfig":
         """Create default configuration with all builtin rules enabled"""
+        from . import __version__
+
         return cls(
+            version=__version__,
             rules={
                 # Plugin structure rules (auto-enabled for plugin/marketplace repos)
                 "plugin-json-required": {"enabled": "auto", "severity": "error"},
@@ -156,7 +159,7 @@ class LinterConfig:
                 # APM (Agent Package Manager) rules
                 "apm-yaml-valid": {"enabled": "auto", "severity": "error"},
                 "apm-structure-valid": {"enabled": "auto", "severity": "warning"},
-            }
+            },
         )
 
     @classmethod

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple
 
 from skillsaw.rule import Rule, RuleViolation, Severity
-from skillsaw.context import RepositoryContext, ALL_INSTRUCTION_FORMATS
+from skillsaw.context import RepositoryContext
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_files,
@@ -29,7 +29,7 @@ from skillsaw.rules.builtin.content_analysis import (
 class ContentWeakLanguageRule(Rule):
     """Detect hedging, vague, and non-actionable language in instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -78,7 +78,7 @@ class ContentWeakLanguageRule(Rule):
 class ContentTautologicalRule(Rule):
     """Detect tautological instructions that waste instruction budget"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -125,7 +125,7 @@ class ContentTautologicalRule(Rule):
 class ContentCriticalPositionRule(Rule):
     """Detect critical instructions buried in the attention dead zone"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     _DEFAULT_MIN_LINES = 50
@@ -186,7 +186,7 @@ class ContentCriticalPositionRule(Rule):
 class ContentRedundantWithToolingRule(Rule):
     """Detect instructions that duplicate existing tooling configuration"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -232,7 +232,7 @@ class ContentRedundantWithToolingRule(Rule):
 class ContentInstructionBudgetRule(Rule):
     """Check total instruction count across all instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -288,7 +288,7 @@ class ContentInstructionBudgetRule(Rule):
 class ContentNegativeOnlyRule(Rule):
     """Detect 'never/don't/avoid X' without a positive alternative"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     _NEGATIVE_RE = re.compile(
@@ -394,7 +394,7 @@ class ContentNegativeOnlyRule(Rule):
 class ContentSectionLengthRule(Rule):
     """Warn about overly long markdown sections"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     _DEFAULT_MAX_TOKENS = 500
@@ -484,7 +484,7 @@ class ContentSectionLengthRule(Rule):
 class ContentContradictionRule(Rule):
     """Detect likely contradictions within instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -561,7 +561,7 @@ class ContentContradictionRule(Rule):
 class ContentHookCandidateRule(Rule):
     """Detect instructions that should be automated hooks"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -638,7 +638,7 @@ class ContentHookCandidateRule(Rule):
 class ContentActionabilityScoreRule(Rule):
     """Compute an actionability score for instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -712,7 +712,7 @@ class ContentActionabilityScoreRule(Rule):
 class ContentCognitiveChunksRule(Rule):
     """Check section organization for cognitive chunking"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -772,7 +772,7 @@ class ContentCognitiveChunksRule(Rule):
 class ContentEmbeddedSecretsRule(Rule):
     """Detect potential secrets embedded in instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     @property
@@ -871,7 +871,7 @@ class ContentEmbeddedSecretsRule(Rule):
 class ContentBannedReferencesRule(Rule):
     """Detect banned or deprecated references in instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     _BUILTIN_PATTERNS = [
@@ -965,7 +965,7 @@ class ContentBannedReferencesRule(Rule):
 class ContentInconsistentTerminologyRule(Rule):
     """Detect inconsistent terminology across instruction files"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     _TERM_GROUPS: List[Tuple[str, List[re.Pattern]]] = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,6 +270,28 @@ def test_content_rules_default_to_auto():
         assert config.rules[rule_id]["enabled"] == "auto", f"{rule_id} should be auto"
 
 
+def test_default_config_sets_current_version():
+    """No config file means all rules run — version must be current release"""
+    from skillsaw import __version__
+
+    config = LinterConfig.default()
+    assert config.version == __version__
+
+
+def test_no_config_skips_version_gate(temp_dir):
+    """Without a config file, version-gated rules should still be enabled"""
+    (temp_dir / "CLAUDE.md").write_text("# Test")
+    context = RepositoryContext(temp_dir)
+    config = LinterConfig.default()
+    assert config.is_rule_enabled(
+        "content-weak-language",
+        context,
+        repo_types=None,
+        formats=frozenset({"HAS_CLAUDE_MD"}),
+        since_version="0.7.0",
+    )
+
+
 def test_for_init_sets_version():
     """Test that for_init() sets version to current release"""
     from skillsaw import __version__


### PR DESCRIPTION
## Summary
- `LinterConfig.default()` now sets `version` to the current release instead of `""`, so version-gated rules are properly enabled when no config file exists
- Content rules no longer require instruction-format files (CLAUDE.md, .cursorrules, etc.) to be detected — they run on any repo with content to analyze (commands, skills, agents, etc.)
- Repos with a `.skillsaw.yaml` at version `0.6.0` (the default for existing configs without an explicit version) still correctly gate out `0.7.0` content rules — this is the intended upgrade path

## Test plan
- [x] `make test` — 820 passed, 14 skipped
- [x] `make lint` — clean
- [x] `skillsaw lint ~/git/ai-helpers` — 0 errors (21 rules, content rules correctly gated by config version 0.6.0)
- [x] `skillsaw lint .` — self-lint clean (31 rules)
- [x] `skillsaw lint /tmp/agent-skills` — 0 errors (24 rules)
- [x] `skillsaw lint /tmp/kubernetes-maintainer-skills` — 4 warnings (33 rules, content rules now fire on commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Default linter configuration now automatically derives its version from the current package version, ensuring better alignment with your installed version.

* **Updates**
  * Built-in content quality rules have been refined with updated format configuration settings.

* **Tests**
  * New test coverage added for automatic configuration versioning and version-gated rule enablement when no configuration file exists.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->