### PR TITLE
Fix crashes when JSON files contain null or non-dict values

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -516,7 +516,10 @@ class RepositoryContext:
         if not self.marketplace_data or "plugins" not in self.marketplace_data:
             return False
 
-        return any(p.get("name") == plugin_name for p in self.marketplace_data["plugins"])
+        return any(
+            isinstance(p, dict) and p.get("name") == plugin_name
+            for p in self.marketplace_data["plugins"]
+        )
 
     def get_plugin_metadata(self, plugin_path: Path) -> Optional[Dict[str, Any]]:
         """

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -453,7 +453,11 @@ class RepositoryContext:
         if not self.marketplace_data or "plugins" not in self.marketplace_data:
             return
 
-        for plugin_entry in self.marketplace_data["plugins"]:
+        marketplace_plugins = self.marketplace_data["plugins"]
+        if not isinstance(marketplace_plugins, list):
+            return
+
+        for plugin_entry in marketplace_plugins:
             if not isinstance(plugin_entry, dict):
                 continue
             source = plugin_entry.get("source")
@@ -516,10 +520,11 @@ class RepositoryContext:
         if not self.marketplace_data or "plugins" not in self.marketplace_data:
             return False
 
-        return any(
-            isinstance(p, dict) and p.get("name") == plugin_name
-            for p in self.marketplace_data["plugins"]
-        )
+        plugins = self.marketplace_data["plugins"]
+        if not isinstance(plugins, list):
+            return False
+
+        return any(isinstance(p, dict) and p.get("name") == plugin_name for p in plugins)
 
     def get_plugin_metadata(self, plugin_path: Path) -> Optional[Dict[str, Any]]:
         """

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -338,7 +338,6 @@ class McpProhibitedRule(Rule):
             if not isinstance(mcp_servers, dict):
                 return violations
 
-
             prohibited = self._get_prohibited_servers(mcp_servers, allowlist)
             if prohibited:
                 if allowlist:

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -338,6 +338,7 @@ class McpProhibitedRule(Rule):
             if not isinstance(mcp_servers, dict):
                 return violations
 
+
             prohibited = self._get_prohibited_servers(mcp_servers, allowlist)
             if prohibited:
                 if allowlist:

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -79,6 +79,9 @@ class McpValidJsonRule(Rule):
             # If plugin.json is invalid, plugin-json-valid rule will catch it
             return violations
 
+        if not isinstance(data, dict):
+            return violations
+
         # Only validate if mcpServers field exists
         if "mcpServers" not in data:
             return violations
@@ -293,7 +296,10 @@ class McpProhibitedRule(Rule):
         if error:
             return violations
 
-        servers = data.get("mcpServers", data) if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            return violations
+
+        servers = data.get("mcpServers", data)
         if not isinstance(servers, dict):
             return violations
 
@@ -324,8 +330,15 @@ class McpProhibitedRule(Rule):
         if error:
             return violations
 
+        if not isinstance(data, dict):
+            return violations
+
         if "mcpServers" in data:
