### PR TITLE
fix: propagate real line numbers for coderabbit instruction violations

### DIFF
--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -483,6 +483,19 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
     return results
 
 
+def _is_block_scalar(lines: List[str], key_line: Optional[int]) -> bool:
+    """Return ``True`` if the YAML key at *key_line* uses a block scalar indicator."""
+    if key_line is None or key_line < 1 or key_line > len(lines):
+        return False
+    key_content = lines[key_line - 1]
+    colon_idx = key_content.find(":")
+    if colon_idx >= 0:
+        after_colon = key_content[colon_idx + 1 :].split("#", 1)[0].strip()
+        if after_colon in ("|", ">", "|-", ">-", "|+", ">+"):
+            return True
+    return False
+
+
 def _instruction_text_start_line(lines: List[str], key_line: Optional[int]) -> Optional[int]:
     """Determine the real start line of an instruction's text content.
 
@@ -494,15 +507,41 @@ def _instruction_text_start_line(lines: List[str], key_line: Optional[int]) -> O
         return None
     if key_line < 1 or key_line > len(lines):
         return key_line
-    key_content = lines[key_line - 1]
-    # After "instructions:", if a block scalar indicator follows, text is next line
-    colon_idx = key_content.find(":")
-    if colon_idx >= 0:
-        # Strip comments and whitespace after the colon
-        after_colon = key_content[colon_idx + 1 :].split("#", 1)[0].strip()
-        if after_colon in ("|", ">", "|-", ">-", "|+", ">+"):
-            return key_line + 1
+    if _is_block_scalar(lines, key_line):
+        return key_line + 1
     return key_line
+
+
+def _extract_raw_block_lines(lines: List[str], start_line: int) -> List[str]:
+    """Extract the physical content lines of a YAML block scalar.
+
+    Starting from *start_line* (1-based, the first content line after ``|``
+    or ``>``), collects lines that belong to the block by checking indentation.
+    Returns the de-indented content lines so they can be placed at their
+    real positions in the assembled body.
+    """
+    if start_line < 1 or start_line > len(lines):
+        return []
+    # Determine the indentation of the first content line.
+    first = lines[start_line - 1]
+    indent = len(first) - len(first.lstrip())
+    if indent == 0:
+        return []
+    result: List[str] = []
+    for i in range(start_line - 1, len(lines)):
+        line = lines[i]
+        # An empty or whitespace-only line within the block is preserved.
+        if line.strip() == "":
+            result.append("")
+            continue
+        cur_indent = len(line) - len(line.lstrip())
+        if cur_indent < indent:
+            break
+        result.append(line[indent:])
+    # Strip trailing empty lines (YAML block scalars don't include them).
+    while result and result[-1] == "":
+        result.pop()
+    return result
 
 
 def _extract_coderabbit_instructions_body(raw: str) -> str:
@@ -511,6 +550,10 @@ def _extract_coderabbit_instructions_body(raw: str) -> str:
     Builds a body string where each instruction's text is placed at its
     real line offset in the YAML file (padded with blank lines) so that
     content analyzers report correct line numbers.
+
+    For block scalars (both ``|`` literal and ``>`` folded), the raw physical
+    lines are extracted from the YAML source so that line positions are
+    preserved even when PyYAML would collapse them.
 
     Returns an empty string on parse failure or when no instructions exist.
     """
@@ -522,21 +565,26 @@ def _extract_coderabbit_instructions_body(raw: str) -> str:
     if not instructions:
         return ""
 
-    # Build a list of (start_line, text) tuples sorted by position.
+    # Build a list of (start_line, text_lines) tuples sorted by position.
     raw_lines = raw.splitlines()
-    positioned: List[Tuple[int, str]] = []
+    positioned: List[Tuple[int, List[str]]] = []
     for _, text, key_line in instructions:
         start = _instruction_text_start_line(raw_lines, key_line)
         if start is None:
             start = 1
-        positioned.append((start, text))
+        # For block scalars, extract raw physical lines to preserve line
+        # fidelity (folded '>' scalars collapse lines after parsing).
+        if _is_block_scalar(raw_lines, key_line):
+            text_lines = _extract_raw_block_lines(raw_lines, start)
+        else:
+            text_lines = text.splitlines()
+        positioned.append((start, text_lines))
     positioned.sort(key=lambda t: t[0])
 
     # Assemble body: pad with blank lines so each text block sits at its
     # real line number.
     result_lines: List[str] = []
-    for start, text in positioned:
-        text_lines = text.splitlines()
+    for start, text_lines in positioned:
         # Pad up to the target line.  start is 1-based; len(result_lines)
         # is the count of lines already emitted (0-based next index).
         while len(result_lines) < start - 1:

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -483,7 +483,7 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
     return results
 
 
