### PR TITLE
fix: surface rule exceptions in LintTool instead of swallowing them

### DIFF
--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -178,8 +178,8 @@ class LintTool:
                 violations.extend(
                     v for v in rule_violations if v.file_path and v.file_path.resolve() == resolved
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                return f"Error running lint: {e}"
 
         if not violations:
             return "No violations found."

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -179,7 +179,7 @@ class LintTool:
                     v for v in rule_violations if v.file_path and v.file_path.resolve() == resolved
                 )
             except Exception as e:
-                return f"Error running lint: {e}"
+                return f"Error running lint ({rule.rule_id}): {e}"
 
         if not violations:
             return "No violations found."

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -611,6 +611,7 @@ class TestLintToolExceptionHandling:
         result = tool.execute(path="skill.md")
 
         assert "Error running lint" in result
+        assert "test/exploding" in result
         assert "kaboom" in result
 
     def test_rule_exception_not_swallowed_as_clean(self, tmp_path, monkeypatch):
@@ -646,4 +647,5 @@ class TestLintToolExceptionHandling:
 
         assert result != "No violations found."
         assert "Error running lint" in result
+        assert "test/broken" in result
         assert "something went wrong" in result

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -14,8 +14,9 @@ from skillsaw.llm.tools import (
     WriteFileTool,
     ReplaceSectionTool,
     DiffTool,
+    LintTool,
 )
-from skillsaw.rule import AutofixConfidence
+from skillsaw.rule import AutofixConfidence, Severity
 
 
 class FakeProvider:
@@ -571,3 +572,78 @@ class TestLintToolExcludePatterns:
         tool_excluded = LintTool(tmp_path, config_excluded, rule_ids={"agentskill-valid"})
         result_excluded = tool_excluded.execute(path="my-skill/SKILL.md")
         assert result_excluded == "No violations found."
+
+
+class TestLintToolExceptionHandling:
+    """LintTool.execute must surface rule exceptions, not swallow them."""
+
+    def test_rule_exception_is_reported(self, tmp_path, monkeypatch):
+        """When a rule's check() raises, the error must be returned to the LLM."""
+        from skillsaw.config import LinterConfig
+        from skillsaw.rule import Rule
+        from skillsaw.context import RepositoryContext
+
+        class ExplodingRule(Rule):
+            rule_id = "test/exploding"
+            name = "Exploding Rule"
+            description = "Always raises"
+
+            def default_severity(self):
+                return Severity.ERROR
+
+            def check(self, context: RepositoryContext):
+                raise RuntimeError("kaboom")
+
+        # Create a minimal file to lint
+        target = tmp_path / "skill.md"
+        target.write_text("---\ntitle: test\n---\n", encoding="utf-8")
+
+        config_file = tmp_path / ".skillsaw.yaml"
+        config_file.write_text("rules: {}\n", encoding="utf-8")
+        config = LinterConfig.from_file(config_file)
+
+        # Patch BUILTIN_RULES so only our exploding rule runs
+        import skillsaw.rules.builtin as builtin_mod
+
+        monkeypatch.setattr(builtin_mod, "BUILTIN_RULES", [ExplodingRule])
+
+        tool = LintTool(tmp_path, config)
+        result = tool.execute(path="skill.md")
+
+        assert "Error running lint" in result
+        assert "kaboom" in result
+
+    def test_rule_exception_not_swallowed_as_clean(self, tmp_path, monkeypatch):
+        """Verify the result is NOT 'No violations found' when a rule crashes."""
+        from skillsaw.config import LinterConfig
+        from skillsaw.rule import Rule
+        from skillsaw.context import RepositoryContext
+
+        class BrokenRule(Rule):
+            rule_id = "test/broken"
+            name = "Broken Rule"
+            description = "Always raises ValueError"
+
+            def default_severity(self):
+                return Severity.ERROR
+
+            def check(self, context: RepositoryContext):
+                raise ValueError("something went wrong")
+
+        target = tmp_path / "skill.md"
+        target.write_text("---\ntitle: test\n---\n", encoding="utf-8")
+
+        config_file = tmp_path / ".skillsaw.yaml"
+        config_file.write_text("rules: {}\n", encoding="utf-8")
+        config = LinterConfig.from_file(config_file)
+
+        import skillsaw.rules.builtin as builtin_mod
+
+        monkeypatch.setattr(builtin_mod, "BUILTIN_RULES", [BrokenRule])
+
+        tool = LintTool(tmp_path, config)
+        result = tool.execute(path="skill.md")
+
+        assert result != "No violations found."
+        assert "Error running lint" in result
+        assert "something went wrong" in result


### PR DESCRIPTION
## Summary

- `LintTool.execute()` had `except Exception: pass` that silently swallowed rule crashes, causing the LLM to receive "No violations found" and terminate the autofix loop on false success
- Changed to `except Exception as e: return f"Error running lint: {e}"` so the LLM gets actionable error feedback
- Added two tests verifying that exceptions are surfaced and not reported as clean lint results

## Test plan

- [x] `make test` -- all 839 tests pass (including 2 new ones)
- [x] `make lint` -- clean
- [x] `make update` -- no changes to generated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Linting now reports errors encountered while running rules instead of silently failing, showing clear error messages when a rule raises an exception.
  * Improved error handling prevents failures from appearing as successful scans with no violations.

* **Tests**
  * Added tests to verify rule exceptions are reported to users rather than suppressed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/108)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->