### PR TITLE
fix: match pull_request_target events in action review step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Post PR review
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
       shell: bash
       run: python3 "${{ github.action_path }}/action/review.py"
       env:


### PR DESCRIPTION
## Summary

- The "Post PR review" step in `action.yml` only checked for `pull_request` events, causing the review to be silently skipped when the action runs on `pull_request_target` (common for fork PRs that need write permissions).
- Added `|| github.event_name == 'pull_request_target'` to the condition so both event types trigger the review.

## Test plan

- [x] `make test` -- 837 passed, 14 skipped
- [x] `make lint` -- clean
- [x] `make update` -- no generated file changes
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PR review comments now post correctly when workflows are triggered by `pull_request_target` events, in addition to `pull_request` events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->