### PR TITLE
Fix crash on invalid severity in rule config

### DIFF
--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -66,7 +66,7 @@ class Rule(ABC):
         else:
             try:
                 self._severity = Severity(severity_str)
-            except (ValueError, KeyError):
+            except (ValueError, TypeError):
                 valid = ", ".join(s.value for s in Severity)
                 raise ValueError(
                     f"Invalid severity '{severity_str}' for rule '{self.rule_id}'. "

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -66,12 +66,12 @@ class Rule(ABC):
         else:
             try:
                 self._severity = Severity(severity_str)
-            except (ValueError, TypeError):
+            except (ValueError, KeyError, TypeError) as err:
                 valid = ", ".join(s.value for s in Severity)
                 raise ValueError(
                     f"Invalid severity '{severity_str}' for rule '{self.rule_id}'. "
                     f"Valid values: {valid}"
-                )
+                ) from err
 
     @property
     @abstractmethod

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -61,7 +61,17 @@ class Rule(ABC):
 
         # Get severity from config or use default
         severity_str = self.config.get("severity", self.default_severity().value)
-        self._severity = Severity(severity_str)
+        if severity_str is None:
+            self._severity = self.default_severity()
+        else:
+            try:
+                self._severity = Severity(severity_str)
+            except (ValueError, KeyError):
+                valid = ", ".join(s.value for s in Severity)
+                raise ValueError(
+                    f"Invalid severity '{severity_str}' for rule '{self.rule_id}'. "
+                    f"Valid values: {valid}"
+                )
 
     @property
     @abstractmethod

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -455,6 +455,14 @@ def test_null_severity_uses_default():
     assert rule.severity == rule.default_severity()
 
 
+def test_unhashable_severity_raises_helpful_error():
+    """Test that an unhashable severity (list/dict) gives a helpful ValueError"""
+    import pytest
+
+    with pytest.raises(ValueError, match=r"Invalid severity.*Valid values:"):
+        PluginJsonRequiredRule({"severity": ["error", "warning"]})
+
+
 def test_valid_severity_override():
     """Test that a valid severity string overrides the default"""
     rule = PluginJsonRequiredRule({"severity": "warning"})

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -428,3 +428,34 @@ def test_marketplace_plugin_entry_valid(temp_dir):
     rule = MarketplaceJsonValidRule()
     violations = rule.check(context)
     assert len(violations) == 0
+
+
+# --- severity config validation ---
+
+
+def test_invalid_severity_string_raises_helpful_error():
+    """Test that an invalid severity string gives a helpful ValueError"""
+    import pytest
+
+    with pytest.raises(ValueError, match=r"Invalid severity 'critical'.*Valid values:"):
+        PluginJsonRequiredRule({"severity": "critical"})
+
+
+def test_invalid_severity_integer_raises_helpful_error():
+    """Test that an integer severity gives a helpful ValueError"""
+    import pytest
+
+    with pytest.raises(ValueError, match=r"Invalid severity '42'.*Valid values:"):
+        PluginJsonRequiredRule({"severity": 42})
+
+
+def test_null_severity_uses_default():
+    """Test that severity: null falls back to the rule's default severity"""
+    rule = PluginJsonRequiredRule({"severity": None})
+    assert rule.severity == rule.default_severity()
+
+
+def test_valid_severity_override():
+    """Test that a valid severity string overrides the default"""
+    rule = PluginJsonRequiredRule({"severity": "warning"})
+    assert rule.severity == Severity.WARNING


### PR DESCRIPTION
## Summary
- Invalid `severity` values in `.skillsaw.yaml` (e.g. `null`, `"critical"`, `42`) previously crashed the linter with an unhelpful `ValueError` traceback
- Now produces a clear error message listing valid values: `error`, `warning`, `info`
- `severity: null` gracefully falls back to the rule's default severity instead of crashing

## Test plan
- [x] Added test for invalid severity string (`"critical"`) -- raises helpful `ValueError`
- [x] Added test for invalid severity integer (`42`) -- raises helpful `ValueError`
- [x] Added test for `severity: null` -- falls back to default
- [x] Added test for valid severity override (`"warning"`) -- works as before
- [x] `make test` passes (468 tests)
- [x] `make lint` passes

Fixes the crash described in the bug report where `Severity(severity_str)` on `rule.py:64` propagated uncaught through `Linter.__init__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved severity configuration handling: invalid values now raise informative errors listing valid severity options; unspecified severity falls back to the rule's default.

* **Tests**
  * Added tests covering severity parsing, including invalid inputs (string, integer, unhashable), null/default behavior, and valid overrides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/118)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->