-def _instruction_text_start_line(raw: str, key_line: Optional[int]) -> Optional[int]:
+def _instruction_text_start_line(lines: List[str], key_line: Optional[int]) -> Optional[int]:
     """Determine the real start line of an instruction's text content.
 
     For YAML block scalars (``|`` or ``>``), the text starts on the line
@@ -492,14 +492,14 @@ def _instruction_text_start_line(raw: str, key_line: Optional[int]) -> Optional[
     """
     if key_line is None:
         return None
-    lines = raw.splitlines()
     if key_line < 1 or key_line > len(lines):
         return key_line
     key_content = lines[key_line - 1]
     # After "instructions:", if a block scalar indicator follows, text is next line
     colon_idx = key_content.find(":")
     if colon_idx >= 0:
-        after_colon = key_content[colon_idx + 1 :].strip()
+        # Strip comments and whitespace after the colon
+        after_colon = key_content[colon_idx + 1 :].split("#", 1)[0].strip()
         if after_colon in ("|", ">", "|-", ">-", "|+", ">+"):
             return key_line + 1
     return key_line
@@ -523,9 +523,10 @@ def _extract_coderabbit_instructions_body(raw: str) -> str:
         return ""
 
     # Build a list of (start_line, text) tuples sorted by position.
+    raw_lines = raw.splitlines()
     positioned: List[Tuple[int, str]] = []
     for _, text, key_line in instructions:
-        start = _instruction_text_start_line(raw, key_line)
+        start = _instruction_text_start_line(raw_lines, key_line)
         if start is None:
             start = 1
         positioned.append((start, text))

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -483,11 +483,35 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
     return results
 
 
+def _instruction_text_start_line(raw: str, key_line: Optional[int]) -> Optional[int]:
+    """Determine the real start line of an instruction's text content.
+
+    For YAML block scalars (``|`` or ``>``), the text starts on the line
+    *after* the key.  For inline/flow scalars the text is on the same line
+    as the key.  Returns ``None`` when *key_line* is ``None``.
+    """
+    if key_line is None:
+        return None
+    lines = raw.splitlines()
+    if key_line < 1 or key_line > len(lines):
+        return key_line
+    key_content = lines[key_line - 1]
+    # After "instructions:", if a block scalar indicator follows, text is next line
+    colon_idx = key_content.find(":")
+    if colon_idx >= 0:
+        after_colon = key_content[colon_idx + 1 :].strip()
+        if after_colon in ("|", ">", "|-", ">-", "|+", ">+"):
+            return key_line + 1
+    return key_line
+
+
 def _extract_coderabbit_instructions_body(raw: str) -> str:
     """Extract instruction text from raw .coderabbit.yaml content.
 
-    Parses the YAML and concatenates all ``instructions`` field values
-    separated by double newlines so content analyzers see only plain text.
+    Builds a body string where each instruction's text is placed at its
+    real line offset in the YAML file (padded with blank lines) so that
+    content analyzers report correct line numbers.
+
     Returns an empty string on parse failure or when no instructions exist.
     """
     try:
@@ -495,7 +519,30 @@ def _extract_coderabbit_instructions_body(raw: str) -> str:
     except yaml.YAMLError:
         return ""
     instructions = _extract_instructions(data, raw)
-    return "\n\n".join(text for _, text, _ in instructions)
+    if not instructions:
+        return ""
+
+    # Build a list of (start_line, text) tuples sorted by position.
+    positioned: List[Tuple[int, str]] = []
+    for _, text, key_line in instructions:
+        start = _instruction_text_start_line(raw, key_line)
+        if start is None:
+            start = 1
+        positioned.append((start, text))
+    positioned.sort(key=lambda t: t[0])
+
+    # Assemble body: pad with blank lines so each text block sits at its
+    # real line number.
+    result_lines: List[str] = []
+    for start, text in positioned:
+        text_lines = text.splitlines()
+        # Pad up to the target line.  start is 1-based; len(result_lines)
+        # is the count of lines already emitted (0-based next index).
+        while len(result_lines) < start - 1:
+            result_lines.append("")
+        result_lines.extend(text_lines)
+
+    return "\n".join(result_lines)
 
 
 class WeakLanguageDetector:

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -170,6 +170,70 @@ class TestContentRulesOnCoderabbit:
         ]
         assert len(coderabbit_violations) >= 1
 
