### PR TITLE
fix: custom rules bypass since_version gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.6.0"
+version = "0.6.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from .rule import Rule, RuleViolation, Severity
 from .context import RepositoryContext

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -19,6 +19,7 @@ class LinterConfig:
     custom_rules: List[str] = field(default_factory=list)
     exclude_patterns: List[str] = field(default_factory=list)
     strict: bool = False
+    version: str = ""
 
     @classmethod
     def from_file(cls, config_path: Path) -> "LinterConfig":
@@ -45,6 +46,7 @@ class LinterConfig:
             custom_rules=data.get("custom-rules", []),
             exclude_patterns=data.get("exclude", []),
             strict=data.get("strict", False),
+            version=str(data.get("version", "")),
         )
 
     @classmethod
@@ -129,7 +131,13 @@ class LinterConfig:
         merged = {**defaults, **overrides}
         return merged
 
-    def is_rule_enabled(self, rule_id: str, context: "RepositoryContext", repo_types=None) -> bool:
+    def is_rule_enabled(
+        self,
+        rule_id: str,
+        context: "RepositoryContext",
+        repo_types=None,
+        since_version: str = "0.1.0",
+    ) -> bool:
         """
         Check if a rule is enabled for the given context
 
@@ -137,10 +145,23 @@ class LinterConfig:
             rule_id: Rule identifier
             context: Repository context
             repo_types: Set of RepositoryType values the rule applies to (None = all)
+            since_version: Minimum skillsaw version that introduced this rule.
+                           If the config declares a ``version`` older than this,
+                           the rule is silently skipped.
 
         Returns:
             True if rule should run
         """
+        # If the config pins a version older than the rule's ``since``, skip it.
+        if self.version:
+            try:
+                cfg_ver = tuple(int(x) for x in str(self.version).split("."))
+                since_ver = tuple(int(x) for x in since_version.split("."))
+                if cfg_ver < since_ver:
+                    return False
+            except (ValueError, TypeError):
+                pass  # Malformed version — ignore the gate
+
         rule_config = self.get_rule_config(rule_id)
         enabled = rule_config.get("enabled", True)
 
