### PR TITLE
fix: guard action/review.py against crashes on missing env vars and malformed data

### DIFF
--- a/action/review.py
+++ b/action/review.py
@@ -156,11 +156,14 @@ def upsert_summary_comment(repo, pr_number, non_diff_violations):
     lines.append("| Severity | Rule | File | Message |")
     lines.append("|----------|------|------|---------|")
     for v in non_diff_violations:
-        icon = SEVERITY_ICONS.get(v["severity"], "")
+        severity = v.get("severity", "warning")
+        icon = SEVERITY_ICONS.get(severity, "")
         path = v.get("file_path", "")
         line = v.get("line")
         loc = f"`{path}:{line}`" if line else f"`{path}`"
-        lines.append(f"| {icon} {v['severity']} | `{v['rule_id']}` | {loc} | {v['message']} |")
+        rule_id = v.get("rule_id", "unknown")
+        message = v.get("message", "")
+        lines.append(f"| {icon} {severity} | `{rule_id}` | {loc} | {message} |")
     lines.append(f"\n{SUMMARY_MARKER}")
     body = "\n".join(lines)
 
@@ -172,7 +175,7 @@ def upsert_summary_comment(repo, pr_number, non_diff_violations):
 
 def main():
     report_file = os.environ.get("SKILLSAW_REPORT_FILE", "")
-    if not report_file or not os.path.exists(report_file):
+    if not report_file or not os.path.isfile(report_file):
         print("No skillsaw report found, skipping review.", file=sys.stderr)
         return
 
@@ -187,6 +190,16 @@ def main():
         print(f"Failed to parse report JSON: {e}", file=sys.stderr)
         return
 
