### PR TITLE
fix: apply_fixes handles AutofixConfidence.LLM

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.7.2"
+version: "0.7.3"
 
 rules:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.7.2"
+version = "0.7.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -213,15 +213,17 @@ class Linter:
         Args:
             fixes: Autofix results to apply
             confidence: Minimum confidence level to apply (SAFE = only safe,
-                        SUGGEST = safe + suggest)
+                        SUGGEST = safe + suggest, LLM = all)
 
         Returns:
             List of fixes that were actually applied
         """
         applied: List[AutofixResult] = []
         allowed = {AutofixConfidence.SAFE}
-        if confidence == AutofixConfidence.SUGGEST:
+        if confidence in (AutofixConfidence.SUGGEST, AutofixConfidence.LLM):
             allowed.add(AutofixConfidence.SUGGEST)
+        if confidence == AutofixConfidence.LLM:
+            allowed.add(AutofixConfidence.LLM)
 
         for fix in fixes:
             if fix.confidence not in allowed:

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -200,6 +200,7 @@ class TestAutofixConfidence:
     def test_values(self):
         assert AutofixConfidence.SAFE.value == "safe"
         assert AutofixConfidence.SUGGEST.value == "suggest"
+        assert AutofixConfidence.LLM.value == "llm"
 
 
 class TestRuleSupportsAutofix:
@@ -329,6 +330,100 @@ class TestApplyFixes:
         applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.SUGGEST)
         assert len(applied) == 1
         assert target.read_text() == "fixed"
+
+    def test_apply_skips_llm_by_default(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix])
+        assert len(applied) == 0
+        assert target.read_text() == "original"
+
+    def test_apply_skips_llm_when_suggest(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.SUGGEST)
+        assert len(applied) == 0
+        assert target.read_text() == "original"
+
+    def test_apply_llm_when_requested(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.LLM)
+        assert len(applied) == 1
+        assert target.read_text() == "fixed"
+
+    def test_apply_llm_includes_safe_and_suggest(self, temp_dir):
+        safe_target = temp_dir / "safe.txt"
+        safe_target.write_text("original-safe")
+
+        suggest_target = temp_dir / "suggest.txt"
+        suggest_target.write_text("original-suggest")
+
+        llm_target = temp_dir / "llm.txt"
+        llm_target.write_text("original-llm")
+
+        fixes = [
+            AutofixResult(
+                rule_id="a",
+                file_path=safe_target,
+                confidence=AutofixConfidence.SAFE,
+                original_content="original-safe",
+                fixed_content="fixed-safe",
+                description="safe fix",
+            ),
+            AutofixResult(
+                rule_id="b",
+                file_path=suggest_target,
+                confidence=AutofixConfidence.SUGGEST,
+                original_content="original-suggest",
+                fixed_content="fixed-suggest",
+                description="suggest fix",
+            ),
+            AutofixResult(
+                rule_id="c",
+                file_path=llm_target,
+                confidence=AutofixConfidence.LLM,
+                original_content="original-llm",
+                fixed_content="fixed-llm",
+                description="llm fix",
+            ),
+        ]
+
+        applied = Linter.apply_fixes(fixes, confidence=AutofixConfidence.LLM)
+        assert len(applied) == 3
+        assert safe_target.read_text() == "fixed-safe"
+        assert suggest_target.read_text() == "fixed-suggest"
+        assert llm_target.read_text() == "fixed-llm"
 
     def test_apply_mixed_confidence(self, temp_dir):
         safe_target = temp_dir / "safe.txt"


### PR DESCRIPTION
## Summary
- Fixed `apply_fixes` to correctly handle `AutofixConfidence.LLM` as a minimum confidence level
- When `confidence=AutofixConfidence.LLM`, the `allowed` set now includes all three tiers: `SAFE`, `SUGGEST`, and `LLM`
- Previously, passing `LLM` caused neither branch to match, so only `SAFE` fixes were applied and both `SUGGEST` and `LLM` fixes were silently dropped

## Test plan
- [x] Added `test_apply_skips_llm_by_default` — LLM fixes skipped with default confidence
- [x] Added `test_apply_skips_llm_when_suggest` — LLM fixes skipped when confidence=SUGGEST
- [x] Added `test_apply_llm_when_requested` — LLM fixes applied when confidence=LLM
- [x] Added `test_apply_llm_includes_safe_and_suggest` — all three tiers applied when confidence=LLM
- [x] All 824 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Tested against `openshift-eng/ai-helpers` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autofix confidence filtering: when LLM confidence is requested, SAFE and SUGGEST fixes are now included alongside LLM fixes.

* **Tests**
  * Added test coverage for LLM autofix confidence handling.

* **Chores**
  * Bumped version to 0.7.3.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/79)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->