@@ -153,12 +174,18 @@ class LinterConfig:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert config to dictionary for serialization"""
-        return {
-            "rules": self.rules,
-            "custom-rules": self.custom_rules,
-            "exclude": self.exclude_patterns,
-            "strict": self.strict,
-        }
+        d: Dict[str, Any] = {}
+        if self.version:
+            d["version"] = self.version
+        d.update(
+            {
+                "rules": self.rules,
+                "custom-rules": self.custom_rules,
+                "exclude": self.exclude_patterns,
+                "strict": self.strict,
+            }
+        )
+        return d
 
     def save(self, config_path: Path):
         """Save configuration to file with rule descriptions as comments"""

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -55,7 +55,10 @@ class Linter:
 
             # Check if enabled for this context
             if self.config.is_rule_enabled(
-                rule_instance.rule_id, self.context, rule_instance.repo_types
+                rule_instance.rule_id,
+                self.context,
+                rule_instance.repo_types,
+                since_version=rule_instance.since,
             ):
                 self.rules.append(rule_instance)
 
@@ -93,7 +96,10 @@ class Linter:
 
                 # Check if enabled
                 if self.config.is_rule_enabled(
-                    rule_instance.rule_id, self.context, rule_instance.repo_types
+                    rule_instance.rule_id,
+                    self.context,
+                    rule_instance.repo_types,
+                    since_version=rule_instance.since,
                 ):
                     self.rules.append(rule_instance)
 

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -48,6 +48,7 @@ class Rule(ABC):
 
     repo_types = None
     config_schema = {}
+    since = "0.1.0"
 
     def __init__(self, config: Dict[str, Any] = None):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,3 +172,39 @@ def test_auto_without_repo_types_always_enabled(valid_plugin):
     config = LinterConfig.default()
     context = RepositoryContext(valid_plugin)
     assert config.is_rule_enabled("some-rule", context, None) is True
+
+
+def test_since_version_gates_rule(valid_plugin):
+    """Test that since_version gates a rule when config declares an older version"""
+    config = LinterConfig.default()
+    config.version = "0.5.0"
+    context = RepositoryContext(valid_plugin)
+
+    # Rule with since_version newer than config version should be disabled
+    assert (
+        config.is_rule_enabled("plugin-json-required", context, None, since_version="0.6.0")
+        is False
+    )
+
+
+def test_since_version_allows_rule_when_config_version_matches(valid_plugin):
+    """Test that since_version allows a rule when config version >= since"""
+    config = LinterConfig.default()
+    config.version = "0.6.0"
+    context = RepositoryContext(valid_plugin)
+
+    assert (
+        config.is_rule_enabled("plugin-json-required", context, None, since_version="0.6.0") is True
+    )
+
+
+def test_since_version_allows_rule_when_no_config_version(valid_plugin):
+    """Test that since_version does not gate when config has no version"""
+    config = LinterConfig.default()
+    # config.version defaults to "" — no version gate
+    context = RepositoryContext(valid_plugin)
+
+    assert (
+        config.is_rule_enabled("plugin-json-required", context, None, since_version="99.0.0")
+        is True
+    )

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -319,3 +319,117 @@ class DisabledRule(Rule):
     # Custom rule should not be loaded
     rule_ids = [rule.rule_id for rule in linter.rules]
     assert "disabled-rule" not in rule_ids
+
+
+def test_custom_rule_respects_since_version_gate(valid_plugin, temp_dir):
+    """Test that custom rules with a since version are gated by config version"""
+    # Create a custom rule with since = "0.8.0"
+    custom_rule_file = temp_dir / "versioned_rule.py"
+    custom_rule_file.write_text("""
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+class VersionedRule(Rule):
+    since = "0.8.0"
+
+    @property
+    def rule_id(self) -> str:
+        return "versioned-rule"
+
+    @property
+    def description(self) -> str:
+        return "A rule introduced in 0.8.0"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return [self.violation("versioned violation")]
+""")
+
+    # Config with version 0.7.0 — older than the rule's since (0.8.0)
+    config = LinterConfig(
+        custom_rules=[str(custom_rule_file)],
+        version="0.7.0",
+    )
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, config)
+
+    # The rule should NOT be loaded because config version < rule since
+    rule_ids = [rule.rule_id for rule in linter.rules]
+    assert "versioned-rule" not in rule_ids
+
+
+def test_custom_rule_loads_when_config_version_meets_since(valid_plugin, temp_dir):
+    """Test that custom rules load when config version >= rule since"""
+    custom_rule_file = temp_dir / "versioned_rule.py"
+    custom_rule_file.write_text("""
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+class VersionedRule(Rule):
+    since = "0.8.0"
+
+    @property
+    def rule_id(self) -> str:
+        return "versioned-rule"
+
+    @property
+    def description(self) -> str:
+        return "A rule introduced in 0.8.0"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return [self.violation("versioned violation")]
+""")
+
+    # Config with version 0.8.0 — equal to the rule's since
+    config = LinterConfig(
+        custom_rules=[str(custom_rule_file)],
+        version="0.8.0",
+    )
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, config)
+
+    # The rule SHOULD be loaded because config version >= rule since
+    rule_ids = [rule.rule_id for rule in linter.rules]
+    assert "versioned-rule" in rule_ids
+
+
+def test_custom_rule_loads_when_no_config_version(valid_plugin, temp_dir):
+    """Test that custom rules with since always load when config has no version"""
+    custom_rule_file = temp_dir / "versioned_rule.py"
+    custom_rule_file.write_text("""
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+class VersionedRule(Rule):
+    since = "0.8.0"
+
+    @property
+    def rule_id(self) -> str:
+        return "versioned-rule"
+
+    @property
+    def description(self) -> str:
+        return "A rule introduced in 0.8.0"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return [self.violation("versioned violation")]
+""")
+
+    # Config without a version — should not gate any rules
+    config = LinterConfig(
+        custom_rules=[str(custom_rule_file)],
+    )
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, config)
+
+    # The rule SHOULD be loaded because no version gate is active
+    rule_ids = [rule.rule_id for rule in linter.rules]
+    assert "versioned-rule" in rule_ids


### PR DESCRIPTION
## Summary
- Custom rules loaded via `--custom-rules` were not passing `since_version` to `is_rule_enabled()`, so a custom rule declaring `since = "0.8.0"` would still fire for configs pinned to `version: "0.7.0"`, completely ignoring the version gate.
- Adds `since` class attribute on `Rule` (default `"0.1.0"`), `version` field on `LinterConfig`, and `since_version` parameter on `is_rule_enabled()`.
- Both builtin and custom rule loading now pass `since_version=rule_instance.since`.

## Test plan
- [x] Added 3 tests in `test_custom_rules.py` for the end-to-end custom rule version gating (gated, allowed, no config version)
- [x] Added 3 tests in `test_config.py` for the `is_rule_enabled` `since_version` parameter directly
- [x] `make test` passes (470 tests)
- [x] `make lint` passes
- [x] `make update` run
- [x] Tested against `openshift-eng/ai-helpers` (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rules can now specify version requirements. A rule will only be enabled when the configured linter version meets or exceeds the rule's minimum version, offering fine-grained control over rule activation.

* **Tests**
  * Comprehensive test coverage added for version-gated rule enablement across built-in and custom rules.

* **Chores**
  * Bumped version to 0.6.1.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->