### PR TITLE
fix: use line-anchored regex for frontmatter field detection

### DIFF
--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -59,12 +59,12 @@ class AgentFrontmatterRule(Rule):
                 frontmatter = frontmatter_match.group(1)
 
                 # Check for required fields
-                if "name:" not in frontmatter:
+                if not re.search(r"^name\s*:", frontmatter, re.MULTILINE):
                     violations.append(
                         self.violation("Missing 'name' in frontmatter", file_path=agent_file)
                     )
 
-                if "description:" not in frontmatter:
+                if not re.search(r"^description\s*:", frontmatter, re.MULTILINE):
                     violations.append(
                         self.violation("Missing 'description' in frontmatter", file_path=agent_file)
                     )
@@ -119,9 +119,13 @@ class AgentFrontmatterRule(Rule):
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []
-                    if missing_name and "name:" not in fm_text:
+                    if missing_name and not re.search(
+                        r"^name\s*:", fm_text, re.MULTILINE
+                    ):
                         additions.append(f"name: {file_path.stem}")
-                    if missing_desc and "description:" not in fm_text:
+                    if missing_desc and not re.search(
+                        r"^description\s*:", fm_text, re.MULTILINE
+                    ):
                         additions.append("description: ")
                     if additions:
                         insert = "\n".join(additions) + "\n"

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -119,13 +119,9 @@ class AgentFrontmatterRule(Rule):
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []
-                    if missing_name and not re.search(
-                        r"^name\s*:", fm_text, re.MULTILINE
-                    ):
+                    if missing_name and not re.search(r"^name\s*:", fm_text, re.MULTILINE):
                         additions.append(f"name: {file_path.stem}")
-                    if missing_desc and not re.search(
-                        r"^description\s*:", fm_text, re.MULTILINE
-                    ):
+                    if missing_desc and not re.search(r"^description\s*:", fm_text, re.MULTILINE):
                         additions.append("description: ")
                     if additions:
                         insert = "\n".join(additions) + "\n"

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -160,9 +160,7 @@ class CommandFrontmatterRule(Rule):
                 )
             elif "Missing 'description'" in v.message and original.startswith("---"):
                 fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
-                if fm_match and not re.search(
-                    r"^description\s*:", fm_match.group(1), re.MULTILINE
-                ):
+                if fm_match and not re.search(r"^description\s*:", fm_match.group(1), re.MULTILINE):
                     fm_end = fm_match.end()
                     fixed = original[:fm_end].replace("\n---", "\ndescription: \n---", 1)
                     fixed += original[fm_end:]

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -130,7 +130,7 @@ class CommandFrontmatterRule(Rule):
                 frontmatter = frontmatter_match.group(1)
 
                 # Check for required fields
-                if "description:" not in frontmatter:
+                if not re.search(r"^description\s*:", frontmatter, re.MULTILINE):
                     violations.append(
                         self.violation("Missing 'description' in frontmatter", file_path=cmd_file)
                     )
@@ -160,7 +160,9 @@ class CommandFrontmatterRule(Rule):
                 )
             elif "Missing 'description'" in v.message and original.startswith("---"):
                 fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
-                if fm_match:
+                if fm_match and not re.search(
+                    r"^description\s*:", fm_match.group(1), re.MULTILINE
+                ):
                     fm_end = fm_match.end()
                     fixed = original[:fm_end].replace("\n---", "\ndescription: \n---", 1)
                     fixed += original[fm_end:]

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -67,12 +67,12 @@ class SkillFrontmatterRule(Rule):
                 frontmatter = frontmatter_match.group(1)
 
                 # Check for recommended fields
-                if "name:" not in frontmatter:
+                if not re.search(r"^name\s*:", frontmatter, re.MULTILINE):
                     violations.append(
                         self.violation("Missing 'name' in SKILL.md frontmatter", file_path=skill_md)
                     )
 
