### PR TITLE
fix: allow LLM-confidence fixes when confidence=LLM is requested

### DIFF
--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -220,8 +220,10 @@ class Linter:
         """
         applied: List[AutofixResult] = []
         allowed = {AutofixConfidence.SAFE}
-        if confidence == AutofixConfidence.SUGGEST:
+        if confidence in (AutofixConfidence.SUGGEST, AutofixConfidence.LLM):
             allowed.add(AutofixConfidence.SUGGEST)
+        if confidence == AutofixConfidence.LLM:
+            allowed.add(AutofixConfidence.LLM)
 
         for fix in fixes:
             if fix.confidence not in allowed:

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -212,18 +212,20 @@ class Linter:
 
         Args:
             fixes: Autofix results to apply
-            confidence: Minimum confidence level to apply (SAFE = only safe,
-                        SUGGEST = safe + suggest)
+            confidence: Minimum confidence level to apply
+                        (SAFE = only safe,
+                         SUGGEST = safe + suggest,
+                         LLM = safe + suggest + llm)
 
         Returns:
             List of fixes that were actually applied
         """
         applied: List[AutofixResult] = []
         allowed = {AutofixConfidence.SAFE}
-        if confidence in (AutofixConfidence.SUGGEST, AutofixConfidence.LLM):
+        if confidence == AutofixConfidence.SUGGEST:
             allowed.add(AutofixConfidence.SUGGEST)
-        if confidence == AutofixConfidence.LLM:
-            allowed.add(AutofixConfidence.LLM)
+        elif confidence == AutofixConfidence.LLM:
+            allowed.update({AutofixConfidence.SUGGEST, AutofixConfidence.LLM})
 
         for fix in fixes:
             if fix.confidence not in allowed:

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -361,7 +361,15 @@ class TestApplyFixes:
         assert safe_target.read_text() == "fixed-safe"
         assert suggest_target.read_text() == "original-suggest"
 
-    def test_apply_skips_llm_by_default(self, temp_dir):
+    @pytest.mark.parametrize(
+        "requested, expected_applied",
+        [
+            (AutofixConfidence.SAFE, 0),
+            (AutofixConfidence.SUGGEST, 0),
+            (AutofixConfidence.LLM, 1),
+        ],
+    )
+    def test_apply_llm_confidence_filtering(self, temp_dir, requested, expected_applied):
         target = temp_dir / "test.txt"
         target.write_text("original")
 
@@ -374,43 +382,9 @@ class TestApplyFixes:
             description="test fix",
         )
 
-        applied = Linter.apply_fixes([fix])
-        assert len(applied) == 0
-        assert target.read_text() == "original"
-
-    def test_apply_skips_llm_when_suggest_requested(self, temp_dir):
-        target = temp_dir / "test.txt"
-        target.write_text("original")
-
-        fix = AutofixResult(
-            rule_id="test",
-            file_path=target,
-            confidence=AutofixConfidence.LLM,
-            original_content="original",
-            fixed_content="fixed",
-            description="test fix",
-        )
-
-        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.SUGGEST)
-        assert len(applied) == 0
-        assert target.read_text() == "original"
-
-    def test_apply_llm_when_llm_requested(self, temp_dir):
-        target = temp_dir / "test.txt"
-        target.write_text("original")
-
-        fix = AutofixResult(
-            rule_id="test",
-            file_path=target,
-            confidence=AutofixConfidence.LLM,
-            original_content="original",
-            fixed_content="fixed",
-            description="test fix",
-        )
-
-        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.LLM)
-        assert len(applied) == 1
-        assert target.read_text() == "fixed"
+        applied = Linter.apply_fixes([fix], confidence=requested)
+        assert len(applied) == expected_applied
+        assert target.read_text() == ("fixed" if expected_applied else "original")
 
     def test_apply_llm_includes_all_confidence_levels(self, temp_dir):
         """When confidence=LLM, all fix levels (SAFE, SUGGEST, LLM) are applied."""

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -361,6 +361,101 @@ class TestApplyFixes:
         assert safe_target.read_text() == "fixed-safe"
         assert suggest_target.read_text() == "original-suggest"
 
+    def test_apply_skips_llm_by_default(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix])
+        assert len(applied) == 0
+        assert target.read_text() == "original"
+
+    def test_apply_skips_llm_when_suggest_requested(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.SUGGEST)
+        assert len(applied) == 0
+        assert target.read_text() == "original"
+
+    def test_apply_llm_when_llm_requested(self, temp_dir):
+        target = temp_dir / "test.txt"
+        target.write_text("original")
+
+        fix = AutofixResult(
+            rule_id="test",
+            file_path=target,
+            confidence=AutofixConfidence.LLM,
+            original_content="original",
+            fixed_content="fixed",
+            description="test fix",
+        )
+
+        applied = Linter.apply_fixes([fix], confidence=AutofixConfidence.LLM)
+        assert len(applied) == 1
+        assert target.read_text() == "fixed"
+
+    def test_apply_llm_includes_all_confidence_levels(self, temp_dir):
+        """When confidence=LLM, all fix levels (SAFE, SUGGEST, LLM) are applied."""
+        safe_target = temp_dir / "safe.txt"
+        safe_target.write_text("original-safe")
+
+        suggest_target = temp_dir / "suggest.txt"
+        suggest_target.write_text("original-suggest")
+
+        llm_target = temp_dir / "llm.txt"
+        llm_target.write_text("original-llm")
+
+        fixes = [
+            AutofixResult(
+                rule_id="a",
+                file_path=safe_target,
+                confidence=AutofixConfidence.SAFE,
+                original_content="original-safe",
+                fixed_content="fixed-safe",
+                description="safe fix",
+            ),
+            AutofixResult(
+                rule_id="b",
+                file_path=suggest_target,
+                confidence=AutofixConfidence.SUGGEST,
+                original_content="original-suggest",
+                fixed_content="fixed-suggest",
+                description="suggest fix",
+            ),
+            AutofixResult(
+                rule_id="c",
+                file_path=llm_target,
+                confidence=AutofixConfidence.LLM,
+                original_content="original-llm",
+                fixed_content="fixed-llm",
+                description="llm fix",
+            ),
+        ]
+
+        applied = Linter.apply_fixes(fixes, confidence=AutofixConfidence.LLM)
+        assert len(applied) == 3
+        assert safe_target.read_text() == "fixed-safe"
+        assert suggest_target.read_text() == "fixed-suggest"
+        assert llm_target.read_text() == "fixed-llm"
+
 
 class TestEndToEndFix:
     def test_full_fix_workflow(self, temp_dir):


### PR DESCRIPTION
## Summary

- Fixed a bug in `Linter.apply_fixes()` where passing `confidence=AutofixConfidence.LLM` only applied SAFE fixes instead of all three confidence levels (SAFE, SUGGEST, LLM)
- The confidence parameter forms a hierarchy (SAFE < SUGGEST < LLM) where a higher level should include all lower levels, but the `LLM` case was not handled in the conditional logic
- Added four tests covering the LLM confidence behavior: skipped by default, skipped at SUGGEST level, applied at LLM level, and mixed-confidence with all levels applied

## Test plan

- [x] `make test` -- all 824 tests pass
- [x] `make lint` -- clean
- [x] `make update` -- no generated file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autofix confidence-gating logic to properly distinguish between suggestion-level and LLM-confidence fixes. LLM-confidence fixes are now applied only when explicitly requested, while suggestion-level fixes remain the default behavior.

* **Tests**
  * Added comprehensive test coverage for LLM-confidence autofix application and confidence-level filtering behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->