### PR TITLE
fix: SARIF formatter no longer emits startLine: 0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.6.0"
+version = "0.6.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from .rule import Rule, RuleViolation, Severity
 from .context import RepositoryContext

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -45,7 +45,7 @@ def format_sarif(
                     },
                 },
             }
-            if v.line is not None:
+            if v.line is not None and v.line >= 1:
                 location["physicalLocation"]["region"] = {"startLine": v.line}
             result["locations"] = [location]
         results.append(result)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -332,6 +332,27 @@ def test_sarif_locations(valid_plugin):
     assert v1_loc["region"]["startLine"] == 3
 
 
+def test_sarif_line_zero_omits_region(valid_plugin):
+    """SARIF spec requires startLine >= 1; line=0 must not emit a region."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.WARNING,
+            message="line zero violation",
+            file_path=Path("plugins/foo/.claude-plugin"),
+            line=0,
+        ),
+    ]
+
+    output = format_sarif(violations, context, [], "1.0.0")
+    data = json.loads(output)
+
+    result = data["runs"][0]["results"][0]
+    loc = result["locations"][0]["physicalLocation"]
+    assert "region" not in loc, "startLine: 0 violates SARIF spec (minimum is 1)"
+
+
 def test_sarif_stats_in_properties(valid_plugin):
     context = RepositoryContext(valid_plugin)
     config = LinterConfig.default()


### PR DESCRIPTION
## Summary
- Fix SARIF formatter emitting `startLine: 0` when `v.line` is `0`, which violates the SARIF 2.1.0 spec (minimum value is 1)
- Change condition from `if v.line is not None` to `if v.line is not None and v.line >= 1` for spec compliance and consistency with text/HTML formatters
- Add test verifying that `line=0` does not produce a `region` in SARIF output

## Test plan
- [x] New test `test_sarif_line_zero_omits_region` verifies the fix
- [x] All 465 existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] Integration test against openshift-eng/ai-helpers passes with exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SARIF formatter to properly validate line numbers, ensuring region data is only included when line numbers meet specification requirements.

* **Chores**
  * Version bumped to 0.6.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->