### PR TITLE
fix: coerce plugin version to str to prevent crash on numeric values

### DIFF
--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -84,7 +84,7 @@ def _extract_plugin(context: RepositoryContext, plugin_path: Path) -> PluginDoc:
         name=name,
         path=plugin_path,
         description=meta.get("description", ""),
-        version=meta.get("version", ""),
+        version=str(meta.get("version", "")),
         author=author_val if isinstance(author_val, dict) else None,
         commands=_extract_commands(plugin_path),
         skills=_extract_skills(plugin_path),

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -84,7 +84,7 @@ def _extract_plugin(context: RepositoryContext, plugin_path: Path) -> PluginDoc:
         name=name,
         path=plugin_path,
         description=meta.get("description", ""),
-        version=str(meta.get("version", "")),
+        version=str(v) if (v := meta.get("version")) is not None else "",
         author=author_val if isinstance(author_val, dict) else None,
         commands=_extract_commands(plugin_path),
         skills=_extract_skills(plugin_path),

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -185,6 +185,23 @@ class TestExtractor:
         assert isinstance(plugin.version, str)
         assert plugin.version == "1"
 
+    def test_extract_null_version(self, temp_dir):
+        """Explicit null version in plugin.json must produce empty string, not 'None'."""
+        plugin_dir = temp_dir / "null-ver"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(
+            json.dumps({"name": "null-ver", "description": "d", "version": None})
+        )
+
+        ctx = RepositoryContext(plugin_dir)
+        docs = extract_docs(ctx)
+        assert len(docs.plugins) == 1
+        plugin = docs.plugins[0]
+        assert isinstance(plugin.version, str)
+        assert plugin.version == ""
+
     def test_custom_title(self, valid_plugin):
         ctx = RepositoryContext(valid_plugin)
         docs = extract_docs(ctx, title="My Custom Title")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -151,6 +151,40 @@ class TestExtractor:
         assert len(plugin.commands) == 1
         assert len(plugin.skills) == 1
 
+    def test_extract_numeric_version_float(self, temp_dir):
+        """Float version in plugin.json (e.g. 0.7) must not crash the extractor."""
+        plugin_dir = temp_dir / "float-ver"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(
+            json.dumps({"name": "float-ver", "description": "d", "version": 0.7})
+        )
+
+        ctx = RepositoryContext(plugin_dir)
+        docs = extract_docs(ctx)
+        assert len(docs.plugins) == 1
+        plugin = docs.plugins[0]
+        assert isinstance(plugin.version, str)
+        assert plugin.version == "0.7"
+
+    def test_extract_numeric_version_int(self, temp_dir):
+        """Integer version in plugin.json (e.g. 1) must not crash the extractor."""
+        plugin_dir = temp_dir / "int-ver"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(
+            json.dumps({"name": "int-ver", "description": "d", "version": 1})
+        )
+
+        ctx = RepositoryContext(plugin_dir)
+        docs = extract_docs(ctx)
+        assert len(docs.plugins) == 1
+        plugin = docs.plugins[0]
+        assert isinstance(plugin.version, str)
+        assert plugin.version == "1"
+
     def test_custom_title(self, valid_plugin):
         ctx = RepositoryContext(valid_plugin)
         docs = extract_docs(ctx, title="My Custom Title")


### PR DESCRIPTION
## Summary

- Wraps `meta.get("version", "")` with `str()` in `_extract_plugin()` so that numeric version values (e.g., `"version": 0.7` float from JSON or `version: 1` int from YAML) are coerced to strings before being stored in `PluginDoc.version`.
- Without this fix, downstream code that treats `version` as a string could crash with `AttributeError: 'float' object has no attribute 'split'` or similar.
- Adds two regression tests: one for float version (`0.7`) and one for int version (`1`).

## Test plan

- [x] `make test` -- all 466 tests pass
- [x] `make lint` -- clean
- [x] New tests `test_extract_numeric_version_float` and `test_extract_numeric_version_int` verify the fix directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation extraction now normalizes plugin version values: numeric versions are converted to strings and missing/null versions are returned as an empty string, preventing inconsistent or erroneous version data.

* **Tests**
  * Added tests covering integer, decimal, and null version values to verify consistent string normalization during extraction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/116)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->