### PR TITLE
fix: reject startLine=0 in SARIF output

### DIFF
--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -46,7 +46,7 @@ def format_sarif(
                     },
                 },
             }
-            if v.line is not None:
+            if v.line is not None and v.line >= 1:
                 location["physicalLocation"]["region"] = {"startLine": v.line}
             result["locations"] = [location]
         results.append(result)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -356,6 +356,27 @@ def test_sarif_locations(valid_plugin):
     assert v1_loc["region"]["startLine"] == 3
 
 
+def test_sarif_line_zero_omits_region(valid_plugin):
+    """SARIF 2.1.0 requires startLine >= 1; line=0 must not emit a region."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.WARNING,
+            message="bogus",
+            file_path=Path("plugins/foo/commands/bar.md"),
+            line=0,
+        ),
+    ]
+
+    output = format_sarif(violations, context, [], "1.0.0")
+    data = json.loads(output)
+
+    result = data["runs"][0]["results"][0]
+    loc = result["locations"][0]["physicalLocation"]
+    assert "region" not in loc, "startLine=0 violates SARIF 2.1.0 (startLine >= 1)"
+
+
 def test_sarif_stats_in_properties(valid_plugin):
     context = RepositoryContext(valid_plugin)
     config = LinterConfig.default()


### PR DESCRIPTION
## Summary

- SARIF 2.1.0 spec requires `startLine >= 1`, but the formatter emitted `"startLine": 0` when a violation had `line=0` because the guard only checked `is not None`
- Added `and v.line >= 1` to the condition in `sarif.py` line 49, matching the truthy checks used by the text and HTML formatters
- Added a regression test `test_sarif_line_zero_omits_region` that verifies `line=0` does not produce a `region` block

## Test plan

- [x] New test `test_sarif_line_zero_omits_region` confirms the fix
- [x] `make test` passes (821 passed, 14 skipped)
- [x] `make lint` passes
- [x] `make update` passes with no doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF security reports now correctly omit line region information when line numbers are invalid or zero, ensuring full compliance with SARIF 2.1.0 format specifications and preventing malformed output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->