### PR TITLE
fix: use config severity in generated docs instead of code default

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,8 @@ These rules validate skills against the [agentskills.io specification](https://a
 | `agentskill-name` | Skill name must be lowercase with hyphens and match directory name | error (auto) | auto |
 | `agentskill-description` | Skill description should be meaningful and within length limits | warning (auto) | - |
 | `agentskill-structure` | Skill directories should only contain recognized subdirectories (stricter than spec) | warning (disabled) | - |
-| `agentskill-evals` | Validate evals/evals.json format when present | error (auto) | - |
-| `agentskill-evals-required` | Require evals/evals.json for each skill (opt-in) | error (disabled) | - |
+| `agentskill-evals` | Validate evals/evals.json format when present | warning (auto) | - |
+| `agentskill-evals-required` | Require evals/evals.json for each skill (opt-in) | warning (disabled) | - |
 
 **`agentskill-structure` parameters:**
 

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -215,7 +215,7 @@ def main():
             rule = rules_by_id[rule_id]
             rule_config = defaults.rules.get(rule_id, {})
             enabled = rule_config.get("enabled", True)
-            severity = rule.default_severity().value
+            severity = rule_config.get("severity", rule.default_severity().value)
 
             if enabled == "auto":
                 severity_str = f"{severity} (auto)"


### PR DESCRIPTION
## Summary

- The docs table in `generate-docs.py` was using `rule.default_severity().value` (the hardcoded code default) instead of the effective config default
- Rules like `agentskill-evals` showed "error" in the README but actually default to "warning" via config
- Fixed to use `rule_config.get("severity", rule.default_severity().value)` so the config value takes precedence

## Test plan

- [x] `make test` passes (837 passed, 14 skipped)
- [x] `make lint` passes
- [x] `make update` regenerates README.md with corrected severity values
- [x] Verified `agentskill-evals` and `agentskill-evals-required` now show "warning" instead of "error" in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `agentskill-evals` and `agentskill-evals-required` rules' default severity from error to warning.
  * Documentation generation now accurately reflects configured severity overrides instead of only built-in defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->