+    def test_violation_line_numbers_match_real_file_inline(self, temp_dir):
+        """Violations in .coderabbit.yaml should report real YAML line numbers."""
+        content = (
+            "language: en-US\n"  # line 1
+            "reviews:\n"  # line 2
+            "  instructions: 'Try to check for null pointers.'\n"  # line 3
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
+        # "Try to" is on the instructions: key line (line 3), not line 1
+        for v in coderabbit_violations:
+            assert v.line == 3, f"Expected line 3, got {v.line}: {v.message}"
+
+    def test_violation_line_numbers_match_real_file_block_scalar(self, temp_dir):
+        """Block scalar instructions should report real YAML line numbers."""
+        content = (
+            "reviews:\n"  # line 1
+            "  instructions: |\n"  # line 2
+            "    Always check for null pointers.\n"  # line 3
+            "    Try to validate all inputs.\n"  # line 4
+            "    Handle errors with retries.\n"  # line 5
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 1
+        # "Try to" is on line 4 of the real file
+        try_violations = [v for v in coderabbit_violations if "try to" in v.message.lower()]
+        assert len(try_violations) == 1
+        assert try_violations[0].line == 4, f"Expected line 4, got {try_violations[0].line}"
+
+    def test_violation_line_numbers_multiple_instruction_sections(self, temp_dir):
+        """Line numbers should be correct across multiple instruction sections."""
+        content = (
+            "reviews:\n"  # line 1
+            "  instructions: |\n"  # line 2
+            "    Always check null pointers.\n"  # line 3
+            "    Validate all inputs.\n"  # line 4
+            "  path_instructions:\n"  # line 5
+            "    - path: 'src/**'\n"  # line 6
+            "      instructions: 'Try to follow the style guide.'\n"  # line 7
+            "chat:\n"  # line 8
+            "  instructions: 'You might want to add docs.'\n"  # line 9
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        assert len(coderabbit_violations) >= 2
+        lines = sorted(v.line for v in coderabbit_violations)
+        # "Try to" is on line 7, "You might want to" is on line 9
+        assert 7 in lines, f"Expected line 7 in {lines}"
+        assert 9 in lines, f"Expected line 9 in {lines}"
+
 
 # ---------------------------------------------------------------------------
 # _get_body for .coderabbit.yaml
@@ -209,6 +273,102 @@ class TestGetBodyCoderabbit:
         cr = temp_dir / ".coderabbit.yaml"
         cr.write_text(":\n  bad: [unterminated\n")
         body = _get_body(cr)
+        assert body == ""
+
+    def test_body_preserves_line_numbers_for_block_scalar(self, temp_dir):
+        """_get_body should place instruction text at real YAML line positions."""
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text(
+            "reviews:\n"  # line 1
+            "  instructions: |\n"  # line 2
+            "    First instruction.\n"  # line 3
+            "    Second instruction.\n"  # line 4
+        )
+        body = _get_body(cr)
+        assert body is not None
+        lines = body.splitlines()
+        # lines[2] (0-indexed) is line 3 (1-indexed) -> "First instruction."
+        assert "First instruction." in lines[2]
+        assert "Second instruction." in lines[3]
+
+    def test_body_preserves_line_numbers_for_inline_scalar(self, temp_dir):
+        """Inline instruction text should appear at the key's line."""
+        cr = temp_dir / ".coderabbit.yaml"
+        cr.write_text(
+            "language: en-US\n"  # line 1
+            "reviews:\n"  # line 2
+            "  instructions: 'Do stuff.'\n"  # line 3
+        )
+        body = _get_body(cr)
+        assert body is not None
+        lines = body.splitlines()
+        # line 3 (1-indexed) = lines[2] (0-indexed)
+        assert "Do stuff." in lines[2]
+
+
+# ---------------------------------------------------------------------------
+# _extract_coderabbit_instructions_body line alignment
+# ---------------------------------------------------------------------------
+
+
+class TestCoderabbitBodyLineAlignment:
+    """Verify _extract_coderabbit_instructions_body aligns text to real lines."""
+
+    def test_block_scalar_alignment(self):
+        raw = (
+            "reviews:\n"  # line 1
+            "  instructions: |\n"  # line 2
+            "    Check nulls.\n"  # line 3
+            "    Validate inputs.\n"  # line 4
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        assert lines[2] == "Check nulls."  # line 3
+        assert lines[3] == "Validate inputs."  # line 4
+
+    def test_inline_scalar_alignment(self):
+        raw = (
+            "reviews:\n"  # line 1
+            "  instructions: 'Do stuff.'\n"  # line 2
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        assert lines[1] == "Do stuff."  # line 2
+
+    def test_multiple_sections_alignment(self):
+        raw = (
+            "reviews:\n"  # line 1
+            "  instructions: |\n"  # line 2
+            "    Review stuff.\n"  # line 3
+            "chat:\n"  # line 4
+            "  instructions: 'Chat stuff.'\n"  # line 5
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        assert lines[2] == "Review stuff."  # line 3
+        assert lines[4] == "Chat stuff."  # line 5
+
+    def test_padding_lines_are_blank(self):
+        raw = (
+            "language: en-US\n"  # line 1
+            "reviews:\n"  # line 2
+            "  instructions: 'Do stuff.'\n"  # line 3
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        # Lines 1-2 should be blank padding
+        assert lines[0] == ""
+        assert lines[1] == ""
+        assert lines[2] == "Do stuff."
+
+    def test_empty_body_on_no_instructions(self):
+        raw = "language: en-US\n"
+        body = _extract_coderabbit_instructions_body(raw)
+        assert body == ""
+
+    def test_empty_body_on_invalid_yaml(self):
+        raw = ":\n  bad: [unterminated\n"
+        body = _extract_coderabbit_instructions_body(raw)
         assert body == ""
 
 

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -361,6 +361,19 @@ class TestCoderabbitBodyLineAlignment:
         assert lines[1] == ""
         assert lines[2] == "Do stuff."
 
+    def test_block_scalar_with_comment_alignment(self):
+        """Block scalar indicator with trailing YAML comment should still work."""
+        raw = (
+            "reviews:\n"  # line 1
+            "  instructions: | # this is a comment\n"  # line 2
+            "    Check nulls.\n"  # line 3
+            "    Validate inputs.\n"  # line 4
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        assert lines[2] == "Check nulls."  # line 3
+        assert lines[3] == "Validate inputs."  # line 4
+
     def test_empty_body_on_no_instructions(self):
         raw = "language: en-US\n"
         body = _extract_coderabbit_instructions_body(raw)

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -374,6 +374,42 @@ class TestCoderabbitBodyLineAlignment:
         assert lines[2] == "Check nulls."  # line 3
         assert lines[3] == "Validate inputs."  # line 4
 
+    def test_folded_scalar_alignment(self):
+        """Folded '>' scalars preserve physical line positions, not collapsed text."""
+        raw = (
+            "reviews:\n"  # line 1
+            "  instructions: >\n"  # line 2
+            "    Always validate inputs.\n"  # line 3
+            "    Try to handle retries.\n"  # line 4
+            "    Check for errors.\n"  # line 5
+        )
+        body = _extract_coderabbit_instructions_body(raw)
+        lines = body.splitlines()
+        # Each physical line should appear at its real position
+        assert lines[2] == "Always validate inputs."  # line 3
+        assert lines[3] == "Try to handle retries."  # line 4
+        assert lines[4] == "Check for errors."  # line 5
+
+    def test_folded_scalar_violation_line_numbers(self, temp_dir):
+        """Violations in folded '>' scalars should report correct physical lines."""
+        content = (
+            "reviews:\n"  # line 1
+            "  instructions: >\n"  # line 2
+            "    Always validate inputs.\n"  # line 3
+            "    Try to handle retries.\n"  # line 4
+            "    Check for errors.\n"  # line 5
+        )
+        (temp_dir / ".coderabbit.yaml").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentWeakLanguageRule().check(context)
+        coderabbit_violations = [
+            v for v in violations if v.file_path == temp_dir / ".coderabbit.yaml"
+        ]
+        # "Try to" is on physical line 4
+        try_violations = [v for v in coderabbit_violations if "try to" in v.message.lower()]
+        assert len(try_violations) == 1
+        assert try_violations[0].line == 4, f"Expected line 4, got {try_violations[0].line}"
+
     def test_empty_body_on_no_instructions(self):
         raw = "language: en-US\n"
         body = _extract_coderabbit_instructions_body(raw)


### PR DESCRIPTION
## Summary

- `_extract_coderabbit_instructions_body()` was concatenating all `instructions` field values and discarding per-instruction line numbers from `_extract_instructions()`, causing content analyzers to report synthetic line numbers starting at 1 instead of real YAML file positions.
- Added `_instruction_text_start_line()` helper to distinguish block scalars (`|`/`>`, text starts on next line) from inline scalars (text on key line).
- The body is now padded with blank lines so each instruction's text sits at its real YAML line offset, preserving the `_get_body() -> Optional[str]` interface without any caller changes.

## Test plan

- [x] Added `TestCoderabbitBodyLineAlignment` with 6 unit tests for `_extract_coderabbit_instructions_body` line alignment (block scalar, inline scalar, multiple sections, padding, empty cases)
- [x] Added `test_body_preserves_line_numbers_for_block_scalar` and `test_body_preserves_line_numbers_for_inline_scalar` to `TestGetBodyCoderabbit`
- [x] Added 3 end-to-end tests in `TestContentRulesOnCoderabbit` verifying `ContentWeakLanguageRule` reports correct line numbers for inline instructions, block scalars, and multiple instruction sections
- [x] All 831 existing tests pass
- [x] `make lint` passes
- [x] `make update` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate reporting of violation line numbers when reading instruction text from CodeRabbit YAML, preserving original physical line positions for inline, block, folded scalars and commented indicators.

* **Tests**
  * Added comprehensive tests validating line-number alignment, blank-line padding, folded/block scalar handling, multiple instruction sections, and cases with no or invalid instructions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/99)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->