### PR TITLE
Fix marketplace CLI crashes on malformed marketplace.json

### DIFF
--- a/src/skillsaw/marketplace/add.py
+++ b/src/skillsaw/marketplace/add.py
@@ -216,7 +216,10 @@ def _resolve_plugin_dir(root: Path, plugin_name: str) -> Path:
     """Find the directory for an existing plugin."""
     mp_path = root / ".claude-plugin" / "marketplace.json"
     data = json.loads(mp_path.read_text(encoding="utf-8"))
-    for entry in data.get("plugins", []):
+    plugins = data.get("plugins", [])
+    if not isinstance(plugins, list):
+        raise ValueError("Invalid marketplace.json: 'plugins' must be a list.")
+    for entry in plugins:
         if not isinstance(entry, dict):
             continue
         if entry.get("name") == plugin_name:

--- a/src/skillsaw/marketplace/add.py
+++ b/src/skillsaw/marketplace/add.py
@@ -111,12 +111,15 @@ def _find_plugin_context(path: Path, plugin_name: Optional[str]) -> Tuple[Path, 
             mp_path = mp_root / ".claude-plugin" / "marketplace.json"
             data = json.loads(mp_path.read_text(encoding="utf-8"))
             plugins = data.get("plugins", [])
-            if not plugins:
+            if not isinstance(plugins, list):
+                raise ValueError("Invalid marketplace.json: 'plugins' must be a list.")
+            valid_plugins = [p for p in plugins if isinstance(p, dict) and "name" in p]
+            if not valid_plugins:
                 raise FileNotFoundError(
                     "No plugins found in this marketplace. Run 'skillsaw add plugin' first."
                 )
-            if len(plugins) == 1:
-                plugin_name = plugins[0]["name"]
+            if len(valid_plugins) == 1:
+                plugin_name = valid_plugins[0]["name"]
             else:
                 raise ValueError(
                     "Multiple plugins in this marketplace. Use --plugin to specify which one."
@@ -180,7 +183,9 @@ def _register_plugin(root: Path, name: str, source: str, description: str) -> No
     mp_path = root / ".claude-plugin" / "marketplace.json"
     data = json.loads(mp_path.read_text(encoding="utf-8"))
     data.setdefault("plugins", [])
-    if not any(p.get("name") == name for p in data["plugins"]):
+    if not isinstance(data["plugins"], list):
+        data["plugins"] = []
+    if not any(isinstance(p, dict) and p.get("name") == name for p in data["plugins"]):
         data["plugins"].append(
             {
                 "name": name,
@@ -212,7 +217,9 @@ def _resolve_plugin_dir(root: Path, plugin_name: str) -> Path:
     mp_path = root / ".claude-plugin" / "marketplace.json"
     data = json.loads(mp_path.read_text(encoding="utf-8"))
     for entry in data.get("plugins", []):
-        if entry["name"] == plugin_name:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") == plugin_name:
             source = entry.get("source", f"./plugins/{plugin_name}")
             resolved = (root / source).resolve()
             if not resolved.is_relative_to(root.resolve()):

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -695,6 +695,12 @@ class TestMalformedMarketplaceJson:
         with pytest.raises(FileNotFoundError, match="not found in marketplace"):
             _resolve_plugin_dir(root, "bar")
 
+    def test_resolve_plugin_dir_plugins_is_string(self, temp_dir):
+        """_resolve_plugin_dir should raise ValueError when plugins is a string."""
+        root = self._make_marketplace(temp_dir, "not-a-list")
+        with pytest.raises(ValueError, match="must be a list"):
+            _resolve_plugin_dir(root, "any-plugin")
+
 
 # ---------------------------------------------------------------------------
 # CLI integration

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -22,6 +22,8 @@ from skillsaw.marketplace.branding import (
 from skillsaw.marketplace.init import init_marketplace
 from skillsaw.marketplace.add import (
     _find_plugin_context,
+    _register_plugin,
+    _resolve_plugin_dir,
     add_agent,
     add_command,
     add_hook,
@@ -578,6 +580,120 @@ class TestContextDetection:
         )
         assert result.returncode == 0, f"Failed:\n{result.stdout}\n{result.stderr}"
         assert (root / ".claude" / "skills" / "cli-skill" / "SKILL.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Malformed marketplace.json
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedMarketplaceJson:
+    """Malformed marketplace.json must not crash with unhandled exceptions."""
+
+    def _make_marketplace(self, temp_dir, plugins_value):
+        """Create a minimal marketplace with a custom plugins value."""
+        root = temp_dir / "mp"
+        root.mkdir()
+        (root / ".claude-plugin").mkdir()
+        data = {"name": "test-mp", "owner": {"name": "testuser"}, "plugins": plugins_value}
+        (root / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps(data), encoding="utf-8"
+        )
+        return root
+
+    # -- _find_plugin_context --------------------------------------------------
+
+    def test_find_plugin_context_int_entry(self, temp_dir):
+        """plugins: [42] should not raise TypeError."""
+        root = self._make_marketplace(temp_dir, [42])
+        with pytest.raises(FileNotFoundError, match="No plugins found"):
+            _find_plugin_context(root, None)
+
+    def test_find_plugin_context_null_entry(self, temp_dir):
+        """plugins: [null] should not raise TypeError."""
+        root = self._make_marketplace(temp_dir, [None])
+        with pytest.raises(FileNotFoundError, match="No plugins found"):
+            _find_plugin_context(root, None)
+
+    def test_find_plugin_context_dict_missing_name(self, temp_dir):
+        """plugins: [{"source": "./foo"}] should not raise KeyError."""
+        root = self._make_marketplace(temp_dir, [{"source": "./foo"}])
+        with pytest.raises(FileNotFoundError, match="No plugins found"):
+            _find_plugin_context(root, None)
+
+    def test_find_plugin_context_plugins_is_string(self, temp_dir):
+        """plugins: "some-string" should raise ValueError, not iterate chars."""
+        root = self._make_marketplace(temp_dir, "some-string")
+        with pytest.raises(ValueError, match="must be a list"):
+            _find_plugin_context(root, None)
+
+    def test_find_plugin_context_valid_among_invalid(self, temp_dir):
+        """One valid entry among invalid ones should auto-select."""
+        root = self._make_marketplace(
+            temp_dir,
+            [42, None, {"source": "./foo"}, {"name": "good", "source": "./plugins/good"}],
+        )
+        # Create the plugin directory so _resolve_plugin_dir succeeds
+        plugin_dir = root / "plugins" / "good"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / ".claude-plugin").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "good"}), encoding="utf-8"
+        )
+
+        _root, resolved_dir, _mp_type = _find_plugin_context(root, None)
+        assert resolved_dir == plugin_dir.resolve()
+
+    # -- _register_plugin ------------------------------------------------------
+
+    def test_register_plugin_plugins_is_string(self, temp_dir):
+        """_register_plugin should recover when plugins is a string."""
+        root = self._make_marketplace(temp_dir, "bad")
+        # Should not raise; should reset plugins to a list and add the entry
+        _register_plugin(root, "new-plugin", "./plugins/new-plugin", "desc")
+
+        data = json.loads(
+            (root / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+        )
+        assert isinstance(data["plugins"], list)
+        assert any(p["name"] == "new-plugin" for p in data["plugins"])
+
+    def test_register_plugin_skips_non_dict_entries(self, temp_dir):
+        """_register_plugin should not crash on non-dict entries when checking duplicates."""
+        root = self._make_marketplace(temp_dir, [42, None, {"name": "existing"}])
+        _register_plugin(root, "new-plugin", "./plugins/new-plugin", "desc")
+
+        data = json.loads(
+            (root / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+        )
+        names = [p["name"] for p in data["plugins"] if isinstance(p, dict)]
+        assert "new-plugin" in names
+
+    # -- _resolve_plugin_dir ---------------------------------------------------
+
+    def test_resolve_plugin_dir_null_entries(self, temp_dir):
+        """_resolve_plugin_dir should skip null entries without crashing."""
+        root = self._make_marketplace(
+            temp_dir,
+            [None, {"name": "foo", "source": "./plugins/foo"}],
+        )
+        plugin_dir = root / "plugins" / "foo"
+        plugin_dir.mkdir(parents=True)
+
+        resolved = _resolve_plugin_dir(root, "foo")
+        assert resolved == plugin_dir.resolve()
+
+    def test_resolve_plugin_dir_int_entries(self, temp_dir):
+        """_resolve_plugin_dir should skip int entries without crashing."""
+        root = self._make_marketplace(temp_dir, [42, 0])
+        with pytest.raises(FileNotFoundError, match="not found in marketplace"):
+            _resolve_plugin_dir(root, "missing")
+
+    def test_resolve_plugin_dir_dict_without_name(self, temp_dir):
+        """_resolve_plugin_dir should skip entries without 'name' key."""
+        root = self._make_marketplace(temp_dir, [{"source": "./bar"}])
+        with pytest.raises(FileNotFoundError, match="not found in marketplace"):
+            _resolve_plugin_dir(root, "bar")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `isinstance(entry, dict)` and `"name" in entry` type guards in `_find_plugin_context`, `_register_plugin`, and `_resolve_plugin_dir` before accessing plugin entries from `marketplace.json`
- When `plugins` is a non-list type (e.g. a string), raise a clear `ValueError` instead of silently iterating characters
- In `_register_plugin`, reset `plugins` to an empty list when it has a wrong type, allowing the operation to recover gracefully
- Add 11 tests covering all crash scenarios: int entries, null entries, missing `"name"` key, string-typed `plugins` field, and mixed valid/invalid entries

**Bug:** Multiple marketplace CLI commands (`skillsaw add skill`, `skillsaw add command`, etc.) crashed with unhandled `TypeError`, `KeyError`, or `AttributeError` when `marketplace.json` contained non-dict plugin entries or wrong types in the `plugins` array.

**Root cause:** Three functions in `src/skillsaw/marketplace/add.py` accessed `entry["name"]` or `entry.get(...)` without first checking that `entry` is a dict. The linter's `context.py` already had these guards (line 279: `if not isinstance(plugin_entry, dict): continue`), but the marketplace CLI did not.

**Fix locations:**
- `_find_plugin_context` (line ~119): Filter to valid entries before counting/selecting
- `_register_plugin` (line ~183): Guard the `any()` duplicate check and reset non-list `plugins`
- `_resolve_plugin_dir` (line ~215): Skip non-dict entries with `continue`

## Test plan
- [x] `make test` passes (474 tests)
- [x] `make lint` passes
- [x] New `TestMalformedMarketplaceJson` class covers all crash scenarios:
  - `plugins: [42]` no longer raises `TypeError`
  - `plugins: [null]` no longer raises `TypeError`
  - `plugins: [{"source": "./foo"}]` no longer raises `KeyError`
  - `plugins: "some-string"` raises clear `ValueError` instead of `AttributeError`
  - Mixed valid/invalid entries correctly auto-select the valid one
  - `_register_plugin` recovers from string-typed `plugins`
  - `_resolve_plugin_dir` skips non-dict entries safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for malformed marketplace configuration, including stricter checks for plugin entries and clearer errors when multiple or no valid plugins are found
  * Made plugin registration and resolution more resilient to unexpected data formats and invalid entries, skipping bad items without crashing

* **Tests**
  * Added coverage for malformed marketplace data to ensure robust behavior and recovery in edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/121)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->