### PR TITLE
fix: prevent double-substitution in apply_replacements

### DIFF
--- a/src/skillsaw/marketplace/branding.py
+++ b/src/skillsaw/marketplace/branding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -99,10 +100,18 @@ def build_replacements(
 
 
 def apply_replacements(content: str, replacements: Dict[str, str]) -> str:
-    """Apply {{PLACEHOLDER}} substitutions to a string."""
-    for key, value in replacements.items():
-        content = content.replace(f"{{{{{key}}}}}", value)
-    return content
+    """Apply {{PLACEHOLDER}} substitutions to a string.
+
+    All placeholders are replaced simultaneously via a single ``re.sub`` pass
+    so that user-supplied values containing ``{{PLACEHOLDER}}`` patterns are
+    never double-substituted.
+    """
+    if not replacements:
+        return content
+
+    # Build a pattern that matches any known placeholder in one pass.
+    pattern = re.compile(r"\{\{(" + "|".join(re.escape(k) for k in replacements) + r")\}\}")
+    return pattern.sub(lambda m: replacements[m.group(1)], content)
 
 
 def apply_branding(root: Path, replacements: Optional[Dict[str, str]] = None) -> None:

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -55,6 +55,19 @@ class TestBranding:
         result = apply_replacements("Hello {{NAME}}", {"NAME": "World"})
         assert result == "Hello World"
 
+    def test_apply_replacements_no_double_substitution(self):
+        """Values containing {{PLACEHOLDER}} patterns must not be substituted again."""
+        result = apply_replacements(
+            "name={{NAME}} owner={{OWNER}}",
+            {"NAME": "{{OWNER}}", "OWNER": "alice"},
+        )
+        # NAME should become the literal string "{{OWNER}}", not "alice"
+        assert result == "name={{OWNER}} owner=alice"
+
+    def test_apply_replacements_empty(self):
+        """An empty replacements dict should return the content unchanged."""
+        assert apply_replacements("{{FOO}}", {}) == "{{FOO}}"
+
     def test_build_replacements(self):
         r = build_replacements("my-mp", "alice", "alice/my-mp", COLOR_PRESETS["ocean-blue"])
         assert r["MARKETPLACE_NAME"] == "my-mp"


### PR DESCRIPTION
## Summary
- `apply_replacements` iterated over keys sequentially, so user-supplied values containing `{{PLACEHOLDER}}` patterns got double-substituted (e.g., a marketplace name of `{{OWNER_NAME}}` would first be inserted, then re-expanded to the owner value).
- Replaced the sequential `str.replace()` loop with a single `re.sub` pass using a callback, so all placeholders are resolved simultaneously and replacement values are never re-scanned.
- Added tests for the double-substitution case and for the empty-replacements edge case.

## Test plan
- [x] `test_apply_replacements_no_double_substitution` verifies that a value like `{{OWNER}}` injected via the `NAME` placeholder is preserved literally and not expanded again.
- [x] `test_apply_replacements_empty` verifies empty replacements dict returns content unchanged.
- [x] All existing tests pass (`make test` -- 839 passed).
- [x] `make lint` and `make update` pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where placeholder patterns contained within replacement values were incorrectly being re-substituted, ensuring single-pass substitution behavior.

* **Tests**
  * Added test cases to verify placeholder patterns in replacement values are not re-substituted.
  * Added test case for empty replacement scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/107)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->