### PR TITLE
fix: handle non-existent files in llm_fix pipeline

### DIFF
--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -389,11 +389,23 @@ class Linter:
 
         changed = False
         diff_text = None
-        if fpath.exists():
+        if fpath.exists() and fpath in originals:
             current = fpath.read_text(encoding="utf-8")
-            if fpath in originals and current != originals[fpath]:
+            original = originals[fpath]
+            if original is None:
+                # File was created by the LLM (didn't exist before)
                 diff_lines = difflib.unified_diff(
-                    originals[fpath].splitlines(keepends=True),
+                    [],
+                    current.splitlines(keepends=True),
+                    fromfile=f"a/{rel_path}",
+                    tofile=f"b/{rel_path}",
+                )
+                diff_text = "".join(diff_lines)
+                if diff_text:
+                    changed = True
+            elif current != original:
+                diff_lines = difflib.unified_diff(
+                    original.splitlines(keepends=True),
                     current.splitlines(keepends=True),
                     fromfile=f"a/{rel_path}",
                     tofile=f"b/{rel_path}",
@@ -437,7 +449,13 @@ class Linter:
             after_count = sum(1 for v in self._relint_file(fpath, before_violations, threshold))
 
             if after_count >= before_count:
-                fpath.write_text(originals[fpath], encoding="utf-8")
+                original = originals[fpath]
+                if original is None:
+                    # File didn't exist before — remove the LLM-created file
+                    if fpath.exists():
+                        fpath.unlink()
+                else:
+                    fpath.write_text(original, encoding="utf-8")
                 violations_after += before_count
             else:
                 violations_after += after_count
@@ -482,10 +500,12 @@ class Linter:
             if v.file_path:
                 files_to_violations.setdefault(v.file_path.resolve(), []).append(v)
 
-        originals: Dict[Path, str] = {}
+        originals: Dict[Path, Optional[str]] = {}
         for fpath in files_to_violations:
             if fpath.exists():
                 originals[fpath] = fpath.read_text(encoding="utf-8")
+            else:
+                originals[fpath] = None  # sentinel: file doesn't exist yet
 
         violations_before = len(llm_violations)
         file_count = len(files_to_violations)
@@ -551,7 +571,12 @@ class Linter:
 
         if dry_run:
             for fpath, original_content in originals.items():
-                fpath.write_text(original_content, encoding="utf-8")
+                if original_content is None:
+                    # File didn't exist before — remove the LLM-created file
+                    if fpath.exists():
+                        fpath.unlink()
+                else:
+                    fpath.write_text(original_content, encoding="utf-8")
 
         return LLMFixResult(
             files_modified=[] if dry_run else kept_files,

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -180,7 +180,7 @@ class DiffTool:
         "required": ["path"],
     }
 
-    def __init__(self, root: Path, originals: Dict[Path, str]):
+    def __init__(self, root: Path, originals: Dict[Path, Optional[str]]):
         self._root = root
         self._originals = originals
 
@@ -190,7 +190,8 @@ class DiffTool:
             return "Error: path escapes repository root"
         if resolved not in self._originals:
             return "Error: no original snapshot for this file"
-        original = self._originals[resolved].splitlines(keepends=True)
+        orig = self._originals[resolved]
+        original = [] if orig is None else orig.splitlines(keepends=True)
         current = resolved.read_text(encoding="utf-8").splitlines(keepends=True)
         diff = difflib.unified_diff(original, current, fromfile=f"a/{path}", tofile=f"b/{path}")
         result = "".join(diff)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -132,6 +132,14 @@ class TestDiffTool:
         result = tool.execute(path="test.md")
         assert result == "No changes."
 
+    def test_diff_new_file(self, tmp_path):
+        content = "new content\n"
+        (tmp_path / "test.md").write_text(content, encoding="utf-8")
+        resolved = (tmp_path / "test.md").resolve()
+        tool = DiffTool(tmp_path, {resolved: None})
+        result = tool.execute(path="test.md")
+        assert "+new content" in result
+
     def test_diff_no_snapshot(self, tmp_path):
         (tmp_path / "test.md").write_text("content", encoding="utf-8")
         tool = DiffTool(tmp_path, {})

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -418,6 +418,103 @@ class TestLLMFixDryRun:
         assert len(result.diffs) > 0 or result.violations_before > 0
 
 
+class TestLLMFixNonExistentFile:
+    """Test that llm_fix correctly handles violations for files that don't exist yet."""
+
+    def _make_plugin_repo(self, tmp_path):
+        """Create a minimal plugin repo that triggers plugin-readme (missing README.md)."""
+        # .claude-plugin dir is needed to detect as SINGLE_PLUGIN repo type
+        claude_plugin = tmp_path / ".claude-plugin"
+        claude_plugin.mkdir()
+        plugin_json = claude_plugin / "plugin.json"
+        plugin_json.write_text(
+            '{"name": "test-plugin", "description": "A test plugin", "version": "1.0.0"}',
+            encoding="utf-8",
+        )
+        commands_dir = tmp_path / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "hello.md").write_text(
+            "---\ndescription: Say hello\n---\nSay hello to the user.\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_created_file_reported_as_modified(self, tmp_path):
+        """When LLM creates a missing file that fixes violations, it should be reported."""
+        self._make_plugin_repo(tmp_path)
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        config.rules["plugin-readme"] = {"enabled": True}
+        context = RepositoryContext(tmp_path)
+        linter = Linter(context, config)
+
+        # Verify that plugin-readme fires
+        violations = linter.run()
+        readme_violations = [v for v in violations if v.rule_id == "plugin-readme"]
+        assert len(readme_violations) >= 1, "Expected plugin-readme violation"
+
+        readme_content = "# test-plugin\n\nA test plugin.\n"
+        provider = _fake_fix_provider(readme_content, path="README.md")
+
+        result = linter.llm_fix(provider)
+        assert result.violations_before > 0
+        # The created file should be reported as modified
+        assert len(result.files_modified) > 0, "Created file should be in files_modified"
+        # Diffs should be generated for the new file
+        assert len(result.diffs) > 0, "Diff should be generated for created file"
+        # The file should exist on disk
+        assert (tmp_path / "README.md").exists()
+
+    def test_dry_run_cleans_up_created_file(self, tmp_path):
+        """In dry-run mode, files created by the LLM should be removed afterward."""
+        self._make_plugin_repo(tmp_path)
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        config.rules["plugin-readme"] = {"enabled": True}
+        context = RepositoryContext(tmp_path)
+        linter = Linter(context, config)
+
+        readme_content = "# test-plugin\n\nA test plugin.\n"
+        provider = _fake_fix_provider(readme_content, path="README.md")
+
+        result = linter.llm_fix(provider, dry_run=True)
+        # The file should NOT exist on disk after dry-run
+        assert not (tmp_path / "README.md").exists(), "Dry-run should clean up LLM-created files"
+        # files_modified should be empty in dry-run
+        assert len(result.files_modified) == 0
+        # But diffs should still be available
+        assert result.violations_before > 0
+
+    def test_rollback_deletes_created_file_on_no_improvement(self, tmp_path):
+        """When rollback fires for a created file, the file should be deleted (not restored)."""
+        self._make_plugin_repo(tmp_path)
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        config.rules["plugin-readme"] = {"enabled": True}
+        context = RepositoryContext(tmp_path)
+        linter = Linter(context, config)
+
+        # Use a provider that does nothing useful (doesn't write the file)
+        provider = FakeProvider(
+            [
+                CompletionResult(
+                    content="I can't fix this.",
+                    tool_calls=[],
+                    usage=TokenUsage(100, 20),
+                ),
+            ]
+        )
+
+        result = linter.llm_fix(provider)
+        # File should NOT exist (LLM didn't create it)
+        assert not (tmp_path / "README.md").exists()
+        # All violations remain unfixed
+        assert result.violations_after == result.violations_before
+
+
 class TestLLMFixScopedLinting:
     """Test that LintTool only runs relevant rules."""
 


### PR DESCRIPTION
## Summary

- Fixed `llm_fix` mishandling violations for non-existent files (e.g., "Missing README.md" from `plugin-readme` rule)
- Previously, when the LLM created a missing file via `WriteFileTool`, the result reported 0 files modified and 0 violations fixed because the file wasn't tracked in `originals`
- In dry-run mode, LLM-created files were left on disk, violating the dry-run contract

## Changes

- Track non-existent files with `originals[fpath] = None` sentinel value
- **Diff generation**: generate diff against empty content for newly created files
- **Rollback**: delete LLM-created files (instead of restoring) when no improvement
- **Dry-run cleanup**: delete LLM-created files to honor the dry-run contract
- **DiffTool**: handle `None` originals for new file diffs during LLM tool calls

## Test plan

- [x] `test_created_file_reported_as_modified` — verifies created files appear in `files_modified` and `diffs`
- [x] `test_dry_run_cleans_up_created_file` — verifies dry-run removes LLM-created files
- [x] `test_rollback_deletes_created_file_on_no_improvement` — verifies rollback when LLM doesn't create the file
- [x] `test_diff_new_file` — verifies DiffTool generates correct diff for `None` originals
- [x] `make test` — 841 passed, 14 skipped
- [x] `make lint` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)