### PR TITLE
Fix regex metacharacter injection in bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -21,20 +21,32 @@ fi
 
 echo "Bumping version: $current_version -> $new_version"
 
-# Use python for portable in-place editing (works on both macOS and Linux)
-"$REPO_ROOT/.venv/bin/python3" -c "
+# Use python for portable in-place editing (works on both macOS and Linux).
+# Values are passed as arguments (not interpolated into source) to avoid
+# injection if a version string contains quotes or backslashes.
+"$REPO_ROOT/.venv/bin/python3" - "$PYPROJECT" "$INIT_PY" "$current_version" "$new_version" <<'PY'
 import sys
-for path, old, new in [
-    ('$PYPROJECT', 'version = \"$current_version\"', 'version = \"$new_version\"'),
-    ('$INIT_PY', '__version__ = \"$current_version\"', '__version__ = \"$new_version\"'),
-]:
-    text = open(path).read()
+from pathlib import Path
+
+pyproject, init_py, current_version, new_version = sys.argv[1:]
+targets = [
+    (pyproject, f'version = "{current_version}"', f'version = "{new_version}"'),
+    (init_py, f'__version__ = "{current_version}"', f'__version__ = "{new_version}"'),
+]
+
+# Phase 1: validate all files before writing any
+updates = []
+for path, old, new in targets:
+    text = Path(path).read_text(encoding="utf-8")
     if old not in text:
-        print(f'Error: could not find {old!r} in {path}', file=sys.stderr)
+        print(f"Error: could not find {old!r} in {path}", file=sys.stderr)
         sys.exit(1)
-    text = text.replace(old, new, 1)
-    open(path, 'w').write(text)
-"
+    updates.append((path, text.replace(old, new, 1)))
+
+# Phase 2: write all files
+for path, content in updates:
+    Path(path).write_text(content, encoding="utf-8")
+PY
 
 echo "Updated:"
 echo "  $PYPROJECT"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -22,14 +22,17 @@ fi
 echo "Bumping version: $current_version -> $new_version"
 
 # Use python for portable in-place editing (works on both macOS and Linux)
-python3 -c "
-import re, sys
-for path, pattern, repl in [
-    ('$PYPROJECT', r'^version = \"$current_version\"', 'version = \"$new_version\"'),
-    ('$INIT_PY', r'^__version__ = \"$current_version\"', '__version__ = \"$new_version\"'),
+"$REPO_ROOT/.venv/bin/python3" -c "
+import sys
+for path, old, new in [
+    ('$PYPROJECT', 'version = \"$current_version\"', 'version = \"$new_version\"'),
+    ('$INIT_PY', '__version__ = \"$current_version\"', '__version__ = \"$new_version\"'),
 ]:
     text = open(path).read()
-    text = re.sub(pattern, repl, text, count=1, flags=re.MULTILINE)
+    if old not in text:
+        print(f'Error: could not find {old!r} in {path}', file=sys.stderr)
+        sys.exit(1)
+    text = text.replace(old, new, 1)
     open(path, 'w').write(text)
 "
 


### PR DESCRIPTION
## Summary

- Replace `re.sub` with `str.replace` in `scripts/bump-version.sh` to prevent regex metacharacter injection when version strings contain characters like `+`, `.`, `*`, etc.
- Switch from bare `python3` to `.venv/bin/python3` per project development rules.
- Add an explicit error check when the expected version string is not found in a target file, providing a clear error message instead of silently succeeding with no substitution.

## Details

The script previously interpolated `$current_version` directly into a regex pattern passed to `re.sub`. If the version contained regex metacharacters (e.g., `1.0.0+build`), the `+` would be interpreted as a quantifier, causing either incorrect matches or `re.error` exceptions. Since the match target is always a literal string, `str.replace` is the correct and safer choice.

## Test plan

- [x] Verified script bumps versions correctly with standard version strings
- [x] Verified script handles versions with regex metacharacters (e.g., `1.0.0+build`)
- [x] Verified bumping FROM a version with metacharacters works
- [x] All 826 tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version bumping script to use virtual environment Python and implement more reliable string matching for version updates.

**Note:** This change affects internal tooling only and has no user-facing impact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->