### PR TITLE
fix: add missing negative assertion in HTML non-verbose test

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -456,3 +456,4 @@ def test_html_non_verbose_hides_info(valid_plugin):
     # In non-verbose, the info violation row should not appear in the table
     # but the error and warning should
     assert "Missing plugin.json" in output_normal
+    assert "Recommended field" not in output_normal

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -456,4 +456,6 @@ def test_html_non_verbose_hides_info(valid_plugin):
     # In non-verbose, the info violation row should not appear in the table
     # but the error and warning should
     assert "Missing plugin.json" in output_normal
+    assert "kebab-case" in output_normal
     assert "Recommended field" not in output_normal
+    assert "Info:" not in output_normal


### PR DESCRIPTION
## Summary
- `test_html_non_verbose_hides_info` was only checking positive cases (verbose output contains info content, non-verbose output contains error content) but never asserted that info-level content is absent from non-verbose output
- Added `assert "Recommended field" not in output_normal` to match the pattern used by the equivalent text formatter test (`test_text_non_verbose_hides_info`)

## Test plan
- [x] `make test` -- all 820 tests pass
- [x] `make lint` -- clean
- [x] `make update` -- no changes to generated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened HTML formatter test to assert that informational violations and the "Info:" section are excluded from non-verbose output, ensuring non-verbose HTML omits informational content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/84)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->