+    missing = []
+    for var in ("GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA"):
+        if var not in os.environ:
+            missing.append(var)
+    if missing:
+        print(
+            f"Missing required environment variable(s): {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     repo = os.environ["GITHUB_REPOSITORY"]
     pr_number = os.environ["PR_NUMBER"]
     head_sha = os.environ["HEAD_SHA"]
@@ -225,10 +238,13 @@ def main():
             non_diff_violations.append(v)
             continue
 
-        fp = fingerprint(v["rule_id"], path, v["message"])
-        icon = SEVERITY_ICONS.get(v["severity"], "")
+        rule_id = v.get("rule_id", "unknown")
+        message = v.get("message", "")
+        severity = v.get("severity", "warning")
+        fp = fingerprint(rule_id, path, message)
+        icon = SEVERITY_ICONS.get(severity, "")
         body = (
-            f"{icon} **{v['severity']}** (`{v['rule_id']}`): {v['message']}\n"
+            f"{icon} **{severity}** (`{rule_id}`): {message}\n"
             f"<!-- skillsaw:{fp} -->"
         )
 

--- a/action/review.py
+++ b/action/review.py
@@ -156,13 +156,15 @@ def upsert_summary_comment(repo, pr_number, non_diff_violations):
     lines.append("| Severity | Rule | File | Message |")
     lines.append("|----------|------|------|---------|")
     for v in non_diff_violations:
+        if not isinstance(v, dict):
+            continue
         severity = v.get("severity", "warning")
         icon = SEVERITY_ICONS.get(severity, "")
-        path = v.get("file_path", "")
+        path = v.get("file_path", "").replace("|", "\\|")
         line = v.get("line")
         loc = f"`{path}:{line}`" if line else f"`{path}`"
-        rule_id = v.get("rule_id", "unknown")
-        message = v.get("message", "")
+        rule_id = v.get("rule_id", "unknown").replace("|", "\\|")
+        message = v.get("message", "").replace("|", "\\|")
         lines.append(f"| {icon} {severity} | `{rule_id}` | {loc} | {message} |")
     lines.append(f"\n{SUMMARY_MARKER}")
     body = "\n".join(lines)
@@ -191,8 +193,9 @@ def main():
         return
 
     missing = []
-    for var in ("GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA"):
-        if var not in os.environ:
+    for var in ("GITHUB_TOKEN", "GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA"):
+        value = os.environ.get(var)
+        if value is None or not value.strip():
             missing.append(var)
     if missing:
         print(
@@ -205,6 +208,9 @@ def main():
     head_sha = os.environ["HEAD_SHA"]
 
     violations = report.get("violations", [])
+    if not isinstance(violations, list):
+        print("Invalid report format: 'violations' must be a list.", file=sys.stderr)
+        return
     if not violations:
         print("No violations found.")
         try:
@@ -229,6 +235,8 @@ def main():
     new_comments = []
     non_diff_violations = []
     for v in violations:
+        if not isinstance(v, dict):
+            continue
         path = v.get("file_path")
         line = v.get("line")
         if not path:

--- a/tests/test_action_review.py
+++ b/tests/test_action_review.py
@@ -1,0 +1,177 @@
+"""Tests for action/review.py crash-path guards."""
+
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+# action/ is not a package, so we import it by manipulating sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "action"))
+import review  # noqa: E402
+
+
+class TestReportFileGuards:
+    """Guards around the SKILLSAW_REPORT_FILE path."""
+
+    def test_missing_report_file_skips(self, capsys):
+        """main() returns early when SKILLSAW_REPORT_FILE points to nothing."""
+        with mock.patch.dict(os.environ, {"SKILLSAW_REPORT_FILE": "/nonexistent"}):
+            review.main()
+        assert "No skillsaw report found" in capsys.readouterr().err
+
+    def test_directory_as_report_file_skips(self, tmp_path, capsys):
+        """main() returns early when SKILLSAW_REPORT_FILE is a directory."""
+        d = tmp_path / "reports"
+        d.mkdir()
+        with mock.patch.dict(os.environ, {"SKILLSAW_REPORT_FILE": str(d)}):
+            review.main()
+        assert "No skillsaw report found" in capsys.readouterr().err
+
+    def test_empty_report_file_skips(self, tmp_path, capsys):
+        """main() returns early when the report file is empty."""
+        f = tmp_path / "report.json"
+        f.write_text("")
+        with mock.patch.dict(os.environ, {"SKILLSAW_REPORT_FILE": str(f)}):
+            review.main()
+        assert "Report file is empty" in capsys.readouterr().err
+
+
+class TestMissingEnvVars:
+    """Missing GITHUB_REPOSITORY / PR_NUMBER / HEAD_SHA should give a
+    clear error, not a raw KeyError."""
+
+    def _write_report(self, tmp_path, violations=None):
+        f = tmp_path / "report.json"
+        f.write_text(
+            json.dumps(
+                {
+                    "violations": violations
+                    or [
+                        {
+                            "file_path": "a.py",
+                            "severity": "error",
+                            "rule_id": "R1",
+                            "message": "bad",
+                        }
+                    ]
+                }
+            )
+        )
+        return str(f)
+
+    def test_all_missing(self, tmp_path):
+        report = self._write_report(tmp_path)
+        env = {"SKILLSAW_REPORT_FILE": report, "GITHUB_TOKEN": "t"}
+        # Remove the three required vars if they exist
+        clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA")
+        }
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                review.main()
+            assert exc_info.value.code == 1
+
+    def test_partial_missing(self, tmp_path, capsys):
+        report = self._write_report(tmp_path)
+        env = {
+            "SKILLSAW_REPORT_FILE": report,
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "owner/repo",
+        }
+        clean = {k: v for k, v in os.environ.items() if k not in ("PR_NUMBER", "HEAD_SHA")}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            with pytest.raises(SystemExit):
+                review.main()
+        err = capsys.readouterr().err
+        assert "PR_NUMBER" in err
+        assert "HEAD_SHA" in err
+        # GITHUB_REPOSITORY is present, so it should not appear in the error
+        assert "GITHUB_REPOSITORY" not in err
+
+
+class TestMalformedViolations:
+    """Violations missing rule_id, message, or severity must not crash."""
+
+    def test_violation_missing_rule_id_and_message(self, tmp_path):
+        """A violation dict with no rule_id/message should use defaults."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "violations": [
+                        {"file_path": "foo.py", "severity": "error"},
+                    ]
+                }
+            )
+        )
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "1",
+            "HEAD_SHA": "abc123",
+        }
+        diff_files = {"foo.py"}
+        diff_lines = {("foo.py", 10)}
+        with mock.patch.dict(os.environ, env):
+            with mock.patch.object(review, "get_diff_info", return_value=(diff_files, diff_lines)):
+                with mock.patch.object(review, "sync_comments", return_value=[]):
+                    with mock.patch.object(review, "upsert_summary_comment"):
+                        # Should not raise
+                        review.main()
+
+    def test_violation_missing_severity(self, tmp_path):
+        """A violation with no severity falls back to 'warning'."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "violations": [
+                        {"file_path": "bar.py", "rule_id": "R1", "message": "oops"},
+                    ]
+                }
+            )
+        )
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "1",
+            "HEAD_SHA": "abc123",
+        }
+        diff_files = {"bar.py"}
+        diff_lines = set()
+        captured_comments = []
+
+        def fake_sync(repo, pr, comments):
+            captured_comments.extend(comments)
+            return comments
+
+        with mock.patch.dict(os.environ, env):
+            with mock.patch.object(review, "get_diff_info", return_value=(diff_files, diff_lines)):
+                with mock.patch.object(review, "sync_comments", side_effect=fake_sync):
+                    with mock.patch.object(review, "upsert_summary_comment"):
+                        with mock.patch.object(review, "github_api"):
+                            review.main()
+
+        assert len(captured_comments) == 1
+        assert "warning" in captured_comments[0]["body"]
+
+    def test_summary_table_with_missing_keys(self):
+        """upsert_summary_comment must not crash on sparse violation dicts."""
+        violations = [
+            {"severity": "error", "file_path": "x.py"},
+            {"file_path": "y.py"},
+            {},
+        ]
+        with mock.patch.object(review, "github_api") as api:
+            api.return_value = []  # no existing comments
+            review.upsert_summary_comment("o/r", "1", violations)
+        # The POST call should have been made without crashing
+        assert api.call_count == 2  # one GET page, one POST

