### PR TITLE
fix: remove tautological assertion in dry-run test

### DIFF
--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -415,7 +415,7 @@ class TestLLMFixDryRun:
         actual = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
         assert actual == content
         assert len(result.files_modified) == 0
-        assert len(result.diffs) > 0 or result.violations_before > 0
+        assert len(result.diffs) > 0
 
 
 class TestLLMFixScopedLinting:


### PR DESCRIPTION
## Summary

- Fixed a tautological assertion in `tests/test_llm_integration.py` line 418 where `assert len(result.diffs) > 0 or result.violations_before > 0` was always true because the test input guarantees `violations_before > 0`, making the diffs check meaningless
- Changed to `assert len(result.diffs) > 0` so the test actually verifies that dry-run mode produces diffs

## Test plan

- [x] `make test` -- all 837 tests pass
- [x] `make lint` -- clean
- [x] `make update` -- no generated file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test validation for dry-run functionality to ensure more accurate assertion checks.

---

**Note:** This release contains internal testing improvements with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/102)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->