### PR TITLE
fix: pass --type override to RepositoryContext before discovery

### DIFF
--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -273,9 +273,9 @@ def _run_lint(args):
 
     if args.fmt == "text":
         print(f"Linting: {args.path}\n")
-    context = RepositoryContext(args.path)
 
-    # Override repo_types if --type was provided
+    # Parse --type before constructing context so discovery uses the override
+    override_types = None
     if args.repo_types:
         type_map = {t.value: t for t in RepositoryType}
         override_types = set()
@@ -288,7 +288,8 @@ def _run_lint(args):
                 )
                 sys.exit(1)
             override_types.add(type_map[val])
-        context.repo_types = override_types
+
+    context = RepositoryContext(args.path, repo_types=override_types)
 
     if context.repo_type == RepositoryType.UNKNOWN:
         print("Warning: Directory doesn't appear to be a recognized repository", file=sys.stderr)

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -102,11 +102,12 @@ class RepositoryContext:
         other discovered data reflect the updated types.
         """
         self.marketplace_data = self._load_marketplace() if self.has_marketplace() else None
-        self.plugin_metadata = {}
+        self.plugin_metadata: Dict[Path, Dict[str, Any]] = {}
         self.plugins = self._discover_plugins()
-        self.skills = self._discover_skills()
-        self.instruction_files = self._discover_instruction_files()
-        self.detected_formats = self._detect_formats()
+        self.skills: List[Path] = self._discover_skills()
+        self.instruction_files: List[Path] = self._discover_instruction_files()
+        self.detected_formats: Set[str] = self._detect_formats()
+        self.apply_excludes()
 
     @property
     def repo_type(self) -> RepositoryType:

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -69,16 +69,21 @@ class RepositoryContext:
     # When .apm/ is present these are generated artifacts and should not be linted.
     APM_COMPILED_DIRS = frozenset((".claude", ".cursor", ".gemini", ".opencode", ".agents"))
 
-    def __init__(self, root_path: Path):
+    def __init__(self, root_path: Path, repo_types: Optional[Set[RepositoryType]] = None):
         """
         Initialize repository context
 
         Args:
             root_path: Root directory of the repository
