### PR TITLE
fix: thread-safe per-file cache invalidation in parallel LLM fix

### DIFF
--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -277,7 +277,7 @@ class Linter:
     def _relint_file(self, fpath, violations_list, threshold):
         from .rules.builtin.utils import invalidate_read_caches
 
-        invalidate_read_caches()
+        invalidate_read_caches(fpath)
         failed_rule_ids = {v.rule_id for v in violations_list}
         failed_rules = [r for r in self.rules if r.rule_id in failed_rule_ids]
         remaining = []

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -136,7 +136,7 @@ class LintTool:
         from ..rules.builtin.utils import invalidate_read_caches
         from ..rule import Rule
 
-        invalidate_read_caches()
+        invalidate_read_caches(resolved)
         context = RepositoryContext(self._root)
         context.content_paths = self._config.content_paths
 

--- a/src/skillsaw/rules/builtin/utils.py
+++ b/src/skillsaw/rules/builtin/utils.py
@@ -12,42 +12,80 @@ import yaml
 class FileCache:
     """Thread-safe cache that supports per-file invalidation.
 
-    Each cached function is keyed by its arguments (which must include a
-    file path).  ``invalidate(file_path)`` removes only entries whose
-    first positional argument matches the given path, so concurrent
-    threads operating on different files never interfere with each other.
+    Internally uses a two-level dictionary::
+
+        resolved_path -> { sub_key -> value }
+
+    ``invalidate(file_path)`` is O(1) -- it pops the entire inner dict
+    for that path.  A global ``maxsize`` caps the total number of entries
+    across all registered functions to prevent unbounded memory growth.
     """
 
-    def __init__(self):
+    def __init__(self, maxsize: int = 2048):
         self._lock = threading.Lock()
-        self._stores: List[Dict] = []  # one dict per registered function
+        self._stores: List[Dict[Path, Dict[tuple, Any]]] = []
+        self._maxsize = maxsize
+        self._total_entries = 0
 
     def cached(self, func: Callable) -> Callable:
         """Decorator -- equivalent to ``@lru_cache`` but with per-key eviction."""
-        store: Dict[tuple, Any] = {}
+        store: Dict[Path, Dict[tuple, Any]] = {}
         self._stores.append(store)
 
         def wrapper(*args, **kwargs):
-            key = (args, tuple(sorted(kwargs.items())))
+            # The first positional arg is always the file path.
+            file_path = args[0] if args else None
+            resolved = file_path.resolve() if isinstance(file_path, Path) else None
+            sub_key = (args[1:], tuple(sorted(kwargs.items())))
             with self._lock:
-                if key in store:
-                    return store[key]
+                bucket = store.get(resolved)
+                if bucket is not None and sub_key in bucket:
+                    return bucket[sub_key]
             # Compute outside the lock to avoid holding it during I/O.
             result = func(*args, **kwargs)
             with self._lock:
-                store[key] = result
+                if self._total_entries >= self._maxsize:
+                    self._evict_oldest()
+                bucket = store.setdefault(resolved, {})
+                if sub_key not in bucket:
+                    self._total_entries += 1
+                bucket[sub_key] = result
             return result
 
         wrapper._store = store  # type: ignore[attr-defined]
-        wrapper.cache_clear = lambda: store.clear()  # type: ignore[attr-defined]
+
+        def _clear():
+            with self._lock:
+                n = sum(len(b) for b in store.values())
+                store.clear()
+                self._total_entries -= n
+
+        wrapper.cache_clear = _clear  # type: ignore[attr-defined]
         return wrapper
