### PR TITLE
fix: produce single autofix when both name and description are missing

### DIFF
--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -3,6 +3,8 @@ Rules for validating agent files
 """
 
 import re
+from collections import defaultdict
+from pathlib import Path
 from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
@@ -73,34 +75,51 @@ class AgentFrontmatterRule(Rule):
         self, context: RepositoryContext, violations: List[RuleViolation]
     ) -> List[AutofixResult]:
         results: List[AutofixResult] = []
+
+        # Group violations by file path so we can apply all fixes for the same
+        # file in a single AutofixResult, avoiding conflicts when multiple
+        # fields are missing.
+        by_file: defaultdict[Path, List[RuleViolation]] = defaultdict(list)
         for v in violations:
-            if not v.file_path or not v.file_path.exists():
+            if v.file_path:
+                by_file[v.file_path].append(v)
+
+        for file_path, file_violations in by_file.items():
+            if not file_path.exists():
                 continue
-            original = v.file_path.read_text(encoding="utf-8")
-            if "Missing frontmatter" in v.message:
-                name = v.file_path.stem
+
+            original = file_path.read_text(encoding="utf-8")
+            messages = {v.message for v in file_violations}
+
+            # Case 1: Missing frontmatter block entirely
+            if any("Missing frontmatter" in m for m in messages):
+                name = file_path.stem
                 fixed = f"---\nname: {name}\ndescription: \n---\n{original}"
                 results.append(
                     AutofixResult(
                         rule_id=self.rule_id,
-                        file_path=v.file_path,
+                        file_path=file_path,
                         confidence=AutofixConfidence.SAFE,
                         original_content=original,
                         fixed_content=fixed,
                         description="Added missing frontmatter to agent file",
-                        violations_fixed=[v],
+                        violations_fixed=file_violations,
                     )
                 )
-            elif (
-                "Missing 'name'" in v.message or "Missing 'description'" in v.message
-            ) and original.startswith("---"):
+                continue
+
+            # Case 2: Frontmatter exists but fields are missing — collect all
+            # missing fields and produce one combined fix.
+            missing_name = any("Missing 'name'" in m for m in messages)
+            missing_desc = any("Missing 'description'" in m for m in messages)
+            if (missing_name or missing_desc) and original.startswith("---"):
                 fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []
-                    if "Missing 'name'" in v.message and "name:" not in fm_text:
-                        additions.append(f"name: {v.file_path.stem}")
-                    if "Missing 'description'" in v.message and "description:" not in fm_text:
+                    if missing_name and "name:" not in fm_text:
+                        additions.append(f"name: {file_path.stem}")
+                    if missing_desc and "description:" not in fm_text:
                         additions.append("description: ")
                     if additions:
                         insert = "\n".join(additions) + "\n"
@@ -109,12 +128,12 @@ class AgentFrontmatterRule(Rule):
                         results.append(
                             AutofixResult(
                                 rule_id=self.rule_id,
-                                file_path=v.file_path,
+                                file_path=file_path,
                                 confidence=AutofixConfidence.SAFE,
                                 original_content=original,
                                 fixed_content=fixed,
                                 description="Added missing fields to agent frontmatter",
-                                violations_fixed=[v],
+                                violations_fixed=file_violations,
                             )
                         )
         return results

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -88,7 +88,9 @@ class AgentFrontmatterRule(Rule):
             if not file_path.exists():
                 continue
 
-            original = file_path.read_text(encoding="utf-8")
+            original = read_text(file_path)
+            if original is None:
+                continue
             messages = {v.message for v in file_violations}
 
             # Case 1: Missing frontmatter block entirely

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -118,7 +118,9 @@ class SkillFrontmatterRule(Rule):
             if not file_path.exists():
                 continue
 
-            original = file_path.read_text(encoding="utf-8")
+            original = read_text(file_path)
+            if original is None:
+                continue
 
             # Case 2: Missing frontmatter block entirely
             if any("Missing frontmatter" in m for m in messages):

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -3,6 +3,8 @@ Rules for validating skill files
 """
 
 import re
+from collections import defaultdict
+from pathlib import Path
 from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
