### PR TITLE
fix: prevent false negatives in content-negative-only for multi-negative lines

### DIFF
--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -363,8 +363,9 @@ class ContentNegativeOnlyRule(Rule):
             return False
 
         text_before_neg = line[: neg_match.start()]
-        if self._POSITIVE_RE.search(text_before_neg):
-            return True
+        for pos_match in self._POSITIVE_RE.finditer(text_before_neg):
+            if not self._is_positive_inside_negative(text_before_neg, pos_match):
+                return True
 
         text_after_neg = line[neg_match.end() :]
         for pos_match in self._POSITIVE_RE.finditer(text_after_neg):
@@ -376,8 +377,10 @@ class ContentNegativeOnlyRule(Rule):
         for j in range(start, end):
             if j == line_idx:
                 continue
-            if self._POSITIVE_RE.search(lines[j]):
-                return True
+            nearby = lines[j]
+            for pos_match in self._POSITIVE_RE.finditer(nearby):
+                if not self._is_positive_inside_negative(nearby, pos_match):
+                    return True
 
         return False
 

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -344,6 +344,19 @@ class ContentNegativeOnlyRule(Rule):
             "- Preserve markdown formatting"
         )
 
+    def _is_positive_inside_negative(self, text, pos_match):
+        """Return True if the positive match is embedded within a negative construction."""
+        # Look backwards from the positive match start for a negative prefix
+        prefix = text[: pos_match.start()]
+        # Check if a negative construction leads into this positive match
+        # e.g. "don't use exec" — the "use exec" is not truly positive
+        trailing_neg = re.search(
+            r"(?:never\s+|don'?t\s+|avoid\s+|do\s+not\s+)\s*$",
+            prefix,
+            re.IGNORECASE,
+        )
+        return trailing_neg is not None
+
     def _has_positive_alternative(self, line, lines, line_idx):
         neg_match = self._NEGATIVE_RE.search(line)
         if not neg_match:
@@ -354,8 +367,9 @@ class ContentNegativeOnlyRule(Rule):
             return True
 
         text_after_neg = line[neg_match.end() :]
-        if self._POSITIVE_RE.search(text_after_neg):
-            return True
+        for pos_match in self._POSITIVE_RE.finditer(text_after_neg):
+            if not self._is_positive_inside_negative(text_after_neg, pos_match):
+                return True
 
         start = max(0, line_idx - 2)
         end = min(len(lines), line_idx + 5)

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -297,6 +297,27 @@ class TestContentNegativeOnlyRule:
         violations = ContentNegativeOnlyRule().check(context)
         assert len(violations) >= 1
 
+    def test_negative_before_negative_not_false_positive(self, temp_dir):
+        """A negative construction before another negative should not count as positive."""
+        (temp_dir / "CLAUDE.md").write_text("Don't use eval, never use exec.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) >= 1
+
+    def test_nearby_negative_line_not_false_positive(self, temp_dir):
+        """A nearby line with a negative should not mask the current line's violation."""
+        (temp_dir / "CLAUDE.md").write_text("Never use eval.\nDon't use exec.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) >= 2
+
+    def test_nearby_positive_line_still_passes(self, temp_dir):
+        """A nearby line with a genuine positive should still suppress the violation."""
+        (temp_dir / "CLAUDE.md").write_text("Never use eval.\nUse a safe parser instead.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) == 0
+
 
 class TestContentSectionLengthRule:
     def test_rule_metadata(self):

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -290,6 +290,13 @@ class TestContentNegativeOnlyRule:
         violations = ContentNegativeOnlyRule().check(context)
         assert len(violations) == 0
 
+    def test_multiple_negatives_on_same_line_flagged(self, temp_dir):
+        """Two negatives should not mask each other as false positive alternatives."""
+        (temp_dir / "CLAUDE.md").write_text("Never use eval, don't use exec.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentNegativeOnlyRule().check(context)
+        assert len(violations) >= 1
+
 
 class TestContentSectionLengthRule:
     def test_rule_metadata(self):


### PR DESCRIPTION
## Summary

- Fix false negative in `ContentNegativeOnlyRule` where multiple negative constructions on the same line (e.g. `"never use eval, don't use exec"`) would suppress the violation because `"use exec"` from `"don't use exec"` was incorrectly matched as a positive alternative.
- Add `_is_positive_inside_negative()` helper that checks whether a positive regex match is actually embedded within a negative construction (`don't`, `never`, `avoid`, `do not`), filtering it out before treating it as a genuine positive alternative.
- Add regression test with `"never use eval, don't use exec"` verifying the line IS flagged.

## Test plan

- [x] New test `test_multiple_negatives_on_same_line_flagged` passes
- [x] All existing tests pass (821 passed, 14 skipped)
- [x] `make lint` passes
- [x] `make update` regenerates docs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)