+
+    def _evict_oldest(self):
+        """Drop roughly half the entries across all stores (called under lock)."""
+        target = self._maxsize // 2
+        evicted = 0
+        for store in self._stores:
+            paths_to_remove = []
+            for path, bucket in store.items():
+                evicted += len(bucket)
+                paths_to_remove.append(path)
+                if evicted >= target:
+                    break
+            for p in paths_to_remove:
+                del store[p]
+            if evicted >= target:
+                break
+        self._total_entries -= evicted
 
     def invalidate(self, file_path: Optional[Path] = None):
         """Drop cache entries.
 
-        If *file_path* is given, only entries whose first positional arg
-        equals *file_path* are removed -- safe to call from a worker thread
-        without disturbing other threads' cached results.
+        If *file_path* is given, only entries keyed by that resolved path
+        are removed -- O(number of registered functions), safe to call from
+        a worker thread without disturbing other threads' cached results.
 
         If *file_path* is ``None`` every entry in every registered store is
         cleared (equivalent to the old ``invalidate_read_caches()``).
@@ -56,26 +94,13 @@ class FileCache:
             if file_path is None:
                 for store in self._stores:
                     store.clear()
+                self._total_entries = 0
             else:
                 resolved = file_path.resolve()
                 for store in self._stores:
-                    keys_to_remove = [
-                        k
-                        for k in store
-                        if k[0] and len(k[0]) > 0 and _path_matches(k[0][0], resolved)
-                    ]
-                    for k in keys_to_remove:
-                        del store[k]
-
-
-def _path_matches(arg: Any, resolved_path: Path) -> bool:
-    """Return True if *arg* is a Path that resolves to *resolved_path*."""
-    if isinstance(arg, Path):
-        try:
-            return arg.resolve() == resolved_path
-        except (OSError, ValueError):
-            return False
-    return False
+                    bucket = store.pop(resolved, None)
+                    if bucket is not None:
+                        self._total_entries -= len(bucket)
 
 
 # Singleton cache used by all utility functions.
@@ -95,8 +120,13 @@ def invalidate_read_caches(file_path: Optional[Path] = None):
 
     Args:
         file_path: When given, only entries for this specific file are
-            evicted.  When ``None``, *all* cached entries are dropped
-            (legacy full-clear behaviour).
+            evicted from the main ``FileCache``.  When ``None``, *all*
+            cached entries are dropped (legacy full-clear behaviour).
+
+    Note:
+        Functions registered via ``register_cache`` (legacy ``lru_cache``
+        decorators) are always fully cleared regardless of *file_path*,
+        as ``lru_cache`` does not support per-key eviction.
     """
     _file_cache.invalidate(file_path)
     # lru_cache functions registered via register_cache do not support

--- a/src/skillsaw/rules/builtin/utils.py
+++ b/src/skillsaw/rules/builtin/utils.py
@@ -2,23 +2,86 @@
 
 import json
 import re
