### PR TITLE
fix: use `is None` check for missing apm.yml fields

### DIFF
--- a/src/skillsaw/rules/builtin/apm.py
+++ b/src/skillsaw/rules/builtin/apm.py
@@ -90,7 +90,7 @@ class ApmYamlValidRule(Rule):
         # Required fields
         for field in ("name", "version", "description"):
             value = data.get(field)
-            if not value:
+            if value is None:
                 violations.append(
                     self.violation(
                         f"Missing required field '{field}' in apm.yml",

--- a/src/skillsaw/rules/builtin/apm.py
+++ b/src/skillsaw/rules/builtin/apm.py
@@ -89,15 +89,16 @@ class ApmYamlValidRule(Rule):
 
         # Required fields
         for field in ("name", "version", "description"):
-            value = data.get(field)
-            if value is None:
+            if field not in data:
                 violations.append(
                     self.violation(
                         f"Missing required field '{field}' in apm.yml",
                         file_path=apm_yml,
                     )
                 )
-            elif not isinstance(value, str):
+                continue
+            value = data[field]
+            if not isinstance(value, str):
                 violations.append(
                     self.violation(
                         f"Field '{field}' must be a string in apm.yml",

--- a/tests/test_apm_rules.py
+++ b/tests/test_apm_rules.py
@@ -282,6 +282,23 @@ def test_apm_yaml_non_string_version_fails(temp_dir):
     assert any("version" in v.message and "string" in v.message for v in violations)
 
 
+def test_apm_yaml_integer_version_reports_type_error(temp_dir):
+    """version: 0 is present but wrong type — should say 'must be a string', not 'Missing'"""
+    repo = temp_dir / "apm-repo"
+    repo.mkdir()
+    _make_apm_repo(
+        repo,
+        skills=["my-skill"],
+        apm_yml="name: test\nversion: 0\ndescription: Integer version\n",
+    )
+
+    context = RepositoryContext(repo)
+    violations = ApmYamlValidRule().check(context)
+    assert len(violations) == 1
+    assert "must be a string" in violations[0].message
+    assert "Missing" not in violations[0].message
+
+
 def test_apm_yaml_not_mapping_fails(temp_dir):
     """apm.yml that is not a mapping should fail"""
     repo = temp_dir / "apm-repo"

--- a/tests/test_apm_rules.py
+++ b/tests/test_apm_rules.py
@@ -299,6 +299,23 @@ def test_apm_yaml_integer_version_reports_type_error(temp_dir):
     assert "Missing" not in violations[0].message
 
 
+def test_apm_yaml_null_version_reports_type_error(temp_dir):
+    """version: null is present but wrong type — should say 'must be a string', not 'Missing'"""
+    repo = temp_dir / "apm-repo"
+    repo.mkdir()
+    _make_apm_repo(
+        repo,
+        skills=["my-skill"],
+        apm_yml="name: test\nversion: null\ndescription: Null version\n",
+    )
+
+    context = RepositoryContext(repo)
+    violations = ApmYamlValidRule().check(context)
+    assert len(violations) == 1
+    assert "must be a string" in violations[0].message
+    assert "Missing" not in violations[0].message
+
+
 def test_apm_yaml_not_mapping_fails(temp_dir):
     """apm.yml that is not a mapping should fail"""
     repo = temp_dir / "apm-repo"


### PR DESCRIPTION
## Summary
- `if not value:` in `ApmYamlValidRule` incorrectly reported "Missing required field" for falsy values like `0`, `False`, or `""`. For example, `version: 0` would say "Missing required field 'version'" instead of "'version' must be a string".
- Changed the check to `if value is None:` so only truly absent fields trigger the missing-field message; falsy-but-present values now correctly fall through to the type check.
- Added a test verifying `version: 0` produces a "must be a string" violation, not a "Missing" violation.

## Test plan
- [x] New test `test_apm_yaml_integer_version_reports_type_error` verifies the fix
- [x] All 821 existing tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] `make update` regenerated docs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APM YAML validation to accept empty values when specified in configuration files. Type validation for required fields remains strict, properly rejecting non-string values in fields like version.

* **Tests**
  * Added test coverage for APM YAML version field type validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->