### PR TITLE
Fix broken --cov=rules flag in Makefile test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint: $(VENV)/bin/activate
 	$(VENV)/bin/black --check src/ tests/
 
 test: $(VENV)/bin/activate
-	$(VENV)/bin/pytest tests/ -v --cov=src --cov=rules --cov-report=xml --cov-report=term
+	$(VENV)/bin/pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
 
 generate-example: $(VENV)/bin/activate
 	rm -f .skillsaw.yaml.example


### PR DESCRIPTION
## Summary
- Remove the `--cov=rules` flag from the Makefile `test` target, which referenced a nonexistent top-level `rules` package
- The rules module lives at `src/skillsaw/rules` and is already covered by `--cov=src`, making the flag both broken and redundant
- pytest-cov silently ignored this with a "No data was collected" warning

## Test plan
- [x] `make test` passes (464 tests, 84% coverage)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage reporting with enhanced metrics output formats for better visibility into source code quality during testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->