-from functools import lru_cache
+import threading
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import yaml
 
 
-@lru_cache(maxsize=512)
-def read_text(file_path: Path) -> Optional[str]:
-    """Cached file read. Returns None on I/O or encoding errors."""
-    try:
-        return file_path.read_text(encoding="utf-8")
-    except (IOError, UnicodeDecodeError):
-        return None
+class FileCache:
+    """Thread-safe cache that supports per-file invalidation.
+
+    Each cached function is keyed by its arguments (which must include a
+    file path).  ``invalidate(file_path)`` removes only entries whose
+    first positional argument matches the given path, so concurrent
+    threads operating on different files never interfere with each other.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._stores: List[Dict] = []  # one dict per registered function
+
+    def cached(self, func: Callable) -> Callable:
+        """Decorator -- equivalent to ``@lru_cache`` but with per-key eviction."""
+        store: Dict[tuple, Any] = {}
+        self._stores.append(store)
+
+        def wrapper(*args, **kwargs):
+            key = (args, tuple(sorted(kwargs.items())))
+            with self._lock:
+                if key in store:
+                    return store[key]
+            # Compute outside the lock to avoid holding it during I/O.
+            result = func(*args, **kwargs)
+            with self._lock:
+                store[key] = result
+            return result
+
+        wrapper._store = store  # type: ignore[attr-defined]
+        wrapper.cache_clear = lambda: store.clear()  # type: ignore[attr-defined]
+        return wrapper
+
+    def invalidate(self, file_path: Optional[Path] = None):
+        """Drop cache entries.
+
+        If *file_path* is given, only entries whose first positional arg
+        equals *file_path* are removed -- safe to call from a worker thread
+        without disturbing other threads' cached results.
+
+        If *file_path* is ``None`` every entry in every registered store is
+        cleared (equivalent to the old ``invalidate_read_caches()``).
+        """
+        with self._lock:
+            if file_path is None:
+                for store in self._stores:
+                    store.clear()
+            else:
+                resolved = file_path.resolve()
+                for store in self._stores:
+                    keys_to_remove = [
+                        k
+                        for k in store
+                        if k[0] and len(k[0]) > 0 and _path_matches(k[0][0], resolved)
+                    ]
+                    for k in keys_to_remove:
+                        del store[k]
 
 
-_extra_caches = []
+def _path_matches(arg: Any, resolved_path: Path) -> bool:
+    """Return True if *arg* is a Path that resolves to *resolved_path*."""
+    if isinstance(arg, Path):
+        try:
+            return arg.resolve() == resolved_path
+        except (OSError, ValueError):
+            return False
+    return False
+
+
+# Singleton cache used by all utility functions.
+_file_cache = FileCache()
+
+_extra_caches: list = []
 
 
 def register_cache(func):
@@ -27,17 +90,31 @@ def register_cache(func):
     return func
 
 
-def invalidate_read_caches():
-    """Clear all file-reading caches. Call after modifying files on disk."""
-    read_text.cache_clear()
-    read_json.cache_clear()
-    frontmatter_key_line.cache_clear()
-    heading_line.cache_clear()
+def invalidate_read_caches(file_path: Optional[Path] = None):
+    """Clear file-reading caches.
+
+    Args:
+        file_path: When given, only entries for this specific file are
+            evicted.  When ``None``, *all* cached entries are dropped
+            (legacy full-clear behaviour).
+    """
+    _file_cache.invalidate(file_path)
+    # lru_cache functions registered via register_cache do not support
+    # per-key eviction, so we must clear them entirely in both cases.
     for cache in _extra_caches:
         cache.cache_clear()
 
 
-@lru_cache(maxsize=512)
+@_file_cache.cached
+def read_text(file_path: Path) -> Optional[str]:
+    """Cached file read. Returns None on I/O or encoding errors."""
+    try:
+        return file_path.read_text(encoding="utf-8")
+    except (IOError, UnicodeDecodeError):
+        return None
+
+
+@_file_cache.cached
 def read_json(file_path: Path) -> Tuple[Optional[object], Optional[str]]:
     """Cached JSON file read. Returns (data, error)."""
     content = read_text(file_path)
@@ -49,7 +126,7 @@ def read_json(file_path: Path) -> Tuple[Optional[object], Optional[str]]:
         return None, str(e)
 
 
-@lru_cache(maxsize=512)
+@_file_cache.cached
 def frontmatter_key_line(file_path: Path, key: str) -> Optional[int]:
     """Find the line number of a top-level key in YAML frontmatter."""
     content = read_text(file_path)
@@ -101,7 +178,7 @@ def extract_section(content: str, heading: str, level: int = 2) -> str:
     return m.group(1).strip() if m else ""
 
 
-@lru_cache(maxsize=512)
+@_file_cache.cached
 def heading_line(file_path: Path, heading: str, level: int = 2) -> Optional[int]:
     """Find the line number of a markdown heading."""
     content = read_text(file_path)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -189,6 +189,75 @@ class TestParallelLLMFix:
         assert result1 != result2 or "No violations" in result1
 
 
+class TestPerFileCacheInvalidation:
+    """Test that per-file cache invalidation does not disturb other files."""
+
+    def test_invalidate_single_file_preserves_others(self, tmp_path):
+        """Invalidating one file's cache must not affect cached reads for other files."""
+        from skillsaw.rules.builtin.utils import read_text, invalidate_read_caches
+
+        file_a = tmp_path / "a.md"
+        file_b = tmp_path / "b.md"
+        file_a.write_text("original-a", encoding="utf-8")
+        file_b.write_text("original-b", encoding="utf-8")
+
+        # Warm both caches
+        invalidate_read_caches()  # full clear first
+        assert read_text(file_a) == "original-a"
+        assert read_text(file_b) == "original-b"
+
+        # Modify file_a on disk and invalidate only its cache
+        file_a.write_text("modified-a", encoding="utf-8")
+        invalidate_read_caches(file_a)
+
+        # file_a should reflect the new content
+        assert read_text(file_a) == "modified-a"
+        # file_b must still return the cached (original) value
+        assert read_text(file_b) == "original-b"
+
+    def test_concurrent_invalidation_is_isolated(self, tmp_path):
+        """Concurrent threads invalidating different files must not interfere."""
+        from skillsaw.rules.builtin.utils import read_text, invalidate_read_caches
+
+        num_files = 10
+        files = []
+        for i in range(num_files):
+            f = tmp_path / f"file{i}.md"
+            f.write_text(f"original-{i}", encoding="utf-8")
+            files.append(f)
+
+        # Warm all caches
+        invalidate_read_caches()
+        for f in files:
+            read_text(f)
+
+        # Modify all files on disk
+        for i, f in enumerate(files):
+            f.write_text(f"modified-{i}", encoding="utf-8")
+
+        errors = []
+
+        def invalidate_and_read(idx):
+            try:
+                f = files[idx]
+                invalidate_read_caches(f)
+                result = read_text(f)
+                if result != f"modified-{idx}":
+                    errors.append(f"file{idx}: expected 'modified-{idx}', got '{result}'")
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [
+            threading.Thread(target=invalidate_and_read, args=(i,)) for i in range(num_files)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+
+
 class TestParallelLintToolIsolation:
     """Test that LintTool instances don't interfere with each other."""
 


### PR DESCRIPTION
## Summary

- Replaces global `lru_cache` instances in `rules/builtin/utils.py` with a thread-safe `FileCache` class that supports per-file invalidation
- Changes `_relint_file` and `LintTool.execute` to call `invalidate_read_caches(file_path)` instead of `invalidate_read_caches()`, so each worker thread only evicts its own file's cache entries
- Prevents a race where Thread A clearing the global cache mid-way through Thread B's `rule.check()` causes incorrect violation counts and wrong rollback decisions

## Details

When `llm_fix` runs with `max_workers > 1`, multiple threads call `_llm_process_one_file` concurrently. Each calls `_relint_file`, which previously called `invalidate_read_caches()` -- a full clear of every cached file read across all threads. Thread A clearing the cache while Thread B is mid-check could cause Thread B to re-read files that Thread A just modified, leading to incorrect re-lint results.

The fix introduces a `FileCache` class with a `threading.Lock`-protected dict-of-dicts. `invalidate(file_path)` only removes entries whose first positional argument matches the given path. The full-clear `invalidate()` (no args) is preserved for backward compatibility and is still used in `_llm_rollback_or_keep`, which runs single-threaded after the thread pool completes.

## Test plan

- [x] `make test` -- 822 passed, 14 skipped
- [x] `make lint` -- clean
- [x] `skillsaw /tmp/ai-helpers` -- exit 0
- [x] New tests in `TestPerFileCacheInvalidation`:
  - `test_invalidate_single_file_preserves_others` -- verifies selective eviction
  - `test_concurrent_invalidation_is_isolated` -- 10 threads invalidating different files concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved caching in the linting flow by introducing thread‑safe per-file read caches and invalidation scoped to individual files, reducing stale reads during iterative checks.

* **Tests**
  * Added tests to verify per-file cache isolation and safe concurrent invalidation/read operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/131)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->