### PR TITLE
fix: escape pipe chars and newlines in PR summary table

### DIFF
--- a/action/review.py
+++ b/action/review.py
@@ -137,7 +137,7 @@ def build_summary_body(non_diff_violations):
         path = v.get("file_path", "")
         line = v.get("line")
         loc = f"`{path}:{line}`" if line else f"`{path}`"
-        msg = v['message'].replace('|', '\\|').replace('\n', ' ')
+        msg = " ".join(v["message"].splitlines()).replace("|", r"\|")
         lines.append(f"| {icon} {v['severity']} | `{v['rule_id']}` | {loc} | {msg} |")
     lines.append(f"\n{SUMMARY_MARKER}")
     return "\n".join(lines)

--- a/action/review.py
+++ b/action/review.py
@@ -127,6 +127,22 @@ def sync_comments(repo, pr_number, new_comments):
     return [c for c in new_comments if c["fingerprint"] not in existing]
 
 
+def build_summary_body(non_diff_violations):
+    """Build the markdown table body for violations outside the diff."""
+    lines = ["### skillsaw: additional violations\n"]
+    lines.append("| Severity | Rule | File | Message |")
+    lines.append("|----------|------|------|---------|")
+    for v in non_diff_violations:
+        icon = SEVERITY_ICONS.get(v["severity"], "")
+        path = v.get("file_path", "")
+        line = v.get("line")
+        loc = f"`{path}:{line}`" if line else f"`{path}`"
+        msg = v['message'].replace('|', '\\|').replace('\n', ' ')
+        lines.append(f"| {icon} {v['severity']} | `{v['rule_id']}` | {loc} | {msg} |")
+    lines.append(f"\n{SUMMARY_MARKER}")
+    return "\n".join(lines)
+
+
 def upsert_summary_comment(repo, pr_number, non_diff_violations):
     """Create or update a single issue comment for violations outside the diff."""
     page = 1
@@ -152,17 +168,7 @@ def upsert_summary_comment(repo, pr_number, non_diff_violations):
     if not non_diff_violations:
         return
 
-    lines = ["### skillsaw: additional violations\n"]
-    lines.append("| Severity | Rule | File | Message |")
-    lines.append("|----------|------|------|---------|")
-    for v in non_diff_violations:
-        icon = SEVERITY_ICONS.get(v["severity"], "")
-        path = v.get("file_path", "")
-        line = v.get("line")
-        loc = f"`{path}:{line}`" if line else f"`{path}`"
-        lines.append(f"| {icon} {v['severity']} | `{v['rule_id']}` | {loc} | {v['message']} |")
-    lines.append(f"\n{SUMMARY_MARKER}")
-    body = "\n".join(lines)
+    body = build_summary_body(non_diff_violations)
 
     if existing_id:
         github_api("PATCH", f"/repos/{repo}/issues/comments/{existing_id}", {"body": body})

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -68,6 +68,21 @@ class TestSummaryBodyEscaping:
         body = build_summary_body(violations)
         assert "Simple message" in body
 
+    def test_crlf_in_message_is_normalized(self):
+        violations = [
+            {
+                "severity": "error",
+                "rule_id": "test-rule",
+                "file_path": "crlf.py",
+                "line": 1,
+                "message": "line one\r\nline two\rline three",
+            }
+        ]
+        body = build_summary_body(violations)
+        rows = _table_data_rows(body)
+        assert len(rows) == 1
+        assert "line one line two line three" in rows[0]
+
     def test_multiple_pipes_all_escaped(self):
         violations = [
             {

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,88 @@
+"""Tests for action/review.py — GitHub PR summary comment generation."""
+
+import re
+import sys
+import os
+
+# Ensure action/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "action"))
+
+from review import build_summary_body
+
+
+def _table_data_rows(body):
+    """Return only the data rows of the markdown table (skip header and separator)."""
+    return [
+        line
+        for line in body.splitlines()
+        if line.startswith("|") and "---" not in line and "Severity" not in line
+    ]
+
+
+class TestSummaryBodyEscaping:
+    """Pipe characters and newlines in violation messages must be escaped."""
+
+    def test_pipe_in_message_does_not_add_extra_columns(self):
+        violations = [
+            {
+                "severity": "error",
+                "rule_id": "test-rule",
+                "file_path": "foo.py",
+                "line": 1,
+                "message": "Use A | B for the union",
+            }
+        ]
+        body = build_summary_body(violations)
+        rows = _table_data_rows(body)
+        assert len(rows) == 1
+        # Unescaped pipes form column boundaries; escaped ones (\|) do not.
+        cols = re.split(r"(?<!\\)\|", rows[0])
+        # Leading empty + 4 data cells + trailing empty = 6 parts
+        assert len(cols) == 6, f"Expected 6 pipe-delimited parts, got {len(cols)}: {rows[0]}"
+
+    def test_newline_in_message_is_replaced_with_space(self):
+        violations = [
+            {
+                "severity": "warning",
+                "rule_id": "test-rule",
+                "file_path": "bar.py",
+                "line": None,
+                "message": "first line\nsecond line",
+            }
+        ]
+        body = build_summary_body(violations)
+        rows = _table_data_rows(body)
+        assert len(rows) == 1
+        assert "first line second line" in rows[0]
+
+    def test_message_without_special_chars_unchanged(self):
+        violations = [
+            {
+                "severity": "info",
+                "rule_id": "test-rule",
+                "file_path": "baz.py",
+                "line": 5,
+                "message": "Simple message",
+            }
+        ]
+        body = build_summary_body(violations)
+        assert "Simple message" in body
+
+    def test_multiple_pipes_all_escaped(self):
+        violations = [
+            {
+                "severity": "error",
+                "rule_id": "test-rule",
+                "file_path": "x.py",
+                "line": 1,
+                "message": "a|b|c",
+            }
+        ]
+        body = build_summary_body(violations)
+        rows = _table_data_rows(body)
+        assert len(rows) == 1
+        # The message cell should contain escaped pipes
+        assert r"a\|b\|c" in rows[0]
+        # And the row should still have exactly 6 pipe-delimited parts
+        cols = re.split(r"(?<!\\)\|", rows[0])
+        assert len(cols) == 6


### PR DESCRIPTION
## Summary
- Violation messages containing `|` or newlines were interpolated directly into the GitHub PR summary markdown table, corrupting column alignment
- Escape `|` as `\|` and replace newlines with spaces before interpolation in `action/review.py`
- Extract `build_summary_body()` as a standalone function for testability
- Add `tests/test_review.py` with tests verifying pipe and newline escaping

## Test plan
- [x] `make test` passes (841 passed)
- [x] `make lint` passes
- [x] `make update` produces no changes
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown formatting of violation summary comments to properly handle special characters (pipes and newlines) in violation messages, preventing malformed table layouts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->