### PR TITLE
fix: frontmatter regex in rules_dir.py truncates on --- in values

### DIFF
--- a/src/skillsaw/rules/builtin/rules_dir.py
+++ b/src/skillsaw/rules/builtin/rules_dir.py
@@ -22,7 +22,7 @@ def _parse_frontmatter(content: str):
     if not content.startswith("---"):
         return None, None
 
-    match = re.match(r"^---\n(.*?\n)?---[ \t]*\n", content, re.DOTALL)
+    match = re.match(r"^---[ \t]*\n(.*?\n)?---[ \t]*(?:\n|$)", content, re.DOTALL)
     if not match:
         return None, "Unterminated frontmatter (missing closing '---')"
 

--- a/src/skillsaw/rules/builtin/rules_dir.py
+++ b/src/skillsaw/rules/builtin/rules_dir.py
@@ -22,11 +22,11 @@ def _parse_frontmatter(content: str):
     if not content.startswith("---"):
         return None, None
 
-    match = re.match(r"^---\n(.*?)---", content, re.DOTALL)
+    match = re.match(r"^---\n(.*?\n)?---[ \t]*\n", content, re.DOTALL)
     if not match:
         return None, "Unterminated frontmatter (missing closing '---')"
 
-    raw = match.group(1).rstrip("\n")
+    raw = (match.group(1) or "").rstrip("\n")
     try:
         data = yaml.safe_load(raw) if raw else None
     except yaml.YAMLError as e:

--- a/tests/test_rules_dir.py
+++ b/tests/test_rules_dir.py
@@ -279,6 +279,17 @@ def test_frontmatter_with_dashes_in_value(dot_claude_with_rules):
     assert len(violations) == 0
 
 
+def test_frontmatter_no_trailing_newline(dot_claude_with_rules):
+    """Frontmatter ending at EOF without trailing newline is valid"""
+    content = '---\npaths:\n  - "src/**/*.ts"\n---'
+    _write_rule(dot_claude_with_rules, "no-trailing.md", content)
+
+    context = RepositoryContext(dot_claude_with_rules)
+    rule = RulesValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
 def test_rule_metadata():
     """Verify rule ID, description, and default severity"""
     rule = RulesValidRule()

--- a/tests/test_rules_dir.py
+++ b/tests/test_rules_dir.py
@@ -268,6 +268,17 @@ def test_empty_frontmatter_is_valid(dot_claude_with_rules):
     assert len(violations) == 0
 
 
+def test_frontmatter_with_dashes_in_value(dot_claude_with_rules):
+    """Frontmatter with --- inside a YAML value must not truncate parsing"""
+    content = '---\npaths:\n  - "src/---internal/**/*.ts"\n---\n\n# Rules\n'
+    _write_rule(dot_claude_with_rules, "dashes.md", content)
+
+    context = RepositoryContext(dot_claude_with_rules)
+    rule = RulesValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
 def test_rule_metadata():
     """Verify rule ID, description, and default severity"""
     rule = RulesValidRule()


### PR DESCRIPTION
## Summary

- Fixed frontmatter regex in `_parse_frontmatter()` in `src/skillsaw/rules/builtin/rules_dir.py` that was missing `\n` before the closing `---` delimiter
- The old regex `r"^---\n(.*?)---"` would treat `---` inside a YAML value (e.g. a path glob like `src/---internal/**`) as the closing delimiter, silently truncating frontmatter
- Changed to `r"^---\n(.*?\n)?---[ \t]*\n"` which requires the closing `---` to appear on its own line, consistent with every other frontmatter parser in the codebase (`utils.py`, `agents.py`, `skills.py`, etc.)
- Also handled the empty frontmatter edge case (`---\n---\n`) where the capture group is `None`

## Test plan

- [x] Added `test_frontmatter_with_dashes_in_value` that verifies `---` inside a YAML path value is not treated as the closing delimiter
- [x] All 821 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] `make update` regenerated files with no changes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)