### PR TITLE
fix: guard against null/wrong-type YAML config fields

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -233,7 +233,9 @@ class LinterConfig:
             Rule configuration dict
         """
         defaults = self.default().rules.get(rule_id, {})
-        overrides = self.rules.get(rule_id) or {}
+        overrides = self.rules.get(rule_id)
+        if overrides is None:
+            overrides = {}
         merged = {**defaults, **overrides}
         return merged
 

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -65,23 +65,55 @@ class LinterConfig:
         except (yaml.YAMLError, IOError) as e:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
-        rules = data.get("rules") or {}
-        custom_rules = data.get("custom-rules") or []
-        exclude_patterns = data.get("exclude") or []
-        strict = bool(data.get("strict") or False)
+        raw_rules = data.get("rules")
+        raw_custom_rules = data.get("custom-rules")
+        raw_exclude = data.get("exclude")
+        raw_strict = data.get("strict")
 
-        if not isinstance(rules, dict):
+        if raw_rules is None:
+            rules = {}
+        elif isinstance(raw_rules, dict):
+            rules = raw_rules
+        else:
             raise ValueError(
-                f"'rules' must be a mapping, got {type(rules).__name__}. "
+                f"'rules' must be a mapping, got {type(raw_rules).__name__}. "
                 "Each rule should be a key with a mapping value, e.g.:\n"
                 "  rules:\n"
                 "    plugin-json-required:\n"
                 "      enabled: true"
             )
-        if not isinstance(custom_rules, list):
-            raise ValueError(f"'custom-rules' must be a list, got {type(custom_rules).__name__}")
-        if not isinstance(exclude_patterns, list):
-            raise ValueError(f"'exclude' must be a list, got {type(exclude_patterns).__name__}")
+
+        for rule_id, rule_config in rules.items():
+            if rule_config is None:
+                rules[rule_id] = {}
+            elif not isinstance(rule_config, dict):
+                raise ValueError(
+                    f"'rules.{rule_id}' must be a mapping or null, "
+                    f"got {type(rule_config).__name__}"
+                )
+
+        if raw_custom_rules is None:
+            custom_rules = []
+        elif isinstance(raw_custom_rules, list):
+            custom_rules = raw_custom_rules
+        else:
+            raise ValueError(
+                f"'custom-rules' must be a list, got {type(raw_custom_rules).__name__}"
+            )
+
+        if raw_exclude is None:
+            exclude_patterns = []
+        elif isinstance(raw_exclude, list):
+            exclude_patterns = raw_exclude
+        else:
+            raise ValueError(f"'exclude' must be a list, got {type(raw_exclude).__name__}")
+
+        if raw_strict is None:
+            strict = False
+        elif isinstance(raw_strict, bool):
+            strict = raw_strict
+        else:
+            raise ValueError(f"'strict' must be a boolean, got {type(raw_strict).__name__}")
 
         llm_data = data.get("llm", {})
         llm_settings = LLMSettings(

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -65,6 +65,24 @@ class LinterConfig:
         except (yaml.YAMLError, IOError) as e:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
+        rules = data.get("rules") or {}
+        custom_rules = data.get("custom-rules") or []
+        exclude_patterns = data.get("exclude") or []
+        strict = bool(data.get("strict") or False)
+
+        if not isinstance(rules, dict):
+            raise ValueError(
+                f"'rules' must be a mapping, got {type(rules).__name__}. "
+                "Each rule should be a key with a mapping value, e.g.:\n"
+                "  rules:\n"
+                "    plugin-json-required:\n"
+                "      enabled: true"
+            )
+        if not isinstance(custom_rules, list):
+            raise ValueError(f"'custom-rules' must be a list, got {type(custom_rules).__name__}")
+        if not isinstance(exclude_patterns, list):
+            raise ValueError(f"'exclude' must be a list, got {type(exclude_patterns).__name__}")
+
         llm_data = data.get("llm", {})
         llm_settings = LLMSettings(
             model=llm_data.get("model", LLMSettings.model),
@@ -76,11 +94,11 @@ class LinterConfig:
 
         return cls(
             version=data.get("version", _DEFAULT_VERSION),
-            rules=data.get("rules", {}),
-            custom_rules=data.get("custom-rules", []),
-            exclude_patterns=data.get("exclude", []),
+            rules=rules,
+            custom_rules=custom_rules,
+            exclude_patterns=exclude_patterns,
             content_paths=data.get("content-paths", []),
-            strict=data.get("strict", False),
+            strict=strict,
             llm=llm_settings,
         )
 
@@ -183,7 +201,7 @@ class LinterConfig:
             Rule configuration dict
         """
         defaults = self.default().rules.get(rule_id, {})
-        overrides = self.rules.get(rule_id, {})
+        overrides = self.rules.get(rule_id) or {}
         merged = {**defaults, **overrides}
         return merged
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -437,3 +437,108 @@ def test_save_includes_version(tmp_path):
     parsed = yaml.safe_load(config_path.read_text())
     assert "version" in parsed
     assert parsed["version"] == config.version
