### PR TITLE
fix: add missing AutofixConfidence and AutofixResult to claudelint shim

### DIFF
--- a/src/claudelint/__init__.py
+++ b/src/claudelint/__init__.py
@@ -5,10 +5,21 @@ This package has been renamed to 'skillsaw'. All imports are re-exported
 from the new package name. Please update your imports to use 'skillsaw'.
 """
 
-from skillsaw import Linter, Rule, RuleViolation, Severity, RepositoryContext, __version__
+from skillsaw import (
+    AutofixConfidence,
+    AutofixResult,
+    Linter,
+    Rule,
+    RuleViolation,
+    Severity,
+    RepositoryContext,
+    __version__,
+)
 
 __all__ = [
     "__version__",
+    "AutofixConfidence",
+    "AutofixResult",
     "Linter",
     "Rule",
     "RuleViolation",

--- a/tests/test_claudelint_compat.py
+++ b/tests/test_claudelint_compat.py
@@ -1,0 +1,34 @@
+"""
+Tests for the claudelint backward-compatibility shim.
+
+Every public symbol exported by skillsaw must also be importable from claudelint.
+"""
+
+import skillsaw
+
+
+def test_claudelint_exports_match_skillsaw():
+    """All symbols in skillsaw.__all__ must be importable from claudelint."""
+    import claudelint
+
+    for name in skillsaw.__all__:
+        assert hasattr(claudelint, name), f"claudelint shim is missing export: {name}"
+
+
+def test_import_autofix_symbols():
+    """AutofixConfidence and AutofixResult are importable from claudelint."""
+    from claudelint import AutofixConfidence, AutofixResult
+
+    assert AutofixConfidence is skillsaw.AutofixConfidence
+    assert AutofixResult is skillsaw.AutofixResult
+
+
+def test_import_core_symbols():
+    """Core symbols are importable from claudelint."""
+    from claudelint import Linter, Rule, RuleViolation, Severity, RepositoryContext
+
+    assert Linter is skillsaw.Linter
+    assert Rule is skillsaw.Rule
+    assert RuleViolation is skillsaw.RuleViolation
+    assert Severity is skillsaw.Severity
+    assert RepositoryContext is skillsaw.RepositoryContext


### PR DESCRIPTION
## Summary

- Add `AutofixConfidence` and `AutofixResult` to the `claudelint` backward-compatibility shim, which were present in `skillsaw.__init__` but missing from the shim
- Add a comprehensive test suite for claudelint shim exports, including a generic test that verifies all `skillsaw.__all__` symbols are re-exported to prevent future drift

## Test plan

- [x] `make test` passes (840 passed)
- [x] `make lint` passes
- [x] `make update` runs clean
- [x] New `test_claudelint_compat.py` verifies:
  - All `skillsaw.__all__` symbols are importable from `claudelint`
  - `AutofixConfidence` and `AutofixResult` specifically importable and identical to skillsaw's
  - Core symbols (Linter, Rule, etc.) importable and identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded claudelint exports to include AutofixConfidence and AutofixResult, improving API availability for consumers.

* **Tests**
  * Added backward-compatibility tests that verify all public symbols are accessible from claudelint and that key public types maintain identical object identity across imports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->