### PR TITLE
fix: handle empty hooks list in add_hook to prevent IndexError

### DIFF
--- a/src/skillsaw/marketplace/add.py
+++ b/src/skillsaw/marketplace/add.py
@@ -464,7 +464,9 @@ def add_hook(
     data.setdefault("hooks", {})
     data["hooks"].setdefault(event, [])
     hook_cmd = f"./hooks/{event}.sh"
-    if not any(h.get("hooks", [{}])[0].get("command") == hook_cmd for h in data["hooks"][event]):
+    if not any(
+        (h.get("hooks") or [{}])[0].get("command") == hook_cmd for h in data["hooks"][event]
+    ):
         data["hooks"][event].append(
             {
                 "hooks": [

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -369,6 +369,26 @@ class TestAddComponents:
         assert len(data["hooks"]["PreToolUse"]) == 1
         assert len(data["hooks"]["PostToolUse"]) == 1
 
+    def test_add_hook_with_existing_empty_hooks_list(self, temp_dir):
+        """Adding a hook when hooks.json has an entry with an empty 'hooks' list should not crash."""
+        root = self._init_with_plugin(temp_dir)
+        hooks_dir = root / "plugins" / "my-plugin" / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        hooks_json = hooks_dir / "hooks.json"
+        # Simulate a pre-existing entry with an empty hooks list
+        hooks_json.write_text(
+            json.dumps({"hooks": {"PreToolUse": [{"hooks": []}]}}, indent=2),
+            encoding="utf-8",
+        )
+
+        result = add_hook("PreToolUse", "my-plugin", path=root)
+        assert result.exists()
+
+        data = json.loads(hooks_json.read_text())
+        # The original empty entry should remain, and a new entry should be appended
+        assert len(data["hooks"]["PreToolUse"]) == 2
+        assert data["hooks"]["PreToolUse"][1]["hooks"][0]["type"] == "command"
+
     def test_add_command_rejects_duplicate(self, temp_dir):
         root = self._init_with_plugin(temp_dir)
         add_command("greet", "my-plugin", path=root)


### PR DESCRIPTION
## Summary
- Fix `IndexError` in `add_hook()` when a hook entry has `"hooks": []` (empty list)
- `h.get("hooks", [{}])[0]` only falls back to `[{}]` when the key is absent, not when it's present but empty; changed to `(h.get("hooks") or [{}])[0]`
- Added test verifying that `add_hook` works correctly when hooks.json contains an entry with an empty hooks list

## Test plan
- [x] New test `test_add_hook_with_existing_empty_hooks_list` covers the exact crash scenario
- [x] Full test suite passes (838 passed, 14 skipped)
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of hook registration to handle cases where existing hook entries have missing or empty hook lists, ensuring new hooks are appended correctly.

* **Tests**
  * Added unit test covering the edge case where an existing hook entry has an empty hooks list, verifying a new hook record is appended as expected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/106)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/106)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->