### PR TITLE
fix: dry-run LLM fix exits 0 when changes don't improve

### DIFF
--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -674,6 +674,9 @@ def _run_fix(args):
         _teardown_scroll_region()
 
     if not result.success:
+        if dry_run:
+            print(f"\n{c['yellow']}LLM fix would not improve violations.{c['reset']}")
+            sys.exit(0)
         print(f"\n{c['red']}LLM fix did not improve violations" f" — changes reverted.{c['reset']}")
         sys.exit(1)
 

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -417,10 +417,13 @@ class TestLLMFixDryRun:
         assert len(result.files_modified) == 0
         assert len(result.diffs) > 0 or result.violations_before > 0
 
-    def test_dry_run_rollback_not_failure(self, tmp_path):
-        """Dry-run with LLM changes that don't improve violations should not
-        be treated as a fatal error by the CLI (gh issue: exit-code-1 in
-        dry-run when result.success is False)."""
+    def test_dry_run_rollback_preserves_original(self, tmp_path):
+        """Dry-run rollback when LLM changes don't improve violations.
+
+        Verifies linter-level behaviour: the original file is untouched,
+        result.success is False, and no files are recorded as modified.
+        The CLI wrapper (_run_fix) maps this to exit-code 0 for dry-run;
+        see src/skillsaw/__main__.py."""
         content = "# Instructions\n\nTry to be careful when deploying.\n"
         _make_dot_claude_repo(tmp_path, content)
 

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -417,6 +417,59 @@ class TestLLMFixDryRun:
         assert len(result.files_modified) == 0
         assert len(result.diffs) > 0 or result.violations_before > 0
 
+    def test_dry_run_rollback_not_failure(self, tmp_path):
+        """Dry-run with LLM changes that don't improve violations should not
+        be treated as a fatal error by the CLI (gh issue: exit-code-1 in
+        dry-run when result.success is False)."""
+        content = "# Instructions\n\nTry to be careful when deploying.\n"
+        _make_dot_claude_repo(tmp_path, content)
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        context = RepositoryContext(tmp_path)
+        linter = Linter(context, config)
+
+        # LLM produces worse content — rollback expected
+        worse_content = (
+            "# Instructions\n\nTry to be careful when deploying.\n"
+            "Consider using caution.\nIf possible, be careful.\n"
+        )
+        rel_path = "CLAUDE.md"
+        provider = FakeProvider(
+            [
+                CompletionResult(
+                    content=None,
+                    tool_calls=[ToolCall(id="1", name="read_file", arguments={"path": rel_path})],
+                    usage=TokenUsage(100, 20),
+                ),
+                CompletionResult(
+                    content=None,
+                    tool_calls=[
+                        ToolCall(
+                            id="2",
+                            name="write_file",
+                            arguments={"path": rel_path, "content": worse_content},
+                        )
+                    ],
+                    usage=TokenUsage(100, 50),
+                ),
+                CompletionResult(
+                    content="Done.",
+                    tool_calls=[],
+                    usage=TokenUsage(100, 20),
+                ),
+            ],
+        )
+
+        result = linter.llm_fix(provider, dry_run=True)
+        # Original file must be untouched
+        actual = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert actual == content
+        # result.success is False because no improvements were kept, but
+        # in dry-run the CLI should treat this as exit 0 (informational)
+        assert not result.success
+        assert len(result.files_modified) == 0
+
 
 class TestLLMFixScopedLinting:
     """Test that LintTool only runs relevant rules."""


### PR DESCRIPTION
## Summary

- In dry-run mode, when the LLM's proposed changes don't improve violations (`result.success` is `False`), the CLI now prints an informational yellow message ("LLM fix would not improve violations") and exits with code 0 instead of printing a misleading red "changes reverted" message and exiting with code 1.
- Added a test (`test_dry_run_rollback_not_failure`) that verifies the linter returns `success=False` with no files modified when dry-run changes are rolled back, documenting the scenario the CLI fix addresses.

## Test plan

- [x] `make test` passes (838 passed, 14 skipped)
- [x] `make lint` passes
- [x] New test `test_dry_run_rollback_not_failure` covers the dry-run rollback scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run mode now reports success and leaves files unchanged when an automated fix would not improve violations, instead of signalling failure.

* **Tests**
  * Added an integration test ensuring dry-run preserves original files and reports no successful fixes when proposed changes worsen content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/117)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->