### PR TITLE
fix: add missing negative assertion in HTML non-verbose test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.6.0"
+version = "0.6.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from .rule import Rule, RuleViolation, Severity
 from .context import RepositoryContext

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -432,3 +432,4 @@ def test_html_non_verbose_hides_info(valid_plugin):
     # In non-verbose, the info violation row should not appear in the table
     # but the error and warning should
     assert "Missing plugin.json" in output_normal
+    assert "Recommended field" not in output_normal


### PR DESCRIPTION
## Summary
- `test_html_non_verbose_hides_info` only asserted that errors still appear in non-verbose HTML output, but never verified that info-level violations were actually hidden
- Added `assert "Recommended field" not in output_normal` to match the equivalent negative assertions in the text (`test_text_non_verbose_hides_info`) and JSON (`test_json_excludes_info_without_verbose`) formatter tests
- Bumped version to 0.6.1

## Test plan
- [x] `make test` passes (464 tests)
- [x] `make lint` passes
- [x] `make update` regenerates files
- [x] Tested against `openshift-eng/ai-helpers` -- exit 0, all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.6.1

* **Tests**
  * Enhanced test coverage to verify HTML formatter correctly excludes verbose-only content when verbose mode is disabled

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->