### PR TITLE
fix: LintTool now applies exclude_patterns from config

### DIFF
--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -139,6 +139,8 @@ class LintTool:
         invalidate_read_caches()
         context = RepositoryContext(self._root)
         context.content_paths = self._config.content_paths
+        context.exclude_patterns = self._config.exclude_patterns
+        context.apply_excludes()
 
         violations = []
         for rule_class in BUILTIN_RULES:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -338,3 +338,39 @@ class TestLLMFixResult:
             success=False,
         )
         assert result.violations_fixed == 0
+
+
+class TestLintToolExcludePatterns:
+    """LintTool must honour config exclude_patterns."""
+
+    def _make_skill(self, tmp_path):
+        """Create a skill with a missing 'name' field so agentskill-valid fires."""
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(
+            "---\ndescription: a test skill\n---\n# My Skill\nDoes things.\n",
+            encoding="utf-8",
+        )
+        return skill_md
+
+    def test_lint_tool_respects_exclude_patterns(self, tmp_path):
+        from skillsaw.config import LinterConfig
+        from skillsaw.llm.tools import LintTool
+
+        skill_md = self._make_skill(tmp_path)
+
+        # Config with no excludes — the rule should fire.
+        config_no_exclude = LinterConfig.default()
+        config_no_exclude.version = "999.0.0"
+        tool_no_exclude = LintTool(tmp_path, config_no_exclude, rule_ids={"agentskill-valid"})
+        result_no_exclude = tool_no_exclude.execute(path="my-skill/SKILL.md")
+        assert "Missing required 'name' field" in result_no_exclude
+
+        # Config with an exclude pattern covering the skill directory.
+        config_excluded = LinterConfig.default()
+        config_excluded.version = "999.0.0"
+        config_excluded.exclude_patterns = ["my-skill"]
+        tool_excluded = LintTool(tmp_path, config_excluded, rule_ids={"agentskill-valid"})
+        result_excluded = tool_excluded.execute(path="my-skill/SKILL.md")
+        assert result_excluded == "No violations found."


### PR DESCRIPTION
## Summary

- `LintTool` created a fresh `RepositoryContext` and copied `content_paths` but never set `exclude_patterns` or called `apply_excludes()`, causing the LLM autofix engine to lint files the user explicitly excluded.
- Added `context.exclude_patterns = self._config.exclude_patterns` and `context.apply_excludes()` after line 141 in `src/skillsaw/llm/tools.py`, matching the pattern used in `Linter.__init__`.
- Added a test that verifies `LintTool` suppresses violations for excluded skill directories.

## Test plan

- [x] New test `TestLintToolExcludePatterns::test_lint_tool_respects_exclude_patterns` confirms violations fire without excludes and are suppressed with excludes
- [x] `make test` passes (838 passed, 14 skipped)
- [x] `make lint` passes
- [x] `make update` regenerated files with no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)