### PR TITLE
fix: guard against unexpected LLM provider responses crashing the fix loop

### DIFF
--- a/src/skillsaw/llm/_litellm.py
+++ b/src/skillsaw/llm/_litellm.py
@@ -23,7 +23,7 @@ class TokenUsage:
 class CompletionResult:
     content: Optional[str]
     tool_calls: List[ToolCall]
-    usage: TokenUsage
+    usage: Optional[TokenUsage]
 
 
 class CompletionProvider(Protocol):
@@ -66,13 +66,21 @@ class LiteLLMProvider:
             kwargs["tools"] = tools
 
         response = litellm.completion(**kwargs)
-        if not response.choices:
+
+        usage_info = getattr(response, "usage", None)
+        usage = TokenUsage(
+            prompt_tokens=getattr(usage_info, "prompt_tokens", 0) or 0,
+            completion_tokens=getattr(usage_info, "completion_tokens", 0) or 0,
+        )
+
+        choices = getattr(response, "choices", None) or []
+        if not choices:
             return CompletionResult(
                 content=None,
                 tool_calls=[],
-                usage=TokenUsage(),
+                usage=usage,
             )
-        choice = response.choices[0]
+        choice = choices[0]
         message = choice.message
 
         tool_calls: List[ToolCall] = []
@@ -93,12 +101,6 @@ class LiteLLMProvider:
                         arguments=args,
                     )
                 )
