### PR TITLE
Fix crash when rule config value is null in YAML

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -125,7 +125,7 @@ class LinterConfig:
             Rule configuration dict
         """
         defaults = self.default().rules.get(rule_id, {})
-        overrides = self.rules.get(rule_id, {})
+        overrides = self.rules.get(rule_id, {}) or {}
         merged = {**defaults, **overrides}
         return merged
 

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -41,9 +41,9 @@ class LinterConfig:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
         return cls(
-            rules=data.get("rules", {}),
-            custom_rules=data.get("custom-rules", []),
-            exclude_patterns=data.get("exclude", []),
+            rules=data.get("rules") or {},
+            custom_rules=data.get("custom-rules") or [],
+            exclude_patterns=data.get("exclude") or [],
             strict=data.get("strict", False),
         )
 
@@ -125,7 +125,10 @@ class LinterConfig:
             Rule configuration dict
         """
         defaults = self.default().rules.get(rule_id, {})
-        overrides = self.rules.get(rule_id, {}) or {}
+        rules = self.rules if isinstance(self.rules, dict) else {}
+        overrides = rules.get(rule_id)
+        if not isinstance(overrides, dict):
+            overrides = {}
         merged = {**defaults, **overrides}
         return merged
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,3 +205,36 @@ def test_from_file_with_null_rule_value(temp_dir):
     result = config.get_rule_config("plugin-json-required")
     assert result["enabled"] == "auto"
     assert result["severity"] == "error"
+
+
+def test_from_file_with_null_rules_key(temp_dir):
+    """Test loading a config file where the top-level rules key is null"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    # YAML 'rules:' with no content parses as rules=None
+    config_file.write_text("rules:\n")
+
+    config = LinterConfig.from_file(config_file)
+    # rules should be normalized to empty dict by from_file
+    assert config.rules == {}
+    # get_rule_config should return defaults without crashing
+    result = config.get_rule_config("plugin-json-required")
+    assert result["enabled"] == "auto"
+    assert result["severity"] == "error"
+
+
+def test_get_rule_config_with_null_rules_attr():
+    """Test that get_rule_config handles self.rules being None"""
+    config = LinterConfig(rules=None)
+    # Should not raise AttributeError
+    result = config.get_rule_config("plugin-json-required")
+    assert result["enabled"] == "auto"
+    assert result["severity"] == "error"
+
+
+def test_get_rule_config_with_scalar_rule_value():
+    """Test that get_rule_config handles a scalar (non-dict) rule value"""
+    config = LinterConfig(rules={"plugin-json-required": True})
+    # A boolean value should be treated as non-dict and fall back to defaults
+    result = config.get_rule_config("plugin-json-required")
+    assert result["enabled"] == "auto"
+    assert result["severity"] == "error"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,3 +172,36 @@ def test_auto_without_repo_types_always_enabled(valid_plugin):
     config = LinterConfig.default()
     context = RepositoryContext(valid_plugin)
     assert config.is_rule_enabled("some-rule", context, None) is True
+
+
+def test_get_rule_config_with_null_value():
+    """Test that get_rule_config handles None rule values (YAML key with no value)"""
+    config = LinterConfig(rules={"plugin-json-required": None})
+    result = config.get_rule_config("plugin-json-required")
+    # Should fall back to defaults instead of crashing
+    assert result["enabled"] == "auto"
+    assert result["severity"] == "error"
+
+
+def test_is_rule_enabled_with_null_value(valid_plugin):
+    """Test that is_rule_enabled handles None rule values (YAML key with no value)"""
+    config = LinterConfig(rules={"plugin-json-required": None})
+    context = RepositoryContext(valid_plugin)
+    # Should not raise TypeError; the rule should use its default config
+    enabled = config.is_rule_enabled(
+        "plugin-json-required", context, {RepositoryType.SINGLE_PLUGIN}
+    )
+    assert enabled is True
+
+
+def test_from_file_with_null_rule_value(temp_dir):
+    """Test loading a config file where a rule key has no value"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    # This YAML has a rule key with no value, which parses as None
+    config_file.write_text("rules:\n  plugin-json-required:\n")
+
+    config = LinterConfig.from_file(config_file)
+    # get_rule_config should not crash
+    result = config.get_rule_config("plugin-json-required")
+    assert result["enabled"] == "auto"
+    assert result["severity"] == "error"


### PR DESCRIPTION
## Summary
- When a user writes a rule key with no value in `.skillsaw.yaml` (e.g. `plugin-json-required:` with nothing after the colon), YAML parses it as `None`, causing `TypeError` crashes in both `get_rule_config` and `is_rule_enabled`
- Added `or {}` guard on the overrides lookup so null values fall back to defaults gracefully
- Added three tests covering: `get_rule_config` with None, `is_rule_enabled` with None, and loading a config file with a null rule value

## Test plan
- [x] `make test` passes (467 tests)
- [x] `make lint` passes
- [x] New tests verify both crash paths are fixed and that config files with null rule values load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null or empty rule configurations to properly fall back to default values instead of causing merge errors.

* **Tests**
  * Added comprehensive test coverage for null rule configuration scenarios, including configuration file loading and rule enablement validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->