--- a/tests/test_action_review.py
+++ b/tests/test_action_review.py
@@ -62,13 +62,13 @@ class TestMissingEnvVars:
         return str(f)
 
     def test_all_missing(self, tmp_path):
+        """All required vars missing triggers sys.exit(1)."""
         report = self._write_report(tmp_path)
-        env = {"SKILLSAW_REPORT_FILE": report, "GITHUB_TOKEN": "t"}
-        # Remove the three required vars if they exist
+        env = {"SKILLSAW_REPORT_FILE": report}
         clean = {
             k: v
             for k, v in os.environ.items()
-            if k not in ("GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA")
+            if k not in ("GITHUB_TOKEN", "GITHUB_REPOSITORY", "PR_NUMBER", "HEAD_SHA")
         }
         clean.update(env)
         with mock.patch.dict(os.environ, clean, clear=True):
@@ -175,3 +175,151 @@ class TestMalformedViolations:
             review.upsert_summary_comment("o/r", "1", violations)
         # The POST call should have been made without crashing
         assert api.call_count == 2  # one GET page, one POST
+
+    def test_non_dict_violations_skipped(self, tmp_path):
+        """Non-dict entries in the violations list are silently skipped."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "violations": [
+                        "not-a-dict",
+                        None,
+                        42,
+                        {"file_path": "ok.py", "rule_id": "R1", "message": "good"},
+                    ]
+                }
+            )
+        )
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "1",
+            "HEAD_SHA": "abc123",
+        }
+        diff_files = {"ok.py"}
+        diff_lines = set()
+        captured = []
+
+        def fake_sync(repo, pr, comments):
+            captured.extend(comments)
+            return comments
+
+        with mock.patch.dict(os.environ, env):
+            with mock.patch.object(review, "get_diff_info", return_value=(diff_files, diff_lines)):
+                with mock.patch.object(review, "sync_comments", side_effect=fake_sync):
+                    with mock.patch.object(review, "upsert_summary_comment"):
+                        with mock.patch.object(review, "github_api"):
+                            review.main()
+        # Only the valid dict violation should produce a comment
+        assert len(captured) == 1
+
+    def test_non_dict_violations_skipped_in_summary(self):
+        """Non-dict entries in non_diff_violations are skipped by the summary."""
+        violations = [
+            "not-a-dict",
+            None,
+            {"severity": "error", "file_path": "x.py", "rule_id": "R1", "message": "m"},
+        ]
+        with mock.patch.object(review, "github_api") as api:
+            api.return_value = []
+            review.upsert_summary_comment("o/r", "1", violations)
+        # Should POST without crashing; only one valid row
+        assert api.call_count == 2
+
+    def test_violations_not_a_list(self, tmp_path, capsys):
+        """If violations is not a list, main() returns early with an error."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps({"violations": "oops"}))
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "1",
+            "HEAD_SHA": "abc123",
+        }
+        with mock.patch.dict(os.environ, env):
+            review.main()
+        assert "must be a list" in capsys.readouterr().err
+
+    def test_missing_github_token(self, tmp_path, capsys):
+        """Missing GITHUB_TOKEN is caught by env var validation."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "violations": [
+                        {
+                            "file_path": "a.py",
+                            "severity": "error",
+                            "rule_id": "R1",
+                            "message": "bad",
+                        }
+                    ]
+                }
+            )
+        )
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_REPOSITORY": "owner/repo",
+            "PR_NUMBER": "1",
+            "HEAD_SHA": "abc",
+        }
+        clean = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            with pytest.raises(SystemExit):
+                review.main()
+        assert "GITHUB_TOKEN" in capsys.readouterr().err
+
+    def test_empty_env_var_treated_as_missing(self, tmp_path, capsys):
+        """Empty or whitespace-only env vars are treated as missing."""
+        report_path = tmp_path / "report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "violations": [
+                        {
+                            "file_path": "a.py",
+                            "severity": "error",
+                            "rule_id": "R1",
+                            "message": "bad",
+                        }
+                    ]
+                }
+            )
+        )
+        env = {
+            "SKILLSAW_REPORT_FILE": str(report_path),
+            "GITHUB_TOKEN": "t",
+            "GITHUB_REPOSITORY": "  ",
+            "PR_NUMBER": "",
+            "HEAD_SHA": "abc",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with pytest.raises(SystemExit):
+                review.main()
+        err = capsys.readouterr().err
+        assert "GITHUB_REPOSITORY" in err
+        assert "PR_NUMBER" in err
+        assert "HEAD_SHA" not in err
+
+    def test_pipe_chars_escaped_in_summary(self):
+        """Pipe characters in violation fields are escaped in the Markdown table."""
+        violations = [
+            {
+                "severity": "error",
+                "file_path": "path|with|pipes.py",
+                "rule_id": "rule|id",
+                "message": "msg|with|pipe",
+            }
+        ]
+        with mock.patch.object(review, "github_api") as api:
+            api.return_value = []
+            review.upsert_summary_comment("o/r", "1", violations)
+        posted_body = api.call_args[0][2]["body"]
+        # The literal pipe chars should be escaped to avoid breaking the table
+        assert "rule\\|id" in posted_body
+        assert "msg\\|with\\|pipe" in posted_body
+        assert "path\\|with\\|pipes.py" in posted_body


### PR DESCRIPTION
## Summary
- Use `os.path.isfile()` instead of `os.path.exists()` so directories are rejected instead of causing `IsADirectoryError`
- Check for `GITHUB_REPOSITORY`, `PR_NUMBER`, `HEAD_SHA` before accessing them and exit with a clear error message instead of raising `KeyError`
- Use `.get()` with defaults for violation fields (`rule_id`, `message`, `severity`) to handle malformed report JSON gracefully
- Add 8 tests covering all four crash paths

## Test plan
- [x] `make test` passes (472 tests including 8 new ones)
- [x] `make lint` passes
- [ ] CI should pass on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing, invalid, or empty report files with more precise detection
  * Added upfront validation of required environment variables with clear, informative error messages on failure
  * Enhanced resilience when processing violation data by safely handling missing or incomplete fields

* **Tests**
  * Added comprehensive test coverage for error conditions, including missing files, invalid inputs, and malformed violation entries

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->