### PR TITLE
Fix invalid version strings crashing _parse_version

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -3,6 +3,7 @@ Configuration management for skillsaw
 """
 
 import os
+import re
 
 import yaml
 from pathlib import Path
@@ -13,10 +14,6 @@ if TYPE_CHECKING:
     from .context import RepositoryContext
 
 _DEFAULT_VERSION = "0.6.0"
-
-
-def _parse_version(v: str) -> Tuple[int, ...]:
-    return tuple(int(x) for x in v.split("."))
 
 
 @dataclass
@@ -31,6 +28,30 @@ class LLMSettings:
         env_model = os.environ.get("SKILLSAW_MODEL")
         if env_model:
             self.model = env_model
+
+
+def _parse_version(v: str) -> Tuple[int, ...]:
+    """Parse a version string like '1.2.3' into a tuple of ints.
+
+    Strips a leading 'v'/'V' prefix and ignores pre-release suffixes
+    (e.g. '-beta', '-rc1').  Raises :class:`ValueError` with a
+    human-readable message when the string cannot be parsed.
+    """
+    original = v
+    v = v.strip()
+    # Strip optional leading 'v' or 'V'
+    v = re.sub(r"^[vV]", "", v)
+    # Strip pre-release / build-metadata suffix (everything from the first
+    # hyphen or plus onward, per semver)
+    v = re.split(r"[-+]", v, maxsplit=1)[0]
+    parts = v.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError as err:
+        raise ValueError(
+            f"Invalid version string '{original}': expected a numeric "
+            f"version like '1.0.0', got non-numeric component"
+        ) from err
 
 
 @dataclass

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -3,7 +3,6 @@ Configuration management for skillsaw
 """
 
 import os
-import re
 
 import yaml
 from pathlib import Path
@@ -30,28 +29,7 @@ class LLMSettings:
             self.model = env_model
 
 
-def _parse_version(v: str) -> Tuple[int, ...]:
-    """Parse a version string like '1.2.3' into a tuple of ints.
-
-    Strips a leading 'v'/'V' prefix and ignores pre-release suffixes
-    (e.g. '-beta', '-rc1').  Raises :class:`ValueError` with a
-    human-readable message when the string cannot be parsed.
-    """
-    original = v
-    v = v.strip()
-    # Strip optional leading 'v' or 'V'
-    v = re.sub(r"^[vV]", "", v)
-    # Strip pre-release / build-metadata suffix (everything from the first
-    # hyphen or plus onward, per semver)
-    v = re.split(r"[-+]", v, maxsplit=1)[0]
-    parts = v.split(".")
-    try:
-        return tuple(int(p) for p in parts)
-    except ValueError as err:
-        raise ValueError(
-            f"Invalid version string '{original}': expected a numeric "
-            f"version like '1.0.0', got non-numeric component"
-        ) from err
+from skillsaw.version import parse_version as _parse_version
 
 
 @dataclass

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -8,6 +8,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.rules.builtin.utils import read_json
+from skillsaw.version import is_valid_semver
 from skillsaw.context import RepositoryContext, RepositoryType
 
 PLUGIN_REPO_TYPES = {RepositoryType.SINGLE_PLUGIN, RepositoryType.MARKETPLACE}
@@ -117,9 +118,7 @@ class PluginJsonValidRule(Rule):
             # Validate version format (semver)
             if "version" in data:
                 version = data["version"]