@@ -83,12 +85,22 @@ class SkillFrontmatterRule(Rule):
         self, context: RepositoryContext, violations: List[RuleViolation]
     ) -> List[AutofixResult]:
         results: List[AutofixResult] = []
+
+        # Group violations by file path so we can apply all fixes for the same
+        # file in a single AutofixResult, avoiding conflicts when multiple
+        # fields are missing.
+        by_file: defaultdict[Path, List[RuleViolation]] = defaultdict(list)
         for v in violations:
-            if not v.file_path:
-                continue
-            if "Missing SKILL.md" in v.message:
-                skill_md = v.file_path / "SKILL.md"
-                name = v.file_path.name
+            if v.file_path:
+                by_file[v.file_path].append(v)
+
+        for file_path, file_violations in by_file.items():
+            messages = {v.message for v in file_violations}
+
+            # Case 1: Missing SKILL.md entirely — file_path is the directory
+            if any("Missing SKILL.md" in m for m in messages):
+                skill_md = file_path / "SKILL.md"
+                name = file_path.name
                 fixed = f"---\nname: {name}\ndescription: \n---\n"
                 results.append(
                     AutofixResult(
@@ -98,49 +110,59 @@ class SkillFrontmatterRule(Rule):
                         original_content="",
                         fixed_content=fixed,
                         description=f"Created SKILL.md with frontmatter for {name}",
-                        violations_fixed=[v],
+                        violations_fixed=file_violations,
                     )
                 )
