### PR TITLE
fix: reject booleans in numeric type checks

### DIFF
--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -591,7 +591,7 @@ class AgentSkillEvalsRule(Rule):
                     violations.append(
                         self.violation(f"evals[{i}] missing required 'id'", file_path=evals_json)
                     )
-                elif not isinstance(entry["id"], (int, float)):
+                elif not isinstance(entry["id"], (int, float)) or isinstance(entry["id"], bool):
                     violations.append(
                         self.violation(f"evals[{i}] 'id' must be a number", file_path=evals_json)
                     )

--- a/src/skillsaw/rules/builtin/openclaw.py
+++ b/src/skillsaw/rules/builtin/openclaw.py
@@ -321,8 +321,9 @@ class OpenclawMetadataRule(Rule):
                     )
                 )
 
-            if "stripComponents" in entry and not isinstance(
-                entry["stripComponents"], (int, float)
+            if "stripComponents" in entry and (
+                not isinstance(entry["stripComponents"], (int, float))
+                or isinstance(entry["stripComponents"], bool)
             ):
                 violations.append(
                     self.violation(

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -556,6 +556,19 @@ def test_evals_entry_missing_id_warns(temp_dir):
     assert any("id" in v.message for v in violations)
 
 
+def test_evals_entry_boolean_id_fails(temp_dir):
+    skill = temp_dir / "bool-id"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: bool-id\ndescription: Bool id\n---\n")
+    evals_dir = skill / "evals"
+    evals_dir.mkdir()
+    (evals_dir / "evals.json").write_text(json.dumps({"evals": [{"id": True, "prompt": "Test"}]}))
+
+    context = RepositoryContext(skill)
+    violations = AgentSkillEvalsRule().check(context)
+    assert any("id" in v.message and "number" in v.message for v in violations)
+
+
 def test_evals_entry_missing_prompt_warns(temp_dir):
     skill = temp_dir / "no-prompt"
     skill.mkdir()

--- a/tests/test_openclaw_rules.py
+++ b/tests/test_openclaw_rules.py
@@ -459,6 +459,21 @@ def test_install_strip_components_wrong_type_fails(temp_dir):
     assert any("stripComponents" in v.message and "number" in v.message for v in violations)
 
 
+def test_install_strip_components_boolean_fails(temp_dir):
+    skill = temp_dir / "bool-strip"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: bool-strip\ndescription: Bool strip\nmetadata:\n"
+        "  openclaw:\n    install:\n"
+        "      - id: dl\n        kind: download\n        url: https://x.com/a\n"
+        "        stripComponents: true\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    violations = OpenclawMetadataRule().check(context)
+    assert any("stripComponents" in v.message and "number" in v.message for v in violations)
+
+
 def test_install_string_fields_wrong_type_fails(temp_dir):
     skill = temp_dir / "bad-strings"
     skill.mkdir()


### PR DESCRIPTION
## Summary

- Add `isinstance(val, bool)` exclusion to `stripComponents` validation in `openclaw.py` and eval `id` validation in `agentskills.py`
- Python's `bool` is a subclass of `int`, so `isinstance(True, (int, float))` returns `True`, allowing `stripComponents: true` and `id: true` to silently pass numeric validation
- Added tests verifying that boolean values are correctly rejected in both checks

## Test plan

- [x] `test_install_strip_components_boolean_fails` verifies `stripComponents: true` is flagged
- [x] `test_evals_entry_boolean_id_fails` verifies `id: true` is flagged
- [x] Full test suite passes (822 passed)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)