### PR TITLE
fix: add SARIF rule descriptor for invalid-config violations

### DIFF
--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -28,6 +28,22 @@ def format_sarif(
                 "shortDescription": {"text": r.description},
             }
 
+    # Add synthetic descriptors for violations whose rule_id has no
+    # matching Rule instance (e.g. "invalid-config" from _validate_config).
+    # SARIF consumers that enforce referential integrity require every
+    # ruleId referenced by a result to appear in runs[].tool.driver.rules[].
+    _SYNTHETIC_DESCRIPTIONS = {
+        "invalid-config": "Unknown rule ID in configuration",
+    }
+    for v in violations:
+        if v.rule_id not in seen:
+            seen[v.rule_id] = {
+                "id": v.rule_id,
+                "shortDescription": {
+                    "text": _SYNTHETIC_DESCRIPTIONS.get(v.rule_id, v.rule_id),
+                },
+            }
+
     results = []
     filtered = violations if verbose else [v for v in violations if v.severity != Severity.INFO]
     for v in filtered:

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -12,6 +12,12 @@ _SEVERITY_MAP = {
     "info": "note",
 }
 
+# Human-readable descriptions for synthetic rule IDs that have no backing
+# Rule instance (e.g. "invalid-config" emitted by Linter._validate_config).
+_SYNTHETIC_DESCRIPTIONS = {
+    "invalid-config": "Unknown rule ID in configuration",
+}
+
 
 def format_sarif(
     violations: List[RuleViolation],
@@ -32,9 +38,6 @@ def format_sarif(
     # matching Rule instance (e.g. "invalid-config" from _validate_config).
     # SARIF consumers that enforce referential integrity require every
     # ruleId referenced by a result to appear in runs[].tool.driver.rules[].
-    _SYNTHETIC_DESCRIPTIONS = {
-        "invalid-config": "Unknown rule ID in configuration",
-    }
     for v in violations:
         if v.rule_id not in seen:
             seen[v.rule_id] = {

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -435,6 +435,15 @@ def test_sarif_synthetic_descriptor_for_unknown_rule_id(valid_plugin):
     rule_ids = {r["id"] for r in rules}
     assert "custom-unknown-rule" in rule_ids
 
+    # Fallback description should be the raw rule_id itself
+    descriptor = next(r for r in rules if r["id"] == "custom-unknown-rule")
+    assert descriptor["shortDescription"]["text"] == "custom-unknown-rule"
+
+    # The result must reference the synthetic descriptor
+    results = data["runs"][0]["results"]
+    assert len(results) == 1
+    assert results[0]["ruleId"] == "custom-unknown-rule"
+
 
 # --- HTML formatter ---
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -391,6 +391,51 @@ def test_sarif_stats_in_properties(valid_plugin):
     assert stats["rules_run"] == len(linter.rules)
 
 
+def test_sarif_invalid_config_has_rule_descriptor(valid_plugin):
+    """Violations with rule_id='invalid-config' must have a matching rule descriptor."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="invalid-config",
+            severity=Severity.WARNING,
+            message="Unknown rule 'bogus-rule' in config — rule does not exist and will be ignored",
+        ),
+    ]
+
+    output = format_sarif(violations, context, [], "1.0.0")
+    data = json.loads(output)
+
+    rules = data["runs"][0]["tool"]["driver"]["rules"]
+    rule_ids = {r["id"] for r in rules}
+    assert "invalid-config" in rule_ids
+
+    descriptor = next(r for r in rules if r["id"] == "invalid-config")
+    assert descriptor["shortDescription"]["text"] == "Unknown rule ID in configuration"
+
+    results = data["runs"][0]["results"]
+    assert len(results) == 1
+    assert results[0]["ruleId"] == "invalid-config"
+
+
+def test_sarif_synthetic_descriptor_for_unknown_rule_id(valid_plugin):
+    """Any violation with a rule_id not in the rules list gets a synthetic descriptor."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="custom-unknown-rule",
+            severity=Severity.ERROR,
+            message="Something went wrong",
+        ),
+    ]
+
+    output = format_sarif(violations, context, [], "1.0.0")
+    data = json.loads(output)
+
+    rules = data["runs"][0]["tool"]["driver"]["rules"]
+    rule_ids = {r["id"] for r in rules}
+    assert "custom-unknown-rule" in rule_ids
+
+
 # --- HTML formatter ---
 
 


### PR DESCRIPTION
## Summary

- The linter's `_validate_config()` produces violations with `rule_id="invalid-config"`, but this synthetic rule ID was never added to the SARIF `runs[].tool.driver.rules[]` array
- SARIF consumers that enforce referential integrity (e.g. GitHub code scanning) may reject or warn on results that reference a `ruleId` with no matching rule descriptor
- Added logic in the SARIF formatter to scan violations for any `rule_id` not already covered by a `Rule` instance and emit a synthetic descriptor, with a human-readable description for the known `invalid-config` case

## Test plan

- [x] `test_sarif_invalid_config_has_rule_descriptor` — verifies an `invalid-config` violation produces a rule descriptor with the correct `shortDescription`
- [x] `test_sarif_synthetic_descriptor_for_unknown_rule_id` — verifies any unknown rule ID from a violation gets a synthetic descriptor
- [x] `make test` passes (466 tests)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF exports now ensure every violation rule ID has a matching descriptor, creating synthetic descriptors when definitions are missing (uses a fallback descriptive text for unknown IDs).

* **Tests**
  * Added tests confirming synthetic rule descriptor creation for unrecognized rule IDs and verifying the fallback message for an invalid-config rule.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/134)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->