-                if not re.match(
-                    r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$", str(version)
-                ):
+                if not is_valid_semver(version):
                     violations.append(
                         self.violation(
                             f"Version '{version}' should follow semver (X.Y.Z)",

--- a/src/skillsaw/version.py
+++ b/src/skillsaw/version.py
@@ -1,0 +1,30 @@
+"""Version string parsing utilities."""
+
+import re
+from typing import Tuple
+
+
+def parse_version(v: str) -> Tuple[int, ...]:
+    """Parse a version string like '1.2.3' into a tuple of ints.
+
+    Strips a leading 'v'/'V' prefix and ignores pre-release suffixes
+    (e.g. '-beta', '-rc1').  Raises :class:`ValueError` with a
+    human-readable message when the string cannot be parsed.
+    """
+    original = v
+    v = v.strip()
+    v = re.sub(r"^[vV]", "", v)
+    v = re.split(r"[-+]", v, maxsplit=1)[0]
+    parts = v.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError as err:
+        raise ValueError(
+            f"Invalid version string '{original}': expected a numeric "
+            f"version like '1.0.0', got non-numeric component"
+        ) from err
+
+
+def is_valid_semver(v: str) -> bool:
+    """Check if a string is a valid semver version (X.Y.Z with optional pre-release/build)."""
+    return bool(re.match(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$", str(v)))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,11 @@ Tests for configuration management
 
 import sys
 from pathlib import Path
+import pytest
 import yaml
 
 
-from skillsaw.config import LinterConfig, find_config
+from skillsaw.config import LinterConfig, find_config, _parse_version
 from skillsaw.context import (
     RepositoryContext,
     RepositoryType,
@@ -734,3 +735,53 @@ def test_severity_override_on_auto_rule_still_fires_when_matching(marketplace_re
         config.is_rule_enabled("marketplace-registration", context, {RepositoryType.MARKETPLACE})
         is True
     )
+
+
+class TestParseVersion:
+    """Tests for _parse_version()"""
+
+    def test_simple_semver(self):
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_two_part_version(self):
+        assert _parse_version("1.0") == (1, 0)
+
+    def test_single_number(self):
+        assert _parse_version("5") == (5,)
+
+    def test_strips_v_prefix(self):
+        assert _parse_version("v1.0.0") == (1, 0, 0)
+
+    def test_strips_uppercase_v_prefix(self):
+        assert _parse_version("V2.3.4") == (2, 3, 4)
+
+    def test_strips_prerelease_suffix(self):
+        assert _parse_version("1.0.0-beta") == (1, 0, 0)
+
+    def test_strips_prerelease_rc(self):
+        assert _parse_version("1.0.0-rc1") == (1, 0, 0)
+
+    def test_strips_build_metadata(self):
+        assert _parse_version("1.0.0+build.123") == (1, 0, 0)
+
+    def test_v_prefix_with_prerelease(self):
+        assert _parse_version("v1.0.0-alpha") == (1, 0, 0)
+
+    def test_whitespace_stripped(self):
+        assert _parse_version("  1.2.3  ") == (1, 2, 3)
+
+    def test_non_numeric_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid version string 'latest'"):
+            _parse_version("latest")
+
+    def test_empty_string_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid version string"):
+            _parse_version("")
+
+    def test_garbage_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid version string"):
+            _parse_version("abc.def.ghi")
+
+    def test_partial_numeric_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid version string"):
+            _parse_version("1.2.x")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,8 @@ import pytest
 import yaml
 
 
-from skillsaw.config import LinterConfig, find_config, _parse_version
+from skillsaw.config import LinterConfig, find_config
+from skillsaw.version import parse_version as _parse_version
 from skillsaw.context import (
     RepositoryContext,
     RepositoryType,


### PR DESCRIPTION
## Summary
- Add `_parse_version()` to `config.py` with proper input validation
- Strips leading `v`/`V` prefix (e.g., `v1.0.0` -> `(1, 0, 0)`)
- Ignores pre-release and build-metadata suffixes (e.g., `1.0.0-beta`, `1.0.0+build.123`)
- Raises a clear `ValueError` with the original input for non-numeric strings (e.g., `latest`, `abc.def`) instead of propagating an opaque `int()` traceback

## Test plan
- [x] `make test` passes (478 tests, including 14 new tests for `_parse_version`)
- [x] `make lint` passes
- [x] Tests cover: simple semver, two-part versions, single numbers, v-prefix stripping, pre-release/build suffix stripping, whitespace handling, and error cases (non-numeric, empty, garbage, partial-numeric inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for many version string formats (semver, v/V prefixes, pre-release/build metadata, whitespace) and error cases.

* **Chores**
  * Centralized and improved version-string normalization and validation for more consistent parsing and clearer error messages.

* **Bug Fixes**
  * Version validation for plugin metadata now relies on the standardized semver check, reducing false positives.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/115)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->