-            prohibited = self._get_prohibited_servers(data["mcpServers"], allowlist)
+            mcp_servers = data["mcpServers"]
+            if not isinstance(mcp_servers, dict):
+                return violations
+
+            prohibited = self._get_prohibited_servers(mcp_servers, allowlist)
             if prohibited:
                 if allowlist:
                     violations.append(

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -89,6 +89,12 @@ class PluginJsonValidRule(Rule):
                 violations.append(self.violation(f"Invalid JSON: {error}", file_path=plugin_json))
                 continue
 
+            if not isinstance(data, dict):
+                violations.append(
+                    self.violation("Expected JSON object in plugin.json", file_path=plugin_json)
+                )
+                continue
+
             # Check required fields
             required_fields = ["name"]
             for field in required_fields:

--- a/tests/test_json_null_handling.py
+++ b/tests/test_json_null_handling.py
@@ -1,0 +1,185 @@
+"""
+Tests for handling JSON null and non-dict values in plugin files.
+
+Covers crash paths where read_json() returns (None, None) for valid JSON
+containing just ``null``, and where marketplace plugins list contains
+non-dict entries (e.g. bare strings).
+"""
+
+import json
+from pathlib import Path
+
+from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.plugin_structure import PluginJsonValidRule
+from skillsaw.rules.builtin.mcp import McpValidJsonRule, McpProhibitedRule
+
+# -- helpers -----------------------------------------------------------------
+
+
+def _create_single_plugin(temp_dir, plugin_json_content: str) -> Path:
+    """Create a minimal single-plugin repo with arbitrary plugin.json content."""
+    plugin_dir = temp_dir / "null-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text(plugin_json_content)
+    return plugin_dir
+
+
+def _create_plugin_with_mcp_content(temp_dir, mcp_content: str) -> Path:
+    """Create a plugin with a valid plugin.json and arbitrary .mcp.json content."""
+    plugin_dir = temp_dir / "mcp-null-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "mcp-null-plugin"}')
+    (plugin_dir / ".mcp.json").write_text(mcp_content)
+    return plugin_dir
+
+
+# -- plugin_structure.py: PluginJsonValidRule --------------------------------
+
+
+def test_plugin_json_null_does_not_crash(temp_dir):
+    """plugin.json containing JSON null must not raise TypeError."""
+    plugin_dir = _create_single_plugin(temp_dir, "null")
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "Expected JSON object" in violations[0].message
+
+
+def test_plugin_json_array_does_not_crash(temp_dir):
+    """plugin.json containing a JSON array must not raise TypeError."""
+    plugin_dir = _create_single_plugin(temp_dir, "[1, 2, 3]")
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "Expected JSON object" in violations[0].message
+
+
+def test_plugin_json_string_does_not_crash(temp_dir):
+    """plugin.json containing a JSON string must not raise TypeError."""
+    plugin_dir = _create_single_plugin(temp_dir, '"just a string"')
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "Expected JSON object" in violations[0].message
+
+
+# -- mcp.py: McpValidJsonRule ._validate_mcp_file ---------------------------
+
+
+def test_mcp_json_null_does_not_crash(temp_dir):
+    """.mcp.json containing JSON null must not raise TypeError."""
+    plugin_dir = _create_plugin_with_mcp_content(temp_dir, "null")
+    context = RepositoryContext(plugin_dir)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    msgs = [v.message for v in violations]
+    assert any("JSON object" in m for m in msgs)
+
+
+def test_mcp_json_array_does_not_crash(temp_dir):
+    """.mcp.json containing a JSON array must not raise TypeError."""
+    plugin_dir = _create_plugin_with_mcp_content(temp_dir, "[]")
+    context = RepositoryContext(plugin_dir)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    msgs = [v.message for v in violations]
+    assert any("JSON object" in m for m in msgs)
+
+
+# -- mcp.py: McpValidJsonRule ._validate_plugin_json_mcp --------------------
+
+
+def test_plugin_json_null_mcp_valid_rule(temp_dir):
+    """McpValidJsonRule must not crash when plugin.json is JSON null."""
+    plugin_dir = _create_single_plugin(temp_dir, "null")
+    context = RepositoryContext(plugin_dir)
+    rule = McpValidJsonRule()
+    # Should not raise
+    violations = rule.check(context)
+    # No MCP-specific violations expected; the non-dict is silently skipped
+    # (plugin-json-valid rule handles that case)
+    assert isinstance(violations, list)
+
+
+# -- mcp.py: McpProhibitedRule ._check_mcp_file & ._check_plugin_json -------
+
+
+def test_mcp_prohibited_null_mcp_json(temp_dir):
+    """McpProhibitedRule must not crash when .mcp.json is JSON null."""
+    plugin_dir = _create_plugin_with_mcp_content(temp_dir, "null")
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    # null has no mcpServers, so nothing prohibited
+    assert len(violations) == 0
+
+
+def test_mcp_prohibited_null_plugin_json(temp_dir):
+    """McpProhibitedRule must not crash when plugin.json is JSON null."""
+    plugin_dir = _create_single_plugin(temp_dir, "null")
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+
+
+# -- context.py: is_registered_in_marketplace --------------------------------
+
+
+def test_marketplace_with_string_plugin_entries(temp_dir):
+    """is_registered_in_marketplace must not crash on non-dict plugin entries."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    # marketplace.json with string entries instead of dicts
+    marketplace_json = {
+        "name": "bad-marketplace",
+        "owner": {"name": "Owner"},
+        "plugins": ["plugin-a", "plugin-b"],
+    }
+    (claude_dir / "marketplace.json").write_text(json.dumps(marketplace_json))
+
+    context = RepositoryContext(temp_dir)
+    # Must not raise AttributeError
+    assert not context.is_registered_in_marketplace("plugin-a")
+    assert not context.is_registered_in_marketplace("nonexistent")
+
+
+def test_marketplace_with_mixed_plugin_entries(temp_dir):
+    """is_registered_in_marketplace handles a mix of dicts and non-dicts."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    plugins_dir = temp_dir / "plugins"
+    plugins_dir.mkdir()
+
+    marketplace_json = {
+        "name": "mixed-marketplace",
+        "owner": {"name": "Owner"},
+        "plugins": [
+            "bare-string",
+            {"name": "real-plugin", "source": "./plugins/real-plugin", "description": "A plugin"},
+            42,
+            None,
+        ],
+    }
+    (claude_dir / "marketplace.json").write_text(json.dumps(marketplace_json))
+
+    # Create the real-plugin directory so discovery doesn't skip it
+    real_plugin = plugins_dir / "real-plugin"
+    real_plugin.mkdir()
+    real_claude = real_plugin / ".claude-plugin"
+    real_claude.mkdir()
+    (real_claude / "plugin.json").write_text('{"name": "real-plugin"}')
+
+    context = RepositoryContext(temp_dir)
+    assert context.is_registered_in_marketplace("real-plugin")
+    assert not context.is_registered_in_marketplace("bare-string")
+    assert not context.is_registered_in_marketplace("nonexistent")

--- a/tests/test_json_null_handling.py
+++ b/tests/test_json_null_handling.py
@@ -108,6 +108,32 @@ def test_plugin_json_null_mcp_valid_rule(temp_dir):
     assert isinstance(violations, list)
 
 
+def test_plugin_json_null_mcp_servers_mcp_valid_rule(temp_dir):
+    """McpValidJsonRule must not crash when plugin.json has mcpServers: null."""
+    plugin_dir = _create_single_plugin(
+        temp_dir, json.dumps({"name": "null-mcp-valid", "mcpServers": None})
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    msgs = [v.message for v in violations]
+    assert any("JSON object" in m for m in msgs)
+
+
+def test_plugin_json_list_mcp_servers_mcp_valid_rule(temp_dir):
+    """McpValidJsonRule must not crash when plugin.json has mcpServers: []."""
+    plugin_dir = _create_single_plugin(
+        temp_dir, json.dumps({"name": "list-mcp-valid", "mcpServers": []})
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    msgs = [v.message for v in violations]
+    assert any("JSON object" in m for m in msgs)
+
+
 # -- mcp.py: McpProhibitedRule ._check_mcp_file & ._check_plugin_json -------
 
 
@@ -131,7 +157,7 @@ def test_mcp_prohibited_null_plugin_json(temp_dir):
 
 
 def test_mcp_prohibited_null_mcp_servers(temp_dir):
-    """McpProhibitedRule must not crash when mcpServers is null."""
+    """McpProhibitedRule must not crash when mcpServers is null in .mcp.json."""
     plugin_dir = _create_plugin_with_mcp_content(temp_dir, json.dumps({"mcpServers": None}))
     context = RepositoryContext(plugin_dir)
     rule = McpProhibitedRule()
@@ -141,9 +167,33 @@ def test_mcp_prohibited_null_mcp_servers(temp_dir):
 
 
 def test_mcp_prohibited_list_mcp_servers(temp_dir):
-    """McpProhibitedRule must not crash when mcpServers is a list instead of dict."""
+    """McpProhibitedRule must not crash when mcpServers is a list in .mcp.json."""
     plugin_dir = _create_plugin_with_mcp_content(
         temp_dir, json.dumps({"mcpServers": ["server-a", "server-b"]})
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    assert len(violations) == 0
+
+
+def test_mcp_prohibited_null_mcp_servers_in_plugin_json(temp_dir):
+    """McpProhibitedRule must not crash when plugin.json has mcpServers: null."""
+    plugin_dir = _create_single_plugin(
+        temp_dir, json.dumps({"name": "null-mcp", "mcpServers": None})
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    assert len(violations) == 0
+
+
+def test_mcp_prohibited_list_mcp_servers_in_plugin_json(temp_dir):
+    """McpProhibitedRule must not crash when plugin.json has mcpServers: []."""
+    plugin_dir = _create_single_plugin(
+        temp_dir, json.dumps({"name": "list-mcp", "mcpServers": []})
     )
     context = RepositoryContext(plugin_dir)
     rule = McpProhibitedRule()

--- a/tests/test_json_null_handling.py
+++ b/tests/test_json_null_handling.py
@@ -130,7 +130,45 @@ def test_mcp_prohibited_null_plugin_json(temp_dir):
     assert isinstance(violations, list)
 
 
+def test_mcp_prohibited_null_mcp_servers(temp_dir):
+    """McpProhibitedRule must not crash when mcpServers is null."""
+    plugin_dir = _create_plugin_with_mcp_content(temp_dir, json.dumps({"mcpServers": None}))
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    assert len(violations) == 0
+
+
+def test_mcp_prohibited_list_mcp_servers(temp_dir):
+    """McpProhibitedRule must not crash when mcpServers is a list instead of dict."""
+    plugin_dir = _create_plugin_with_mcp_content(
+        temp_dir, json.dumps({"mcpServers": ["server-a", "server-b"]})
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = McpProhibitedRule()
+    violations = rule.check(context)
+    assert isinstance(violations, list)
+    assert len(violations) == 0
+
+
 # -- context.py: is_registered_in_marketplace --------------------------------
+
+
+def test_marketplace_with_null_plugins(temp_dir):
+    """is_registered_in_marketplace must not crash when plugins is null."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    marketplace_json = {
+        "name": "null-plugins-marketplace",
+        "owner": {"name": "Owner"},
+        "plugins": None,
+    }
+    (claude_dir / "marketplace.json").write_text(json.dumps(marketplace_json))
+
+    context = RepositoryContext(temp_dir)
+    assert not context.is_registered_in_marketplace("any-plugin")
 
 
 def test_marketplace_with_string_plugin_entries(temp_dir):

--- a/tests/test_json_null_handling.py
+++ b/tests/test_json_null_handling.py
@@ -192,9 +192,7 @@ def test_mcp_prohibited_null_mcp_servers_in_plugin_json(temp_dir):
 
 def test_mcp_prohibited_list_mcp_servers_in_plugin_json(temp_dir):
     """McpProhibitedRule must not crash when plugin.json has mcpServers: []."""
-    plugin_dir = _create_single_plugin(
-        temp_dir, json.dumps({"name": "list-mcp", "mcpServers": []})
-    )
+    plugin_dir = _create_single_plugin(temp_dir, json.dumps({"name": "list-mcp", "mcpServers": []}))
     context = RepositoryContext(plugin_dir)
     rule = McpProhibitedRule()
     violations = rule.check(context)


### PR DESCRIPTION
## Summary
- `read_json()` returns `(None, None)` for valid JSON containing just `null`, causing `TypeError` in multiple rules that assume `data` is always a dict when `error` is `None`
- Added `isinstance(data, dict)` guards after every `read_json()` call in `plugin_structure.py` (line 95) and `mcp.py` (lines 83, 327)
- Fixed `context.py` `is_registered_in_marketplace()` to skip non-dict entries in the plugins list, preventing `AttributeError` on bare strings/ints/nulls

## Test plan
- [x] Added `tests/test_json_null_handling.py` covering all four crash paths:
  - `PluginJsonValidRule` with null, array, and string plugin.json
  - `McpValidJsonRule._validate_mcp_file` with null and array .mcp.json
  - `McpValidJsonRule._validate_plugin_json_mcp` with null plugin.json
  - `McpProhibitedRule._check_mcp_file` and `._check_plugin_json` with null
  - `is_registered_in_marketplace` with string-only and mixed plugin entries
- [x] `make test` passes (474 tests)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of marketplace and plugin file validation to avoid crashes when JSON content is non-object (null/array/string) or when marketplace/plugin entries are malformed.

* **Tests**
  * Added tests covering JSON edge cases and malformed marketplace/plugin entries to ensure safe handling and clear violation messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/119)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->