### PR TITLE
fix: handle null rules key in config

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -41,9 +41,9 @@ class LinterConfig:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
         return cls(
-            rules=data.get("rules", {}),
-            custom_rules=data.get("custom-rules", []),
-            exclude_patterns=data.get("exclude", []),
+            rules=data.get("rules") or {},
+            custom_rules=data.get("custom-rules") or [],
+            exclude_patterns=data.get("exclude") or [],
             strict=data.get("strict", False),
         )
 

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -40,11 +40,21 @@ class LinterConfig:
         except (yaml.YAMLError, IOError) as e:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Failed to load config from {config_path}: "
+                f"expected a YAML mapping, got {type(data).__name__}"
+            )
+
+        raw_rules = data.get("rules") or {}
+        # Sanitize individual rule values: null entries become empty dicts
+        rules = {k: v if isinstance(v, dict) else {} for k, v in raw_rules.items()}
+
         return cls(
-            rules=data.get("rules") or {},
+            rules=rules,
             custom_rules=data.get("custom-rules") or [],
             exclude_patterns=data.get("exclude") or [],
-            strict=data.get("strict", False),
+            strict=bool(data.get("strict", False)),
         )
 
     @classmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,3 +172,31 @@ def test_auto_without_repo_types_always_enabled(valid_plugin):
     config = LinterConfig.default()
     context = RepositoryContext(valid_plugin)
     assert config.is_rule_enabled("some-rule", context, None) is True
+
+
+def test_config_null_rules_key(temp_dir):
+    """Test that a config with rules: null or bare rules: does not crash"""
+    # Explicit YAML null
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules: null\n")
+    config = LinterConfig.from_file(config_file)
+    assert config.rules == {}
+    # Ensure downstream methods work without AttributeError
+    rule_config = config.get_rule_config("plugin-json-required")
+    assert rule_config["enabled"] == "auto"
+
+    # Bare key (also YAML null)
+    config_file.write_text("rules:\n")
+    config = LinterConfig.from_file(config_file)
+    assert config.rules == {}
+    rule_config = config.get_rule_config("plugin-json-required")
+    assert rule_config["enabled"] == "auto"
+
+
+def test_config_null_custom_rules_and_exclude(temp_dir):
+    """Test that null custom-rules and exclude keys do not crash"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("custom-rules: null\nexclude: null\n")
+    config = LinterConfig.from_file(config_file)
+    assert config.custom_rules == []
+    assert config.exclude_patterns == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -200,3 +200,33 @@ def test_config_null_custom_rules_and_exclude(temp_dir):
     config = LinterConfig.from_file(config_file)
     assert config.custom_rules == []
     assert config.exclude_patterns == []
+
+
+def test_config_null_individual_rule_value(temp_dir):
+    """Test that a rule set to null (e.g. 'some-rule: null') does not crash"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\n  plugin-json-required: null\n")
+    config = LinterConfig.from_file(config_file)
+    # The null value should be sanitized to an empty dict
+    assert config.rules["plugin-json-required"] == {}
+    # get_rule_config should still merge defaults without crashing
+    rule_config = config.get_rule_config("plugin-json-required")
+    assert rule_config["enabled"] == "auto"
+
+
+def test_config_null_strict_key(temp_dir):
+    """Test that strict: null resolves to False, not None"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("strict: null\n")
+    config = LinterConfig.from_file(config_file)
+    assert config.strict is False
+
+
+def test_config_non_dict_top_level(temp_dir):
+    """Test that a non-mapping YAML top level raises ValueError"""
+    import pytest
+
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("[1, 2, 3]\n")
+    with pytest.raises(ValueError, match="expected a YAML mapping"):
+        LinterConfig.from_file(config_file)


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'NoneType' object has no attribute 'get'` crash when config YAML has `rules:` with no value (YAML null) or `rules: null`
- Same fix applied to `custom-rules` and `exclude` keys which had the identical vulnerability
- Changed `data.get("rules", {})` to `data.get("rules") or {}` so falsy values (None) are coalesced to empty dict/list

## Test plan
- [x] Added test for `rules: null` and bare `rules:` — verifies no crash and downstream methods work
- [x] Added test for `custom-rules: null` and `exclude: null` — verifies empty list fallback
- [x] All 466 existing tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing to handle empty/null values for rules, custom-rules, exclude, and strict—applying sensible defaults (e.g., treating null/empty rules as empty sets and strict:null as false) and returning a clear error when the YAML top-level is not a mapping.
* **Tests**
  * Added coverage verifying robust handling of null/empty config entries and the non-mapping YAML error.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/113)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->