-
-        usage_info = response.usage
-        usage = TokenUsage(
-            prompt_tokens=getattr(usage_info, "prompt_tokens", 0) or 0,
-            completion_tokens=getattr(usage_info, "completion_tokens", 0) or 0,
-        )
 
         return CompletionResult(
             content=message.content,

--- a/src/skillsaw/llm/_litellm.py
+++ b/src/skillsaw/llm/_litellm.py
@@ -66,6 +66,12 @@ class LiteLLMProvider:
             kwargs["tools"] = tools
 
         response = litellm.completion(**kwargs)
+        if not response.choices:
+            return CompletionResult(
+                content=None,
+                tool_calls=[],
+                usage=TokenUsage(),
+            )
         choice = response.choices[0]
         message = choice.message
 
@@ -76,7 +82,10 @@ class LiteLLMProvider:
             for tc in message.tool_calls:
                 args = tc.function.arguments
                 if isinstance(args, str):
-                    args = json.loads(args)
+                    try:
+                        args = json.loads(args)
+                    except json.JSONDecodeError:
+                        args = {"_raw": args, "_error": "invalid JSON in tool call arguments"}
                 tool_calls.append(
                     ToolCall(
                         id=tc.id,

--- a/src/skillsaw/llm/engine.py
+++ b/src/skillsaw/llm/engine.py
@@ -119,8 +119,9 @@ class LLMEngine:
                     budget_exhausted=False,
                 )
 
-            self._total_usage.prompt_tokens += result.usage.prompt_tokens
-            self._total_usage.completion_tokens += result.usage.completion_tokens
+            if result.usage:
+                self._total_usage.prompt_tokens += result.usage.prompt_tokens
+                self._total_usage.completion_tokens += result.usage.completion_tokens
 
             if not result.tool_calls:
                 return LLMResult(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -287,14 +287,38 @@ class TestLiteLLMProviderEdgeCases:
     """Tests for edge cases in the LiteLLM provider's complete() method."""
 
     def test_empty_choices_list(self):
-        """Provider should return empty result when choices list is empty."""
+        """Provider should return empty result but still extract usage when choices is empty."""
         from unittest.mock import MagicMock, patch
         from skillsaw.llm._litellm import LiteLLMProvider
 
         mock_litellm = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = []
+        mock_response.usage.prompt_tokens = 42
+        mock_response.usage.completion_tokens = 0
         mock_litellm.completion.return_value = mock_response
+
+        provider = LiteLLMProvider()
+        with patch("skillsaw.llm._litellm._get_litellm", return_value=mock_litellm):
+            result = provider.complete(
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[],
+                model="test-model",
+            )
+
+        assert result.content is None
+        assert result.tool_calls == []
+        assert result.usage.prompt_tokens == 42
+        assert result.usage.completion_tokens == 0
+
+    def test_missing_choices_attribute(self):
+        """Provider should return empty result when response has no choices attribute."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        from skillsaw.llm._litellm import LiteLLMProvider
+
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace()
 
         provider = LiteLLMProvider()
         with patch("skillsaw.llm._litellm._get_litellm", return_value=mock_litellm):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -243,6 +243,112 @@ class TestLLMEngine:
         assert len(result.tool_calls) == 1
         assert "Error: unknown tool" in result.tool_calls[0].result
 
+    def test_none_usage_in_result(self):
+        """Engine should not crash when CompletionResult.usage is None."""
+        provider = FakeProvider(
+            [
+                CompletionResult(
+                    content="Done!",
+                    tool_calls=[],
+                    usage=None,
+                )
+            ]
+        )
+        engine = LLMEngine(provider, [])
+        result = engine.run("system", "user")
+        assert result.text == "Done!"
+        assert result.usage.prompt_tokens == 0
+        assert result.usage.completion_tokens == 0
+
+    def test_none_usage_with_tool_calls(self):
+        """Engine should not crash when usage is None across multiple iterations."""
+        provider = FakeProvider(
+            [
+                CompletionResult(
+                    content=None,
+                    tool_calls=[ToolCall(id="call_1", name="unknown", arguments={})],
+                    usage=None,
+                ),
+                CompletionResult(
+                    content="ok",
+                    tool_calls=[],
+                    usage=TokenUsage(10, 10),
+                ),
+            ]
+        )
+        engine = LLMEngine(provider, [])
+        result = engine.run("system", "user")
+        assert result.text == "ok"
+        assert result.usage.prompt_tokens == 10
+        assert result.usage.completion_tokens == 10
+
+
+class TestLiteLLMProviderEdgeCases:
+    """Tests for edge cases in the LiteLLM provider's complete() method."""
+
+    def test_empty_choices_list(self):
+        """Provider should return empty result when choices list is empty."""
+        from unittest.mock import MagicMock, patch
+        from skillsaw.llm._litellm import LiteLLMProvider
+
+        mock_litellm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = []
+        mock_litellm.completion.return_value = mock_response
+
+        provider = LiteLLMProvider()
+        with patch("skillsaw.llm._litellm._get_litellm", return_value=mock_litellm):
+            result = provider.complete(
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[],
+                model="test-model",
+            )
+
+        assert result.content is None
+        assert result.tool_calls == []
+        assert result.usage.prompt_tokens == 0
+        assert result.usage.completion_tokens == 0
+
+    def test_invalid_json_tool_call_arguments(self):
+        """Provider should handle invalid JSON in tool call arguments gracefully."""
+        from unittest.mock import MagicMock, patch
+        from skillsaw.llm._litellm import LiteLLMProvider
+
+        mock_litellm = MagicMock()
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+
+        mock_tool_call = MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.function.name = "read_file"
+        mock_tool_call.function.arguments = "not valid json {{{{"
+
+        mock_message.content = None
+        mock_message.tool_calls = [mock_tool_call]
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_response.usage = MagicMock()
+        mock_response.usage.prompt_tokens = 10
+        mock_response.usage.completion_tokens = 5
+
+        mock_litellm.completion.return_value = mock_response
+
+        provider = LiteLLMProvider()
+        with patch("skillsaw.llm._litellm._get_litellm", return_value=mock_litellm):
+            result = provider.complete(
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[],
+                model="test-model",
+            )
+
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc.name == "read_file"
+        assert "_error" in tc.arguments
+        assert "invalid JSON" in tc.arguments["_error"]
+        assert tc.arguments["_raw"] == "not valid json {{{{"
+
 
 class TestLLMConfigFromYaml:
     def test_llm_settings_in_config(self, tmp_path):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -333,6 +333,29 @@ class TestLiteLLMProviderEdgeCases:
         assert result.usage.prompt_tokens == 0
         assert result.usage.completion_tokens == 0
 
+    def test_missing_choices_attribute_preserves_usage(self):
+        """Provider should preserve prompt usage even when choices attribute is missing."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+        from skillsaw.llm._litellm import LiteLLMProvider
+
+        mock_litellm = MagicMock()
+        usage = SimpleNamespace(prompt_tokens=55, completion_tokens=0)
+        mock_litellm.completion.return_value = SimpleNamespace(usage=usage)
+
+        provider = LiteLLMProvider()
+        with patch("skillsaw.llm._litellm._get_litellm", return_value=mock_litellm):
+            result = provider.complete(
+                messages=[{"role": "user", "content": "hello"}],
+                tools=[],
+                model="test-model",
+            )
+
+        assert result.content is None
+        assert result.tool_calls == []
+        assert result.usage.prompt_tokens == 55
+        assert result.usage.completion_tokens == 0
+
     def test_invalid_json_tool_call_arguments(self):
         """Provider should handle invalid JSON in tool call arguments gracefully."""
         from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary
- Guard `response.choices[0]` with an empty-list check to prevent `IndexError` when the LLM API returns no choices
- Wrap `json.loads(args)` in `try/except JSONDecodeError` to handle malformed tool call arguments gracefully instead of crashing
- Guard `result.usage` with a None check before accessing `.prompt_tokens`/`.completion_tokens` to prevent `AttributeError`

## Test plan
- [x] Added `test_empty_choices_list` -- verifies provider returns empty `CompletionResult` when choices list is empty
- [x] Added `test_invalid_json_tool_call_arguments` -- verifies provider surfaces error metadata instead of crashing on bad JSON
- [x] Added `test_none_usage_in_result` -- verifies engine handles `None` usage without crashing
- [x] Added `test_none_usage_with_tool_calls` -- verifies usage accumulation works across iterations when some have `None` usage
- [x] All 841 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete responses from LLM providers
  * Enhanced error recovery for malformed tool-call arguments
  * Fixed potential crashes when usage information is unavailable during operation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->