-                if "description:" not in frontmatter:
+                if not re.search(r"^description\s*:", frontmatter, re.MULTILINE):
                     violations.append(
                         self.violation(
                             "Missing 'description' in SKILL.md frontmatter", file_path=skill_md
@@ -148,9 +148,13 @@ class SkillFrontmatterRule(Rule):
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []
-                    if missing_name and "name:" not in fm_text:
+                    if missing_name and not re.search(
+                        r"^name\s*:", fm_text, re.MULTILINE
+                    ):
                         additions.append(f"name: {file_path.parent.name}")
-                    if missing_desc and "description:" not in fm_text:
+                    if missing_desc and not re.search(
+                        r"^description\s*:", fm_text, re.MULTILINE
+                    ):
                         additions.append("description: ")
                     if additions:
                         insert = "\n".join(additions) + "\n"

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -148,13 +148,9 @@ class SkillFrontmatterRule(Rule):
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []
-                    if missing_name and not re.search(
-                        r"^name\s*:", fm_text, re.MULTILINE
-                    ):
+                    if missing_name and not re.search(r"^name\s*:", fm_text, re.MULTILINE):
                         additions.append(f"name: {file_path.parent.name}")
-                    if missing_desc and not re.search(
-                        r"^description\s*:", fm_text, re.MULTILINE
-                    ):
+                    if missing_desc and not re.search(r"^description\s*:", fm_text, re.MULTILINE):
                         additions.append("description: ")
                     if additions:
                         insert = "\n".join(additions) + "\n"

--- a/tests/test_agent_rules.py
+++ b/tests/test_agent_rules.py
@@ -248,6 +248,64 @@ def test_fix_both_name_and_description_missing(plugin_with_missing_both_fields):
     assert len(fix.violations_fixed) == 2
 
 
+def test_substring_field_does_not_mask_missing_name(temp_dir):
+    """Test that a field like 'full-name:' does not suppress 'Missing name' violation"""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "test-plugin"}')
+
+    agents_dir = plugin_dir / "agents"
+    agents_dir.mkdir()
+
+    # frontmatter has 'full-name' but NOT 'name'
+    agent_content = """---
+full-name: Some Agent
+description: "An agent"
+---
+
+# Agent
+"""
+    (agents_dir / "agent.md").write_text(agent_content)
+
+    context = RepositoryContext(plugin_dir)
+    rule = AgentFrontmatterRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "name" in violations[0].message.lower()
+
+
+def test_substring_field_does_not_mask_missing_description(temp_dir):
+    """Test that a field like 'long-description:' does not suppress 'Missing description' violation"""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "test-plugin"}')
+
+    agents_dir = plugin_dir / "agents"
+    agents_dir.mkdir()
+
+    # frontmatter has 'long-description' but NOT 'description'
+    agent_content = """---
+name: test-agent
+long-description: "Not the real description field"
+---
+
+# Agent
+"""
+    (agents_dir / "agent.md").write_text(agent_content)
+
+    context = RepositoryContext(plugin_dir)
+    rule = AgentFrontmatterRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "description" in violations[0].message.lower()
+
+
 def test_rule_metadata():
     """Test rule metadata"""
     rule = AgentFrontmatterRule()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -18,6 +18,7 @@ from skillsaw.rules.builtin.command_format import (
     CommandFrontmatterRule,
     CommandNameFormatRule,
 )
+from skillsaw.rules.builtin.skills import SkillFrontmatterRule
 from skillsaw.rules.builtin.marketplace import (
     MarketplaceJsonValidRule,
     MarketplaceRegistrationRule,
@@ -556,3 +557,88 @@ def test_valid_severity_override():
     """Test that a valid severity string overrides the default"""
     rule = PluginJsonRequiredRule({"severity": "warning"})
     assert rule.severity == Severity.WARNING
+
+
+# --- substring false-negative tests ---
+
+
+def test_skill_frontmatter_substring_does_not_mask_missing_name(temp_dir):
+    """Test that 'full-name:' in SKILL.md frontmatter doesn't suppress 'Missing name' violation"""
+    import json
+
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "test-plugin"}, f)
+
+    skills_dir = plugin_dir / "skills"
+    skills_dir.mkdir()
+    skill_dir = skills_dir / "my-skill"
+    skill_dir.mkdir()
+
+    (skill_dir / "SKILL.md").write_text(
+        "---\nfull-name: My Skill\ndescription: A skill\n---\n\n# My Skill\n"
+    )
+
+    context = RepositoryContext(plugin_dir)
+    rule = SkillFrontmatterRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "name" in violations[0].message.lower()
+
+
+def test_skill_frontmatter_substring_does_not_mask_missing_description(temp_dir):
+    """Test that 'long-description:' in SKILL.md frontmatter doesn't suppress 'Missing description' violation"""
+    import json
+
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "test-plugin"}, f)
+
+    skills_dir = plugin_dir / "skills"
+    skills_dir.mkdir()
+    skill_dir = skills_dir / "my-skill"
+    skill_dir.mkdir()
+
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: My Skill\nlong-description: Not real\n---\n\n# My Skill\n"
+    )
+
+    context = RepositoryContext(plugin_dir)
+    rule = SkillFrontmatterRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "description" in violations[0].message.lower()
+
+
+def test_command_frontmatter_substring_does_not_mask_missing_description(temp_dir):
+    """Test that 'long-description:' in command frontmatter doesn't suppress 'Missing description' violation"""
+    import json
+
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "test-plugin"}, f)
+
+    commands_dir = plugin_dir / "commands"
+    commands_dir.mkdir()
+
+    (commands_dir / "test-cmd.md").write_text(
+        "---\nlong-description: Not real\n---\n\n## Name\ntest-plugin:test-cmd\n"
+    )
+
+    context = RepositoryContext(plugin_dir)
+    rule = CommandFrontmatterRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "description" in violations[0].message.lower()


### PR DESCRIPTION
## Summary

- Frontmatter field checks in `skill-frontmatter`, `agent-frontmatter`, and `command-frontmatter` rules used substring matching (`"name:" not in frontmatter`) which caused false negatives when a field like `full-name:` contained `name:` as a substring
- Replaced all occurrences with `re.search(r"^name:", frontmatter, re.MULTILINE)` to match only at line start, in both `check()` and `fix()` methods
- Added regression tests for all three rules verifying that substring-containing fields (`full-name:`, `long-description:`) do not suppress missing-field violations

## Test plan

- [x] `make test` -- all 825 tests pass (5 new tests added)
- [x] `make lint` -- passes
- [x] `make update` -- regenerated docs, no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)