### PR TITLE
fix: LLM tools crash on directories, binary files, and edge-case paths

### DIFF
--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -50,7 +50,12 @@ class ReadFileTool:
             return "Error: path escapes repository root"
         if not resolved.exists():
             return f"Error: file not found: {path}"
-        return resolved.read_text(encoding="utf-8")
+        if resolved.is_dir():
+            return f"Error: path is a directory, not a file: {path}"
+        try:
+            return resolved.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return f"Error: file is not valid UTF-8 text (binary file?): {path}"
 
 
 class WriteFileTool:
@@ -72,7 +77,12 @@ class WriteFileTool:
         resolved = _resolve_safe(self._root, path)
         if resolved is None:
             return "Error: path escapes repository root"
-        resolved.parent.mkdir(parents=True, exist_ok=True)
+        if resolved.is_dir():
+            return f"Error: path is an existing directory, not a file: {path}"
+        try:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+        except (NotADirectoryError, FileExistsError):
+            return f"Error: a parent component of the path is a file, not a directory: {path}"
         resolved.write_text(content, encoding="utf-8")
         return f"Wrote {len(content)} bytes to {path}"
 
@@ -99,6 +109,8 @@ class ReplaceSectionTool:
             return "Error: path escapes repository root"
         if not resolved.exists():
             return f"Error: file not found: {path}"
+        if resolved.is_dir():
+            return f"Error: path is a directory, not a file: {path}"
         content = resolved.read_text(encoding="utf-8")
         count = content.count(old_text)
         if count == 0:

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -111,7 +111,10 @@ class ReplaceSectionTool:
             return f"Error: file not found: {path}"
         if resolved.is_dir():
             return f"Error: path is a directory, not a file: {path}"
-        content = resolved.read_text(encoding="utf-8")
+        try:
+            content = resolved.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return f"Error: file is not valid UTF-8 text (binary file?): {path}"
         count = content.count(old_text)
         if count == 0:
             return "Error: old_text not found in file"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -53,6 +53,18 @@ class TestReadFileTool:
         result = tool.execute(path="../../../etc/passwd")
         assert "Error: path escapes repository root" in result
 
+    def test_read_directory(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        tool = ReadFileTool(tmp_path)
+        result = tool.execute(path="subdir")
+        assert "Error: path is a directory" in result
+
+    def test_read_binary_file(self, tmp_path):
+        (tmp_path / "binary.bin").write_bytes(b"\x80\x81\x82\xff\xfe")
+        tool = ReadFileTool(tmp_path)
+        result = tool.execute(path="binary.bin")
+        assert "Error: file is not valid UTF-8 text" in result
+
     def test_tool_metadata(self):
         tool = ReadFileTool(Path("/tmp"))
         assert tool.name == "read_file"
@@ -82,6 +94,18 @@ class TestWriteFileTool:
         tool = WriteFileTool(tmp_path)
         tool.execute(path="sub/dir/file.md", content="nested")
         assert (tmp_path / "sub" / "dir" / "file.md").read_text() == "nested"
+
+    def test_write_to_existing_directory(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        tool = WriteFileTool(tmp_path)
+        result = tool.execute(path="subdir", content="data")
+        assert "Error: path is an existing directory" in result
+
+    def test_write_parent_is_file(self, tmp_path):
+        (tmp_path / "afile").write_text("I am a file", encoding="utf-8")
+        tool = WriteFileTool(tmp_path)
+        result = tool.execute(path="afile/child.md", content="data")
+        assert "Error: a parent component of the path is a file" in result
 
 
 class TestReplaceSectionTool:
@@ -113,6 +137,12 @@ class TestReplaceSectionTool:
         tool = ReplaceSectionTool(tmp_path)
         result = tool.execute(path="missing.md", old_text="a", new_text="b")
         assert "Error: file not found" in result
+
+    def test_replace_on_directory(self, tmp_path):
+        (tmp_path / "subdir").mkdir()
+        tool = ReplaceSectionTool(tmp_path)
+        result = tool.execute(path="subdir", old_text="a", new_text="b")
+        assert "Error: path is a directory" in result
 
 
 class TestDiffTool:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -144,6 +144,12 @@ class TestReplaceSectionTool:
         result = tool.execute(path="subdir", old_text="a", new_text="b")
         assert "Error: path is a directory" in result
 
+    def test_replace_on_binary_file(self, tmp_path):
+        (tmp_path / "binary.bin").write_bytes(b"\x80\x81\x82\xff\xfe")
+        tool = ReplaceSectionTool(tmp_path)
+        result = tool.execute(path="binary.bin", old_text="a", new_text="b")
+        assert "Error: file is not valid UTF-8 text" in result
+
 
 class TestDiffTool:
     def test_diff_with_changes(self, tmp_path):


### PR DESCRIPTION
## Summary
- **ReadFileTool**: Add `is_dir()` check and `UnicodeDecodeError` handler so directories and binary files return clean error strings instead of raising `IsADirectoryError` / `UnicodeDecodeError`
- **WriteFileTool**: Add `is_dir()` check for the target path and catch `NotADirectoryError` / `FileExistsError` from `mkdir()` when a parent path component is a regular file
- **ReplaceSectionTool**: Add `is_dir()` check before calling `read_text()` to prevent `IsADirectoryError`

These exceptions were already caught by the engine's `_dispatch_tool` try/except, so they never crashed the fix loop -- but they produced ugly stack traces instead of clean error messages the LLM could act on.

## Test plan
- [x] `test_read_directory` -- ReadFileTool returns clean error for directory paths
- [x] `test_read_binary_file` -- ReadFileTool returns clean error for non-UTF-8 files
- [x] `test_write_to_existing_directory` -- WriteFileTool returns clean error when target is a directory
- [x] `test_write_parent_is_file` -- WriteFileTool returns clean error when a parent component is a file
- [x] `test_replace_on_directory` -- ReplaceSectionTool returns clean error for directory paths
- [x] All 825 existing tests pass, lint clean

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in file operations with explicit validation for directories versus files
  * Enhanced error messages when operations encounter incompatible file types or directory paths
  * Better handling of binary and non-UTF-8 files during operations

* **Tests**
  * Added comprehensive test coverage for file operation edge cases and error conditions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->