### PR TITLE
fix: add end anchor to semver version regex

### DIFF
--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -112,7 +112,7 @@ class PluginJsonValidRule(Rule):
             if "version" in data:
                 version = data["version"]
                 if not re.match(
-                    r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$", str(version)
+                    r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$", str(version)
                 ):
                     violations.append(
                         self.violation(

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -111,7 +111,9 @@ class PluginJsonValidRule(Rule):
             # Validate version format (semver)
             if "version" in data:
                 version = data["version"]
-                if not re.match(r"^\d+\.\d+\.\d+", str(version)):
+                if not re.match(
+                    r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$", str(version)
+                ):
                     violations.append(
                         self.violation(
                             f"Version '{version}' should follow semver (X.Y.Z)",

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -241,8 +241,8 @@ def test_plugin_json_valid_version_rejects_trailing_garbage(temp_dir):
         "1.0.0!",
     ]
 
-    for bad_version in invalid_versions:
-        plugin_dir = temp_dir / "ver-plugin"
+    for i, bad_version in enumerate(invalid_versions):
+        plugin_dir = temp_dir / f"ver-plugin-invalid-{i}"
         plugin_dir.mkdir(exist_ok=True)
 
         claude_dir = plugin_dir / ".claude-plugin"
@@ -281,13 +281,15 @@ def test_plugin_json_valid_version_accepts_semver_prerelease(temp_dir):
         "10.20.30",
         "1.0.0-alpha",
         "1.0.0-alpha.1",
+        "1.0.0-alpha-1",
         "1.0.0-0.3.7",
         "1.0.0+build.123",
+        "1.0.0+build-meta.123",
         "1.0.0-beta+build.456",
     ]
 
-    for good_version in valid_versions:
-        plugin_dir = temp_dir / "ver-plugin"
+    for i, good_version in enumerate(valid_versions):
+        plugin_dir = temp_dir / f"ver-plugin-valid-{i}"
         plugin_dir.mkdir(exist_ok=True)
 
         claude_dir = plugin_dir / ".claude-plugin"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -229,6 +229,93 @@ def test_plugin_json_missing_name_is_error(temp_dir):
     assert len(warnings) == 2
 
 
+def test_plugin_json_valid_version_rejects_trailing_garbage(temp_dir):
+    """Test that version strings with trailing garbage are rejected"""
+    import json
+
+    invalid_versions = [
+        "1.0.0garbage",
+        "1.0.0.0.0",
+        "1.0.0; rm -rf /",
+        "1.0.0 ",
+        "1.0.0!",
+    ]
+
+    for bad_version in invalid_versions:
+        plugin_dir = temp_dir / "ver-plugin"
+        plugin_dir.mkdir(exist_ok=True)
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir(exist_ok=True)
+
+        with open(claude_dir / "plugin.json", "w") as f:
+            json.dump(
+                {
+                    "name": "ver-plugin",
+                    "description": "Test",
+                    "version": bad_version,
+                    "author": {"name": "Test"},
+                },
+                f,
+            )
+
+        (plugin_dir / "commands").mkdir(exist_ok=True)
+
+        context = RepositoryContext(plugin_dir)
+        rule = PluginJsonValidRule()
+        violations = rule.check(context)
+
+        version_violations = [
+            v for v in violations if "semver" in v.message.lower() or "Version" in v.message
+        ]
+        assert len(version_violations) == 1, f"Expected version '{bad_version}' to be rejected"
+
+
+def test_plugin_json_valid_version_accepts_semver_prerelease(temp_dir):
+    """Test that valid semver versions with prerelease/build metadata are accepted"""
+    import json
+
+    valid_versions = [
+        "1.0.0",
+        "0.1.0",
+        "10.20.30",
+        "1.0.0-alpha",
+        "1.0.0-alpha.1",
+        "1.0.0-0.3.7",
+        "1.0.0+build.123",
+        "1.0.0-beta+build.456",
+    ]
+
+    for good_version in valid_versions:
+        plugin_dir = temp_dir / "ver-plugin"
+        plugin_dir.mkdir(exist_ok=True)
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir(exist_ok=True)
+
+        with open(claude_dir / "plugin.json", "w") as f:
+            json.dump(
+                {
+                    "name": "ver-plugin",
+                    "description": "Test",
+                    "version": good_version,
+                    "author": {"name": "Test"},
+                },
+                f,
+            )
+
+        (plugin_dir / "commands").mkdir(exist_ok=True)
+
+        context = RepositoryContext(plugin_dir)
+        rule = PluginJsonValidRule()
+        violations = rule.check(context)
+
+        version_violations = [
+            v for v in violations if "semver" in v.message.lower() or "Version" in v.message
+        ]
+        assert len(version_violations) == 0, f"Expected version '{good_version}' to be accepted"
+
+
 def test_command_name_format_reports_line_number(temp_dir):
     """CommandNameFormatRule should report the line of the ## Name heading"""
     import json


### PR DESCRIPTION
## Summary
- The semver validation regex in the `plugin-json-valid` rule (`plugin_structure.py` line 114) was missing an end anchor (`$`), allowing malformed version strings like `"1.0.0garbage"`, `"1.0.0.0.0"`, or `"1.0.0; rm -rf /"` to pass validation.
- Added `$` anchor with optional semver prerelease (`-alpha.1`) and build metadata (`+build.123`) groups.
- Added tests verifying that 5 invalid versions are rejected and 8 valid semver variants (including prerelease/build suffixes) are accepted.

## Test plan
- [x] `make test` -- all 822 tests pass
- [x] `make lint` -- clean
- [x] `make update` -- no generated file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)