### PR TITLE
fix: file named `plugins` at repo root crashes discovery

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -207,7 +207,7 @@ class RepositoryContext:
             types.add(RepositoryType.MARKETPLACE)
         elif (self.root_path / ".claude-plugin").exists():
             types.add(RepositoryType.SINGLE_PLUGIN)
-        elif (self.root_path / "plugins").exists():
+        elif (self.root_path / "plugins").is_dir():
             types.add(RepositoryType.MARKETPLACE)
 
         # Agentskills
@@ -432,7 +432,7 @@ class RepositoryContext:
     def _discover_from_plugins_dir(self, plugins: List[Path], discovered_paths: Set[Path]) -> None:
         """Discover plugins from traditional plugins/ directory"""
         plugins_dir = self.root_path / "plugins"
-        if not plugins_dir.exists():
+        if not plugins_dir.is_dir():
             return
 
         for item in plugins_dir.iterdir():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -255,6 +255,18 @@ def test_plugins_file_not_detected_as_marketplace(temp_dir):
     assert len(context.plugins) == 0
 
 
+def test_plugins_file_with_marketplace_json_no_crash(temp_dir):
+    """A file named 'plugins' should be ignored even if marketplace.json exists"""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text(json.dumps({"name": "test", "plugins": []}))
+    (temp_dir / "plugins").write_text("Not a directory")
+
+    context = RepositoryContext(temp_dir)
+    assert context.repo_type == RepositoryType.MARKETPLACE
+    assert len(context.plugins) == 0
+
+
 def test_dot_claude_not_detected_empty(temp_dir):
     """Empty .claude/ without marker dirs should not be DOT_CLAUDE"""
     claude_dir = temp_dir / ".claude"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -246,6 +246,15 @@ def test_dot_claude_skills_discovery(temp_dir):
     assert context.skills[0].resolve() == skill_dir.resolve()
 
 
+def test_plugins_file_not_detected_as_marketplace(temp_dir):
+    """A regular file named 'plugins' should not be detected as a marketplace"""
+    (temp_dir / "plugins").write_text("This is a plain file, not a directory")
+
+    context = RepositoryContext(temp_dir)
+    assert context.repo_type != RepositoryType.MARKETPLACE
+    assert len(context.plugins) == 0
+
+
 def test_dot_claude_not_detected_empty(temp_dir):
     """Empty .claude/ without marker dirs should not be DOT_CLAUDE"""
     claude_dir = temp_dir / ".claude"


### PR DESCRIPTION
## Summary
- A regular file named `plugins` at the repo root was misdetected as a marketplace directory because `_detect_types()` used `.exists()` instead of `.is_dir()`.
- This caused `NotADirectoryError` when `_discover_from_plugins_dir()` called `iterdir()` on the file.
- Changed both checks (line 60 in `_detect_types` and line 257 in `_discover_from_plugins_dir`) to use `.is_dir()`.

## Test plan
- [x] Added `test_plugins_file_not_detected_as_marketplace` that creates a regular file named `plugins` and verifies no crash and no marketplace detection
- [x] `make test` passes (465 tests)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace detection accuracy by ensuring `plugins` must be a directory rather than any file type. This prevents incorrect classification of repositories containing a `plugins` file.

* **Tests**
  * Added test coverage to verify `plugins` files are not mistakenly detected as marketplace indicators.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->