+
+
+# --- Null/wrong-type YAML config field tests ---
+
+
+def test_null_rules_does_not_crash(temp_dir):
+    """rules: null should not crash, should behave like empty dict"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\n")  # YAML parses bare key as None
+
+    config = LinterConfig.from_file(config_file)
+    assert config.rules == {}
+
+
+def test_null_custom_rules_does_not_crash(temp_dir):
+    """custom-rules: null should not crash, should behave like empty list"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("custom-rules:\n")
+
+    config = LinterConfig.from_file(config_file)
+    assert config.custom_rules == []
+
+
+def test_null_exclude_does_not_crash(temp_dir):
+    """exclude: null should not crash, should behave like empty list"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("exclude:\n")
+
+    config = LinterConfig.from_file(config_file)
+    assert config.exclude_patterns == []
+
+
+def test_null_strict_does_not_crash(temp_dir):
+    """strict: null should not crash, should behave like False"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("strict:\n")
+
+    config = LinterConfig.from_file(config_file)
+    assert config.strict is False
+
+
+def test_explicit_null_rules(temp_dir):
+    """rules: null (explicit) should not crash"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules: null\n")
+
+    config = LinterConfig.from_file(config_file)
+    assert config.rules == {}
+
+
+def test_rules_as_list_raises_error(temp_dir):
+    """rules as a list instead of dict should raise a clear ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\n  - plugin-json-required\n  - plugin-naming\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'rules' must be a mapping"):
+        LinterConfig.from_file(config_file)
+
+
+def test_custom_rules_wrong_type_raises_error(temp_dir):
+    """custom-rules as a string should raise a clear ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text('custom-rules: "my_rule.py"\n')
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'custom-rules' must be a list"):
+        LinterConfig.from_file(config_file)
+
+
+def test_exclude_wrong_type_raises_error(temp_dir):
+    """exclude as a string should raise a clear ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text('exclude: "*.pyc"\n')
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'exclude' must be a list"):
+        LinterConfig.from_file(config_file)
+
+
+def test_null_rule_config_value(temp_dir):
+    """A rule key with null value should not crash get_rule_config"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\n  plugin-json-required:\n")
+
+    config = LinterConfig.from_file(config_file)
+    # Should not crash; null rule config treated as empty override
+    rule_config = config.get_rule_config("plugin-json-required")
+    # Should still get defaults
+    assert "enabled" in rule_config
+
+
+def test_all_fields_null_does_not_crash(temp_dir):
+    """Config with every field set to null should load without crashing"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\ncustom-rules:\nexclude:\nstrict:\n")
+
+    config = LinterConfig.from_file(config_file)
+    assert config.rules == {}
+    assert config.custom_rules == []
+    assert config.exclude_patterns == []
+    assert config.strict is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -542,3 +542,61 @@ def test_all_fields_null_does_not_crash(temp_dir):
     assert config.custom_rules == []
     assert config.exclude_patterns == []
     assert config.strict is False
+
+
+# --- Falsey wrong-type regression tests ---
+
+
+def test_rules_empty_list_raises_error(temp_dir):
+    """rules: [] (falsey but wrong type) should raise ValueError, not silently become {}"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules: []\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'rules' must be a mapping"):
+        LinterConfig.from_file(config_file)
+
+
+def test_custom_rules_empty_string_raises_error(temp_dir):
+    """custom-rules: '' (falsey but wrong type) should raise ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("custom-rules: ''\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'custom-rules' must be a list"):
+        LinterConfig.from_file(config_file)
+
+
+def test_exclude_empty_string_raises_error(temp_dir):
+    """exclude: '' (falsey but wrong type) should raise ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("exclude: ''\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'exclude' must be a list"):
+        LinterConfig.from_file(config_file)
+
+
+def test_strict_string_raises_error(temp_dir):
+    """strict: 'false' (string, not bool) should raise ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("strict: 'false'\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'strict' must be a boolean"):
+        LinterConfig.from_file(config_file)
+
+
+def test_rule_config_non_mapping_raises_error(temp_dir):
+    """rules: {plugin-json-required: true} should raise ValueError"""
+    config_file = temp_dir / ".skillsaw.yaml"
+    config_file.write_text("rules:\n  plugin-json-required: true\n")
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'rules.plugin-json-required' must be a mapping or null"):
+        LinterConfig.from_file(config_file)


### PR DESCRIPTION
## Summary
- Add `or {}` / `or []` guards on all config fields in `from_file()` so that YAML null values (`rules:`, `rules: null`, etc.) fall back to safe defaults instead of crashing with `AttributeError`
- Add type checks with clear error messages when fields have the wrong type (e.g. `rules` as a list instead of a dict, `custom-rules` or `exclude` as a string instead of a list)
- Fix `get_rule_config()` to handle null individual rule config values via `or {}` guard

## Test plan
- [x] `test_null_rules_does_not_crash` -- bare `rules:` key loads as empty dict
- [x] `test_null_custom_rules_does_not_crash` -- bare `custom-rules:` loads as empty list
- [x] `test_null_exclude_does_not_crash` -- bare `exclude:` loads as empty list
- [x] `test_null_strict_does_not_crash` -- bare `strict:` loads as False
- [x] `test_explicit_null_rules` -- `rules: null` loads as empty dict
- [x] `test_rules_as_list_raises_error` -- rules as a list raises clear ValueError
- [x] `test_custom_rules_wrong_type_raises_error` -- custom-rules as string raises ValueError
- [x] `test_exclude_wrong_type_raises_error` -- exclude as string raises ValueError
- [x] `test_null_rule_config_value` -- individual rule with null value doesn't crash get_rule_config
- [x] `test_all_fields_null_does_not_crash` -- every field null simultaneously
- [x] All 474 existing tests pass
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file validation with stricter type checking and clearer error messages when configuration values have incorrect types.
  * Null values in YAML configuration files are now handled gracefully with appropriate defaults.

* **Tests**
  * Added comprehensive test coverage for configuration loading and edge-case scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->