-            elif v.file_path.exists():
-                original = v.file_path.read_text(encoding="utf-8")
-                if "Missing frontmatter" in v.message:
-                    name = v.file_path.parent.name
-                    fixed = f"---\nname: {name}\ndescription: \n---\n{original}"
-                    results.append(
-                        AutofixResult(
-                            rule_id=self.rule_id,
-                            file_path=v.file_path,
-                            confidence=AutofixConfidence.SAFE,
-                            original_content=original,
-                            fixed_content=fixed,
-                            description="Added missing frontmatter to SKILL.md",
-                            violations_fixed=[v],
-                        )
+                continue
+
+            if not file_path.exists():
+                continue
+
+            original = file_path.read_text(encoding="utf-8")
+
+            # Case 2: Missing frontmatter block entirely
+            if any("Missing frontmatter" in m for m in messages):
+                name = file_path.parent.name
+                fixed = f"---\nname: {name}\ndescription: \n---\n{original}"
+                results.append(
+                    AutofixResult(
+                        rule_id=self.rule_id,
+                        file_path=file_path,
+                        confidence=AutofixConfidence.SAFE,
+                        original_content=original,
+                        fixed_content=fixed,
+                        description="Added missing frontmatter to SKILL.md",
+                        violations_fixed=file_violations,
                     )
-                elif (
-                    "Missing 'name'" in v.message or "Missing 'description'" in v.message
-                ) and original.startswith("---"):
-                    fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
-                    if fm_match:
-                        fm_text = fm_match.group(1)
-                        additions = []
-                        if "Missing 'name'" in v.message and "name:" not in fm_text:
-                            additions.append(f"name: {v.file_path.parent.name}")
-                        if "Missing 'description'" in v.message and "description:" not in fm_text:
-                            additions.append("description: ")
-                        if additions:
-                            insert = "\n".join(additions) + "\n"
-                            fixed = original[: fm_match.end()].replace("\n---", f"\n{insert}---", 1)
-                            fixed += original[fm_match.end() :]
-                            results.append(
-                                AutofixResult(
-                                    rule_id=self.rule_id,
-                                    file_path=v.file_path,
-                                    confidence=AutofixConfidence.SAFE,
-                                    original_content=original,
-                                    fixed_content=fixed,
-                                    description="Added missing fields to SKILL.md frontmatter",
-                                    violations_fixed=[v],
-                                )
+                )
+                continue
+
+            # Case 3: Frontmatter exists but fields are missing — collect all
+            # missing fields and produce one combined fix.
+            missing_name = any("Missing 'name'" in m for m in messages)
+            missing_desc = any("Missing 'description'" in m for m in messages)
+            if (missing_name or missing_desc) and original.startswith("---"):
+                fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
+                if fm_match:
+                    fm_text = fm_match.group(1)
+                    additions = []
+                    if missing_name and "name:" not in fm_text:
+                        additions.append(f"name: {file_path.parent.name}")
+                    if missing_desc and "description:" not in fm_text:
+                        additions.append("description: ")
+                    if additions:
+                        insert = "\n".join(additions) + "\n"
+                        fixed = original[: fm_match.end()].replace("\n---", f"\n{insert}---", 1)
+                        fixed += original[fm_match.end() :]
+                        results.append(
+                            AutofixResult(
+                                rule_id=self.rule_id,
+                                file_path=file_path,
+                                confidence=AutofixConfidence.SAFE,
+                                original_content=original,
+                                fixed_content=fixed,
+                                description="Added missing fields to SKILL.md frontmatter",
+                                violations_fixed=file_violations,
                             )
+                        )
         return results

--- a/tests/test_agent_rules.py
+++ b/tests/test_agent_rules.py
@@ -201,6 +201,53 @@ def test_no_agents_directory(plugin_without_agents):
     assert len(violations) == 0
 
 
+@pytest.fixture
+def plugin_with_missing_both_fields(temp_dir):
+    """Create a plugin with agent missing both name and description"""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "test-plugin"}')
+
+    agents_dir = plugin_dir / "agents"
+    agents_dir.mkdir()
+
+    agent_content = """---
+some-other-field: value
+---
+
+# Test Agent
+"""
+    (agents_dir / "both-missing.md").write_text(agent_content)
+
+    return plugin_dir
+
+
+def test_fix_both_name_and_description_missing(plugin_with_missing_both_fields):
+    """Test that fixing both missing name and description produces a single
+    AutofixResult that contains both fields, not two conflicting results."""
+    context = RepositoryContext(plugin_with_missing_both_fields)
+    rule = AgentFrontmatterRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 2
+    messages = {v.message for v in violations}
+    assert "Missing 'name' in frontmatter" in messages
+    assert "Missing 'description' in frontmatter" in messages
+
+    fixes = rule.fix(context, violations)
+    # Must produce exactly one fix for the file, not two conflicting ones
+    assert len(fixes) == 1
+
+    fix = fixes[0]
+    assert "name: both-missing" in fix.fixed_content
+    assert "description: " in fix.fixed_content
+    # Both violations should be covered by the single fix
+    assert len(fix.violations_fixed) == 2
+
+
 def test_rule_metadata():
     """Test rule metadata"""
     rule = AgentFrontmatterRule()

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -2,6 +2,7 @@
 Tests for the autofix framework infrastructure
 """
 
+import json
 from pathlib import Path
 from typing import List
 
@@ -17,6 +18,8 @@ from skillsaw.rule import (
 from skillsaw.context import RepositoryContext
 from skillsaw.config import LinterConfig
 from skillsaw.linter import Linter
+from skillsaw.rules.builtin.skills import SkillFrontmatterRule
+from skillsaw.rules.builtin.agents import AgentFrontmatterRule
 
 
 class NoFixRule(Rule):
@@ -384,3 +387,140 @@ class TestEndToEndFix:
 
         violations_after = linter.run()
         assert len(violations_after) == 0
+
+
+class TestSkillFixBothFieldsMissing:
+    """Regression: when both name and description are missing from SKILL.md
+    frontmatter, the fix must produce a single AutofixResult that adds both
+    fields, not two conflicting results that overwrite each other."""
+
+    def test_skill_fix_adds_both_fields_at_once(self, temp_dir):
+        # Create a plugin with a skill whose frontmatter has neither name nor description
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        skills_dir = plugin_dir / "skills"
+        skills_dir.mkdir()
+
+        skill_dir = skills_dir / "my-skill"
+        skill_dir.mkdir()
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("---\nsome-field: value\n---\n\n# My Skill\n")
+
+        context = RepositoryContext(plugin_dir)
+        rule = SkillFrontmatterRule()
+
+        violations = rule.check(context)
+        assert len(violations) == 2
+        messages = {v.message for v in violations}
+        assert "Missing 'name' in SKILL.md frontmatter" in messages
+        assert "Missing 'description' in SKILL.md frontmatter" in messages
+
+        fixes = rule.fix(context, violations)
+        # Must produce exactly one fix, not two conflicting ones
+        assert len(fixes) == 1
+
+        fix = fixes[0]
+        assert "name: my-skill" in fix.fixed_content
+        assert "description: " in fix.fixed_content
+        assert len(fix.violations_fixed) == 2
+
+    def test_skill_fix_single_field_still_works(self, temp_dir):
+        """Ensure fixing just one missing field still works correctly."""
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        skills_dir = plugin_dir / "skills"
+        skills_dir.mkdir()
+
+        skill_dir = skills_dir / "my-skill"
+        skill_dir.mkdir()
+
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("---\nname: my-skill\n---\n\n# My Skill\n")
+
+        context = RepositoryContext(plugin_dir)
+        rule = SkillFrontmatterRule()
+
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "description" in violations[0].message
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert "description: " in fixes[0].fixed_content
+        assert "name: my-skill" in fixes[0].fixed_content
+
+
+class TestAgentFixBothFieldsMissing:
+    """Regression: when both name and description are missing from agent
+    frontmatter, the fix must produce a single AutofixResult that adds both
+    fields, not two conflicting results that overwrite each other."""
+
+    def test_agent_fix_adds_both_fields_at_once(self, temp_dir):
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        agents_dir = plugin_dir / "agents"
+        agents_dir.mkdir()
+
+        agent_md = agents_dir / "my-agent.md"
+        agent_md.write_text("---\nsome-field: value\n---\n\n# My Agent\n")
+
+        context = RepositoryContext(plugin_dir)
+        rule = AgentFrontmatterRule()
+
+        violations = rule.check(context)
+        assert len(violations) == 2
+        messages = {v.message for v in violations}
+        assert "Missing 'name' in frontmatter" in messages
+        assert "Missing 'description' in frontmatter" in messages
+
+        fixes = rule.fix(context, violations)
+        # Must produce exactly one fix, not two conflicting ones
+        assert len(fixes) == 1
+
+        fix = fixes[0]
+        assert "name: my-agent" in fix.fixed_content
+        assert "description: " in fix.fixed_content
+        assert len(fix.violations_fixed) == 2
+
+    def test_agent_fix_single_field_still_works(self, temp_dir):
+        """Ensure fixing just one missing field still works correctly."""
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        agents_dir = plugin_dir / "agents"
+        agents_dir.mkdir()
+
+        agent_md = agents_dir / "my-agent.md"
+        agent_md.write_text("---\nname: my-agent\n---\n\n# My Agent\n")
+
+        context = RepositoryContext(plugin_dir)
+        rule = AgentFrontmatterRule()
+
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "description" in violations[0].message
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert "description: " in fixes[0].fixed_content
+        assert "name: my-agent" in fixes[0].fixed_content


### PR DESCRIPTION
## Summary

- When a SKILL.md or agent .md was missing both `name:` and `description:`, `fix()` processed each violation independently against the original file content, producing two conflicting `AutofixResult` objects. Whichever was applied last would overwrite the other, losing one field.
- Changed `fix()` in both `SkillFrontmatterRule` and `AgentFrontmatterRule` to group violations by file path and produce a single combined `AutofixResult` per file, so all missing fields are added in one pass.

## Test plan

- [x] Added `TestSkillFixBothFieldsMissing` in `test_autofix.py` verifying a single fix adds both fields
- [x] Added `TestAgentFixBothFieldsMissing` in `test_autofix.py` verifying a single fix adds both fields
- [x] Added `test_fix_both_name_and_description_missing` in `test_agent_rules.py`
- [x] Verified single-field-missing cases still produce correct fixes
- [x] `make test` passes (825 tests)
- [x] `make lint` passes
- [x] `make update` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontmatter autofix to group issues by file and emit a single combined fix per file, adding missing frontmatter and/or missing metadata fields together.

* **Tests**
  * Added tests covering autofix behavior for agents and skills, including cases where both required frontmatter fields are missing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/97)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->