+            repo_types: Optional set of repository types to use instead of auto-detection.
+                        When provided, discovery is driven by these types rather than
+                        the auto-detected ones.
         """
         self.root_path = root_path.resolve()
         self.has_apm = self._detect_apm()
-        self.repo_types: Set[RepositoryType] = self._detect_types()
+        self.repo_types: Set[RepositoryType] = (
+            repo_types if repo_types is not None else self._detect_types()
+        )
         self.marketplace_data = self._load_marketplace() if self.has_marketplace() else None
         self.plugin_metadata: Dict[Path, Dict[str, Any]] = (
             {}
@@ -89,6 +94,19 @@ class RepositoryContext:
         self.detected_formats: Set[str] = self._detect_formats()
         self.content_paths: List[str] = []
         self.exclude_patterns: List[str] = []
+
+    def rediscover(self) -> None:
+        """Re-run discovery using the current repo_types.
+
+        Call this after mutating ``repo_types`` so that plugins, skills, and
+        other discovered data reflect the updated types.
+        """
+        self.marketplace_data = self._load_marketplace() if self.has_marketplace() else None
+        self.plugin_metadata = {}
+        self.plugins = self._discover_plugins()
+        self.skills = self._discover_skills()
+        self.instruction_files = self._discover_instruction_files()
+        self.detected_formats = self._detect_formats()
 
     @property
     def repo_type(self) -> RepositoryType:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -503,3 +503,92 @@ def test_coderabbit_with_claude_md_gets_both_formats(temp_dir):
     context = RepositoryContext(temp_dir)
     assert HAS_CODERABBIT in context.detected_formats
     assert HAS_CLAUDE_MD in context.detected_formats
+
+
+# --- repo_types override tests ---
+
+
+def test_repo_types_override_triggers_discovery(temp_dir):
+    """Passing repo_types to RepositoryContext uses override for discovery"""
+    # Create a directory that would auto-detect as UNKNOWN (empty temp_dir)
+    # but has a plugins/ subdirectory with a plugin that should only be
+    # discovered when repo_types includes MARKETPLACE.
+    plugins_dir = temp_dir / "plugins"
+    plugins_dir.mkdir()
+    plugin_dir = plugins_dir / "my-plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / ".claude-plugin").mkdir()
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "my-plugin", "description": "test", "version": "1.0.0"})
+    )
+    (plugin_dir / "commands").mkdir()
+
+    # Without override, auto-detection sees plugins/ and picks MARKETPLACE
+    auto_ctx = RepositoryContext(temp_dir)
+    assert RepositoryType.MARKETPLACE in auto_ctx.repo_types
+    assert len(auto_ctx.plugins) >= 1
+
+    # With an override to AGENTSKILLS only, the MARKETPLACE discovery path
+    # should NOT run, so no plugins are discovered from plugins/.
+    override_ctx = RepositoryContext(temp_dir, repo_types={RepositoryType.AGENTSKILLS})
+    assert override_ctx.repo_types == {RepositoryType.AGENTSKILLS}
+    assert len(override_ctx.plugins) == 0
+
+
+def test_repo_types_override_excludes_marketplace_plugins(temp_dir):
+    """Overriding to non-MARKETPLACE excludes marketplace plugin discovery"""
+    # Create a marketplace layout
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "test-marketplace",
+                "plugins": [
+                    {"name": "mp-plugin", "source": "./plugins/mp-plugin", "description": "test"}
+                ],
+            }
+        )
+    )
+    plugins_dir = temp_dir / "plugins" / "mp-plugin"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / ".claude-plugin").mkdir()
+    (plugins_dir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "mp-plugin", "description": "test", "version": "1.0.0"})
+    )
+    (plugins_dir / "commands").mkdir()
+
+    # Auto-detect: picks up MARKETPLACE and discovers plugin
+    auto_ctx = RepositoryContext(temp_dir)
+    assert RepositoryType.MARKETPLACE in auto_ctx.repo_types
+    assert len(auto_ctx.plugins) >= 1
+
+    # Override to AGENTSKILLS only: marketplace discovery should not run
+    override_ctx = RepositoryContext(temp_dir, repo_types={RepositoryType.AGENTSKILLS})
+    assert override_ctx.repo_types == {RepositoryType.AGENTSKILLS}
+    # No plugins from marketplace discovery
+    assert len(override_ctx.plugins) == 0
+
+
+def test_rediscover_updates_after_repo_types_change(temp_dir):
+    """rediscover() re-runs discovery after repo_types is mutated"""
+    # Set up a marketplace-like layout
+    plugins_dir = temp_dir / "plugins"
+    plugins_dir.mkdir()
+    plugin_dir = plugins_dir / "my-plugin"
+    plugin_dir.mkdir()
+    (plugin_dir / ".claude-plugin").mkdir()
+    (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "my-plugin", "description": "test", "version": "1.0.0"})
+    )
+    (plugin_dir / "commands").mkdir()
+
+    # Start with AGENTSKILLS override — no plugins discovered
+    ctx = RepositoryContext(temp_dir, repo_types={RepositoryType.AGENTSKILLS})
+    assert len(ctx.plugins) == 0
+
+    # Mutate and rediscover
+    ctx.repo_types = {RepositoryType.MARKETPLACE}
+    ctx.rediscover()
+    assert len(ctx.plugins) == 1
+    assert ctx.get_plugin_name(ctx.plugins[0]) == "my-plugin"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -592,3 +592,25 @@ def test_rediscover_updates_after_repo_types_change(temp_dir):
     ctx.rediscover()
     assert len(ctx.plugins) == 1
     assert ctx.get_plugin_name(ctx.plugins[0]) == "my-plugin"
+
+
+def test_rediscover_applies_excludes(temp_dir):
+    """rediscover() re-applies exclude_patterns to newly discovered items"""
+    # Set up an agentskills repo with two skills
+    skill_a = temp_dir / "skill-a"
+    skill_a.mkdir()
+    (skill_a / "SKILL.md").write_text("---\nname: skill-a\ndescription: A\n---\n")
+    skill_b = temp_dir / "skill-b"
+    skill_b.mkdir()
+    (skill_b / "SKILL.md").write_text("---\nname: skill-b\ndescription: B\n---\n")
+
+    ctx = RepositoryContext(temp_dir, repo_types={RepositoryType.AGENTSKILLS})
+    assert len(ctx.skills) == 2
+
+    # Set excludes and rediscover — skill-b should be excluded
+    ctx.exclude_patterns = ["skill-b"]
+    ctx.repo_types = {RepositoryType.AGENTSKILLS}
+    ctx.rediscover()
+    skill_names = [s.name for s in ctx.skills]
+    assert "skill-a" in skill_names
+    assert "skill-b" not in skill_names


### PR DESCRIPTION
## Summary
- `RepositoryContext.__init__` ran all discovery (plugins, skills, instruction files, etc.) immediately using auto-detected `repo_types`. The `--type` CLI flag was applied **after** the constructor finished, so discovered data never reflected the user's override.
- Fix: accept `repo_types` as an optional parameter to `RepositoryContext.__init__`, and parse `--type` in `__main__.py` **before** constructing the context so discovery uses the correct types from the start.
- Also add a `rediscover()` method for callers that need to mutate `repo_types` after construction and re-run discovery.

## Test plan
- [x] New test `test_repo_types_override_triggers_discovery`: verifies that passing `repo_types` to the constructor drives discovery (marketplace plugins not discovered when override excludes MARKETPLACE)
- [x] New test `test_repo_types_override_excludes_marketplace_plugins`: verifies override with a full marketplace.json layout
- [x] New test `test_rediscover_updates_after_repo_types_change`: verifies `rediscover()` correctly re-runs discovery after mutating `repo_types`
- [x] All 823 existing tests pass
- [x] `make lint` clean
- [x] `make update` regenerated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)