### PR TITLE
Fix _has_instructions_md to detect named .instructions.md files

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.7.2"
+version: "0.7.3"
 
 rules:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.7.2"
+version = "0.7.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -167,7 +167,7 @@ class RepositoryContext:
         """Walk the repo looking for .instructions.md, skipping heavy directories."""
         for dirpath, dirnames, filenames in os.walk(self.root_path):
             dirnames[:] = [d for d in dirnames if d not in self._WALK_SKIP_DIRS]
-            if ".instructions.md" in filenames:
+            if any(f.endswith(".instructions.md") for f in filenames):
                 return True
         return False
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -283,6 +283,15 @@ def test_detected_formats_copilot(temp_dir):
     assert HAS_COPILOT in context.detected_formats
 
 
+def test_detected_formats_copilot_named_instructions_md(temp_dir):
+    """Detect <name>.instructions.md files (e.g. coding.instructions.md)"""
+    instr_dir = temp_dir / ".github" / "instructions"
+    instr_dir.mkdir(parents=True)
+    (instr_dir / "coding.instructions.md").write_text("# Coding guidelines")
+    context = RepositoryContext(temp_dir)
+    assert HAS_COPILOT in context.detected_formats
+
+
 def test_detected_formats_gemini(temp_dir):
     """Detect GEMINI.md at root"""
     (temp_dir / "GEMINI.md").write_text("# Gemini instructions")


### PR DESCRIPTION
## Summary
- `_has_instructions_md()` used `".instructions.md" in filenames` which only matches a file literally named `.instructions.md`, not Copilot's `<name>.instructions.md` convention (e.g. `coding.instructions.md`)
- Replaced with `any(f.endswith(".instructions.md") for f in filenames)` to match all `*.instructions.md` files
- Added test verifying `coding.instructions.md` under `.github/instructions/` is detected as Copilot config

## Test plan
- [x] `make test` passes (821 tests)
- [x] `make lint` passes
- [x] `make update` regenerates all files cleanly
- [x] Tested against `openshift-eng/ai-helpers` -- exit 0, all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.7.3 across configuration and package files

* **New Features**
  * Instruction file detection now recognizes files matching the `<name>.instructions.md` pattern, enabling support for multiple named instruction files (e.g., `coding.instructions.md`)

* **Tests**
  * Added tests verifying detection of named instruction files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/81)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->