### PR TITLE
refactor: introduce lint tree as single discovery source

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.7.2"
+version: "0.7.3"
 
 rules:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
   - [Initialize a Marketplace](#initialize-a-marketplace)
   - [Add Components](#add-components)
   - [Context Detection](#context-detection)
+- [Lint Tree](#lint-tree)
 - [Documentation Generation](#documentation-generation)
 - [Exit Codes](#exit-codes)
 - [Example Output](#example-output)
@@ -99,6 +100,9 @@ skillsaw init
 
 # List all rules with fix support info
 skillsaw list-rules
+
+# View the lint tree (what skillsaw sees)
+skillsaw tree
 
 # Generate plugin/skill documentation
 skillsaw docs
@@ -634,6 +638,33 @@ skillsaw automatically detects your repo type and places files in the right loca
 - **`.claude/` repo** — components go under `.claude/`
 
 In a marketplace with multiple plugins, specify `--plugin <name>` or skillsaw will prompt interactively.
+
+## Lint Tree
+
+`skillsaw tree` visualizes the typed lint tree — the internal data structure that all rules operate on. Every lintable entity (plugins, skills, commands, agents, instruction files, config files) is a typed node in the tree.
+
+```bash
+# View the lint tree
+skillsaw tree
+
+# View a specific path
+skillsaw tree /path/to/repo
+```
+
+Example output:
+
+```
+my-marketplace/
+    ├── AGENTS.md (agents-md)
+    ├── marketplace.json
+    ├── plugins/ [marketplace]
+    │   └── my-plugin/ [plugin]
+    │       ├── hello.md (command)
+    │       └── my-skill/ [skill]
+    │           └── SKILL.md (skill)
+    └── .coderabbit.yaml
+        └── reviews.instructions (coderabbit)
+```
 
 ## Documentation Generation
 

--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ These rules validate skills against the [agentskills.io specification](https://a
 
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
-| `skill-frontmatter` | SKILL.md files should have frontmatter with name and description | warning | auto |
-| `agent-frontmatter` | Agent files must have valid frontmatter with name and description | error | auto |
+| `skill-frontmatter` | SKILL.md files should have frontmatter with name and description | warning | auto, llm |
+| `agent-frontmatter` | Agent files must have valid frontmatter with name and description | error | auto, llm |
 | `hooks-json-valid` | hooks.json must be valid JSON with proper hook configuration structure | error | - |
 
 ### MCP (Model Context Protocol)

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Warns when instruction and configuration files exceed recommended token limits. 
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `limits` | Token limits per file category (int for warn-only, or {warn, error} dict) | `{"agents-md": {"warn": 6000, "error": 12000}, "claude-md": {"warn": 6000, "error": 12000}, "gemini-md": {"warn": 6000, "error": 12000}, "instruction": {"warn": 4000, "error": 8000}, "skill": {"warn": 3000, "error": 6000}, "command": {"warn": 2000, "error": 4000}, "agent": {"warn": 2000, "error": 4000}, "rule": {"warn": 2000, "error": 4000}}` |
+| `limits` | Token limits per file category (int for warn-only, or {warn, error} dict) | `{"agents-md": {"warn": 6000, "error": 12000}, "claude-md": {"warn": 6000, "error": 12000}, "gemini-md": {"warn": 6000, "error": 12000}, "instruction": {"warn": 4000, "error": 8000}, "skill": {"warn": 3000, "error": 6000}, "command": {"warn": 2000, "error": 4000}, "agent": {"warn": 2000, "error": 4000}, "rule": {"warn": 2000, "error": 4000}, "skill-description": {"warn": 200, "error": 500}, "command-description": {"warn": 200, "error": 500}}` |
 
 ### Content Intelligence
 

--- a/docs/designs/lint-tree.md
+++ b/docs/designs/lint-tree.md
@@ -1,0 +1,101 @@
+# Design: Repository Lint Tree
+
+**Status:** Implementing
+**Date:** 2026-05-10
+
+## Overview
+
+The lint tree is a tree data structure that represents everything lintable in a
+repository. It is built once per lint run and serves as the single source of
+truth for discovery. Rules walk the tree to find nodes they are compatible with.
+The fix pipeline processes tree nodes. Everything is tree traversals.
+
+## Motivation
+
+Discovery was fragmented: content rules shared `gather_all_content_blocks()`,
+structural rules each discovered files inside their own `check()`, and the fix
+pipeline split into block-based and file-based paths. Format-specific logic
+(CodeRabbit YAML, Cursor frontmatter) lived in free functions rather than being
+encapsulated by the objects themselves.
+
+## Tree Structure
+
+```
+LintTarget (base)
+  ├── PluginNode             — plugin directory
+  ├── SkillNode              — skill directory
+  ├── ContentBlock (ABC)     — leaf with lintable text body
+  │   ├── FileContentBlock          — plain files (CLAUDE.md, AGENTS.md, etc.)
+  │   ├── FrontmatterContentBlock   — .mdc files
+  │   └── CodeRabbitContentBlock    — instruction fragment from .coderabbit.yaml
+```
+
+### LintTarget
+
+Base class for all tree nodes. Holds a `path` and a list of `children`.
+Provides `walk()` for depth-first traversal and `find(type)` to collect all
+descendants of a given type.
+
+### ContentBlock
+
+Abstract base class for leaf nodes with lintable text content. Defines:
+
+- `read_body()` — lazily read content on first access
+- `write_body()` — write fixed content back to the correct location
+- `file_line()` — translate body-relative line numbers to file-absolute
+- `__eq__` / `__hash__` — identity for matching across re-lint cycles
+
+Each subclass encapsulates its format:
+
+- **FileContentBlock**: reads/writes the whole file
+- **FrontmatterContentBlock**: strips YAML frontmatter on read, preserves it on write
+- **CodeRabbitContentBlock**: reads one instruction from `.coderabbit.yaml`, writes
+  back via ruamel.yaml round-trip preserving comments and formatting
+
+### PluginNode / SkillNode
+
+Typed markers for structural nodes. Rules find them via `tree.find(PluginNode)`
+and inspect their children or path to check structural requirements.
+
+## Tree Builder
+
+`build_lint_tree(context)` in `src/skillsaw/lint_tree.py` is the single
+discovery entrypoint. It walks the repository once, creating typed nodes:
+
+- Instruction files become FileContentBlock / FrontmatterContentBlock
+- Plugin directories become PluginNode with content children
+- Skill directories become SkillNode with content children
+- `.coderabbit.yaml` instructions become CodeRabbitContentBlock children
+
+The tree is cached on `RepositoryContext.lint_tree` (lazy property).
+`rebuild_lint_tree()` invalidates the cache for use during fix loops.
+
+## How Rules Use the Tree
+
+Content rules walk the tree for ContentBlock leaves:
+
+```python
+for block in context.lint_tree.content_blocks():
+    body = block.read_body()
+    # analyze body...
+```
+
+Structural rules find specific node types:
+
+```python
+for plugin in context.lint_tree.find(PluginNode):
+    if not (plugin.path / "plugin.json").exists():
+        # report violation
+```
+
+## Fix Pipeline
+
+Every violation references a tree node (ContentBlock). The fix pipeline has one
+path: group violations by block, process each with block-scoped LLM tools
+(read_block, write_block, replace_block_section, lint_block, diff_block).
+No separate file-level fix path.
+
+## CLI
+
+`skillsaw tree` prints the discovered tree structure, showing all nodes with
+their types and categories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.7.2"
+version = "0.7.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -17,7 +17,7 @@ from .rule import Severity
 from .formatters import format_report, get_counts, infer_format, FORMATS
 from . import __version__
 
-_SUBCOMMANDS = {"lint", "init", "list-rules", "docs", "add", "fix"}
+_SUBCOMMANDS = {"lint", "init", "list-rules", "docs", "add", "fix", "tree"}
 
 
 def _get_version() -> str:
@@ -235,6 +235,25 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     )
     docs_parser.add_argument("--title", default=None, help="Custom title for the documentation")
 
+    # --- tree ---
+    tree_parser = subparsers.add_parser(
+        "tree",
+        help="Display the repository lint tree",
+    )
+    tree_parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to repository (default: current directory)",
+    )
+    tree_parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        help="Path to .skillsaw.yaml config file",
+    )
+
     # --- add ---
     subparsers.add_parser(
         "add",
@@ -254,6 +273,41 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         _run_list_rules()
     elif args.command == "docs":
         _run_docs(args)
+    elif args.command == "tree":
+        _run_tree(args)
+
+
+def _run_tree(args):
+    if not args.path.exists():
+        print(f"Error: Path not found: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    context = RepositoryContext(args.path)
+
+    if args.config:
+        config_path = args.config
+        if not config_path.exists():
+            print(f"Error: Config file not found: {config_path}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        config_path = find_config(args.path)
+
+    if config_path:
+        try:
+            config = LinterConfig.from_file(config_path)
+        except ValueError as e:
+            print(f"Error loading config: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        config = LinterConfig.default()
+
+    context.content_paths = config.content_paths
+    context.exclude_patterns = config.exclude_patterns
+    context.apply_excludes()
+
+    tree = context.lint_tree
+    print(tree.print_tree(root_path=context.root_path))
+    sys.exit(0)
 
 
 def _run_lint(args):

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -253,6 +253,13 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         type=Path,
         help="Path to .skillsaw.yaml config file",
     )
+    tree_parser.add_argument(
+        "--format",
+        dest="fmt",
+        default="text",
+        choices=["text", "dot"],
+        help="Output format (default: text)",
+    )
 
     # --- add ---
     subparsers.add_parser(
@@ -306,7 +313,10 @@ def _run_tree(args):
     context.apply_excludes()
 
     tree = context.lint_tree
-    print(tree.print_tree(root_path=context.root_path))
+    if args.fmt == "dot":
+        print(tree.print_dot(root_path=context.root_path))
+    else:
+        print(tree.print_tree(root_path=context.root_path))
     sys.exit(0)
 
 

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -321,6 +321,19 @@ def _run_tree(args):
 
 
 def _run_lint(args):
+    if args.verbose:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(name)s: %(message)s",
+            stream=sys.stderr,
+        )
+    else:
+        logging.basicConfig(
+            level=logging.WARNING,
+            format="%(name)s: %(message)s",
+            stream=sys.stderr,
+        )
+
     cli_version = _get_version()
 
     output_formats = {}
@@ -461,7 +474,7 @@ def _require_llm_provider(config):
         )
         sys.exit(1)
 
-    logging.basicConfig(level=logging.WARNING, format="%(message)s", stream=sys.stderr)
+    logging.basicConfig(level=logging.WARNING, format="%(name)s: %(message)s", stream=sys.stderr)
     return LiteLLMProvider()
 
 

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -82,6 +82,9 @@ class RepositoryContext:
         self.root_path = root_path.resolve()
         self.has_apm = self._detect_apm()
         self.repo_types: Set[RepositoryType] = self._detect_types()
+        logger.info(
+            "Detected repo types: %s", ", ".join(t.value for t in self.repo_types) or "none"
+        )
         self.marketplace_data = self._load_marketplace() if self.has_marketplace() else None
         self.plugin_metadata: Dict[Path, Dict[str, Any]] = (
             {}

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 import fnmatch
 from enum import Enum
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Set
+from typing import Optional, List, Dict, Any, Set, TYPE_CHECKING
 import json
 import logging
 import os
+
+if TYPE_CHECKING:
+    from .lint_target import LintTarget
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +92,18 @@ class RepositoryContext:
         self.detected_formats: Set[str] = self._detect_formats()
         self.content_paths: List[str] = []
         self.exclude_patterns: List[str] = []
+        self._lint_tree: Optional["LintTarget"] = None
+
+    @property
+    def lint_tree(self) -> "LintTarget":
+        if self._lint_tree is None:
+            from .lint_tree import build_lint_tree
+
+            self._lint_tree = build_lint_tree(self)
+        return self._lint_tree
+
+    def rebuild_lint_tree(self) -> None:
+        self._lint_tree = None
 
     @property
     def repo_type(self) -> RepositoryType:

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.docs.models import (
@@ -19,7 +17,16 @@ from skillsaw.docs.models import (
     RuleFileDoc,
     SkillDoc,
 )
-from skillsaw.rules.builtin.utils import extract_section, parse_frontmatter
+from skillsaw.lint_target import PluginNode, SkillNode
+from skillsaw.rules.builtin.content_analysis import (
+    AgentBlock,
+    CommandBlock,
+    HooksBlock,
+    McpBlock,
+    PluginRuleBlock,
+    ReadmeBlock,
+    SkillBlock,
+)
 
 
 def extract_docs(
@@ -27,7 +34,7 @@ def extract_docs(
     title: Optional[str] = None,
 ) -> DocsOutput:
     """Extract documentation from a repository context."""
-    plugins = [_extract_plugin(context, p) for p in context.plugins]
+    plugins = [_extract_plugin(context, pn) for pn in context.lint_tree.find(PluginNode)]
 
     marketplace = None
     if RepositoryType.MARKETPLACE in context.repo_types and context.marketplace_data:
@@ -41,9 +48,9 @@ def extract_docs(
     standalone_skills: List[SkillDoc] = []
     if RepositoryType.AGENTSKILLS in context.repo_types:
         plugin_skill_paths = {s.dir_path.resolve() for p in plugins for s in p.skills}
-        for skill_path in context.skills:
-            if skill_path.resolve() not in plugin_skill_paths:
-                doc = _extract_skill(skill_path)
+        for skill_node in context.lint_tree.find(SkillNode):
+            if skill_node.path.resolve() not in plugin_skill_paths:
+                doc = _extract_skill(skill_node)
                 if doc:
                     standalone_skills.append(doc)
 
@@ -72,7 +79,8 @@ def _default_title(
     return context.repo_type.value.replace("-", " ").title() + " Documentation"
 
 
-def _extract_plugin(context: RepositoryContext, plugin_path: Path) -> PluginDoc:
+def _extract_plugin(context: RepositoryContext, plugin_node: PluginNode) -> PluginDoc:
+    plugin_path = plugin_node.path
     meta = context.get_plugin_metadata(plugin_path) or {}
     name = context.get_plugin_name(plugin_path)
 
@@ -86,85 +94,59 @@ def _extract_plugin(context: RepositoryContext, plugin_path: Path) -> PluginDoc:
         description=meta.get("description", ""),
         version=str(v) if (v := meta.get("version")) is not None else "",
         author=author_val if isinstance(author_val, dict) else None,
-        commands=_extract_commands(plugin_path),
-        skills=_extract_skills(plugin_path),
-        agents=_extract_agents(plugin_path),
-        hooks=_extract_hooks(plugin_path),
-        mcp_servers=_extract_mcp_servers(plugin_path, meta),
-        rules=_extract_rules(plugin_path),
-        has_readme=(plugin_path / "README.md").exists(),
+        commands=_extract_commands(plugin_node),
+        skills=_extract_skills(plugin_node),
+        agents=_extract_agents(plugin_node),
+        hooks=_extract_hooks(plugin_node),
+        mcp_servers=_extract_mcp_servers(plugin_node, meta),
+        rules=_extract_rules(plugin_node),
+        has_readme=bool(plugin_node.find(ReadmeBlock)),
     )
 
 
 # -- Commands --
 
 
-def _extract_commands(plugin_path: Path) -> List[CommandDoc]:
-    commands_dir = plugin_path / "commands"
-    if not commands_dir.is_dir():
-        return []
+def _extract_commands(plugin_node: PluginNode) -> List[CommandDoc]:
     docs = []
-    for cmd_file in sorted(commands_dir.glob("*.md")):
-        doc = _parse_command(cmd_file)
-        if doc:
-            docs.append(doc)
-    return docs
-
-
-def _parse_command(cmd_file: Path) -> Optional[CommandDoc]:
-    content = _read(cmd_file)
-    if content is None:
-        return None
-    fm, body = parse_frontmatter(content)
-    description = fm.get("description", "") if fm else ""
-    name_lines = extract_section(content, "Name").strip().splitlines()
-    full_name = name_lines[0] if name_lines else ""
-    synopsis = _strip_fences(extract_section(content, "Synopsis"))
-    body_text = extract_section(content, "Description")
-    return CommandDoc(
-        name=cmd_file.stem,
-        file_path=cmd_file,
-        description=description,
-        full_name=full_name,
-        synopsis=synopsis,
-        body=body_text,
-    )
-
-
-def _strip_fences(text: str) -> str:
-    """Remove leading/trailing code fences from a block."""
-    lines = text.strip().splitlines()
-    if len(lines) >= 2 and lines[0].startswith("```") and lines[-1].startswith("```"):
-        return "\n".join(lines[1:-1]).strip()
-    return text.strip()
+    for block in plugin_node.find(CommandBlock):
+        fm = block.frontmatter or {}
+        name_lines = block.section("Name").strip().splitlines()
+        full_name = name_lines[0] if name_lines else ""
+        synopsis = _strip_fences(block.section("Synopsis"))
+        body_text = block.section("Description")
+        docs.append(
+            CommandDoc(
+                name=block.path.stem,
+                file_path=block.path,
+                description=fm.get("description", ""),
+                full_name=full_name,
+                synopsis=synopsis,
+                body=body_text,
+            )
+        )
+    return sorted(docs, key=lambda d: d.name)
 
 
 # -- Skills --
 
 
-def _extract_skills(plugin_path: Path) -> List[SkillDoc]:
-    skills_dir = plugin_path / "skills"
-    if not skills_dir.is_dir():
-        return []
+def _extract_skills(plugin_node: PluginNode) -> List[SkillDoc]:
     docs = []
-    for skill_dir in sorted(skills_dir.iterdir()):
-        if not skill_dir.is_dir() or skill_dir.name.startswith("."):
-            continue
-        doc = _extract_skill(skill_dir)
+    for skill_node in plugin_node.find(SkillNode):
+        doc = _extract_skill(skill_node)
         if doc:
             docs.append(doc)
-    return docs
+    return sorted(docs, key=lambda d: d.name)
 
 
-def _extract_skill(skill_dir: Path) -> Optional[SkillDoc]:
-    skill_md = skill_dir / "SKILL.md"
-    if not skill_md.exists():
+def _extract_skill(skill_node: SkillNode) -> Optional[SkillDoc]:
+    blocks = skill_node.find(SkillBlock)
+    if not blocks:
         return None
-    content = _read(skill_md)
-    if content is None:
-        return None
-    fm, body = parse_frontmatter(content)
-    if not fm:
+    block = blocks[0]
+    fm = block.frontmatter
+    if fm is None:
         fm = {}
 
     allowed_tools = fm.get("allowed-tools", [])
@@ -174,103 +156,77 @@ def _extract_skill(skill_dir: Path) -> Optional[SkillDoc]:
         allowed_tools = []
 
     return SkillDoc(
-        name=fm.get("name", skill_dir.name),
-        dir_path=skill_dir,
+        name=fm.get("name", skill_node.path.name),
+        dir_path=skill_node.path,
         description=fm.get("description", ""),
         license=fm.get("license", ""),
         compatibility=fm.get("compatibility", ""),
         metadata=fm.get("metadata", {}),
         allowed_tools=allowed_tools or [],
-        body=body.strip(),
+        body=block.body_text.strip(),
     )
 
 
 # -- Agents --
 
 
-def _extract_agents(plugin_path: Path) -> List[AgentDoc]:
-    agents_dir = plugin_path / "agents"
-    if not agents_dir.is_dir():
-        return []
+def _extract_agents(plugin_node: PluginNode) -> List[AgentDoc]:
     docs = []
-    for agent_file in sorted(agents_dir.glob("*.md")):
-        doc = _parse_agent(agent_file)
-        if doc:
-            docs.append(doc)
-    return docs
-
-
-def _parse_agent(agent_file: Path) -> Optional[AgentDoc]:
-    content = _read(agent_file)
-    if content is None:
-        return None
-    fm, body = parse_frontmatter(content)
-    if not fm:
-        fm = {}
-    return AgentDoc(
-        name=fm.get("name", agent_file.stem),
-        file_path=agent_file,
-        description=fm.get("description", ""),
-        body=body.strip(),
-    )
+    for block in plugin_node.find(AgentBlock):
+        fm = block.frontmatter or {}
+        docs.append(
+            AgentDoc(
+                name=fm.get("name", block.path.stem),
+                file_path=block.path,
+                description=fm.get("description", ""),
+                body=block.body_text.strip(),
+            )
+        )
+    return sorted(docs, key=lambda d: d.name)
 
 
 # -- Hooks --
 
 
-def _extract_hooks(plugin_path: Path) -> List[HookDoc]:
-    hooks_file = plugin_path / "hooks" / "hooks.json"
-    if not hooks_file.exists():
-        return []
-    data = _read_json(hooks_file)
-    if not data or not isinstance(data, dict):
-        return []
-    hooks_obj = data.get("hooks", {})
-    if not isinstance(hooks_obj, dict):
-        return []
-
+def _extract_hooks(plugin_node: PluginNode) -> List[HookDoc]:
     docs = []
-    for event_type in sorted(hooks_obj):
-        configs = hooks_obj[event_type]
-        if not isinstance(configs, list):
-            continue
-        entries = []
-        for cfg in configs:
-            if not isinstance(cfg, dict):
-                continue
-            entries.append(
+    for block in plugin_node.find(HooksBlock):
+        for event_type in sorted(block.events):
+            configs = block.events[event_type]
+            entries = [
                 HookEntry(
-                    matcher=cfg.get("matcher", ".*"),
-                    hooks=cfg.get("hooks", []),
+                    matcher=cfg.matcher,
+                    hooks=[
+                        {k: v for k, v in h.__dict__.items() if v is not None and k != "type"}
+                        | {"type": h.type}
+                        for h in cfg.handlers
+                    ],
                 )
-            )
-        if entries:
-            docs.append(HookDoc(event_type=event_type, entries=entries))
+                for cfg in configs
+            ]
+            if entries:
+                docs.append(HookDoc(event_type=event_type, entries=entries))
     return docs
 
 
 # -- MCP Servers --
 
 
-def _extract_mcp_servers(plugin_path: Path, plugin_meta: Dict[str, Any]) -> List[McpServerDoc]:
+def _extract_mcp_servers(plugin_node: PluginNode, plugin_meta: dict) -> List[McpServerDoc]:
     servers: List[McpServerDoc] = []
     seen: set = set()
 
-    mcp_json_path = plugin_path / ".mcp.json"
-    if mcp_json_path.exists():
-        data = _read_json(mcp_json_path)
-        if data and isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
-            for name, cfg in data["mcpServers"].items():
-                if isinstance(cfg, dict):
-                    servers.append(
-                        McpServerDoc(
-                            name=name,
-                            server_type=cfg.get("type", "stdio"),
-                            config=cfg,
-                            source_file=".mcp.json",
-                        )
-                    )
-                    seen.add(name)
+    for block in plugin_node.find(McpBlock):
+        for srv in block.servers:
+            servers.append(
+                McpServerDoc(
+                    name=srv.name,
+                    server_type=srv.type,
+                    config={k: v for k, v in srv.__dict__.items() if v is not None and k != "name"},
+                    source_file=".mcp.json",
+                )
+            )
+            seen.add(srv.name)
 
     mcp_in_plugin = plugin_meta.get("mcpServers", {})
     if isinstance(mcp_in_plugin, dict):
@@ -288,57 +244,35 @@ def _extract_mcp_servers(plugin_path: Path, plugin_meta: Dict[str, Any]) -> List
     return servers
 
 
-# -- Rules (DOT_CLAUDE) --
+# -- Rules --
 
 
-def _extract_rules(plugin_path: Path) -> List[RuleFileDoc]:
-    rules_dir = plugin_path / "rules"
-    if not rules_dir.is_dir():
-        return []
+def _extract_rules(plugin_node: PluginNode) -> List[RuleFileDoc]:
     docs = []
-    for rule_file in sorted(rules_dir.rglob("*.md")):
-        doc = _parse_rule_file(rule_file)
-        if doc:
-            docs.append(doc)
-    return docs
-
-
-def _parse_rule_file(rule_file: Path) -> Optional[RuleFileDoc]:
-    content = _read(rule_file)
-    if content is None:
-        return None
-    fm, body = parse_frontmatter(content)
-    globs: List[str] = []
-    description = ""
-    if fm:
+    for block in plugin_node.find(PluginRuleBlock):
+        fm = block.frontmatter or {}
+        globs: List[str] = []
         paths = fm.get("paths", [])
         if isinstance(paths, list):
             globs = [str(p) for p in paths]
-        description = fm.get("description", "")
-    return RuleFileDoc(
-        name=rule_file.stem,
-        file_path=rule_file,
-        description=description,
-        globs=globs,
-        body=body.strip(),
-    )
+        docs.append(
+            RuleFileDoc(
+                name=block.path.stem,
+                file_path=block.path,
+                description=fm.get("description", ""),
+                globs=globs,
+                body=block.body_text.strip(),
+            )
+        )
+    return sorted(docs, key=lambda d: d.name)
 
 
 # -- Helpers --
 
 
-def _read(path: Path) -> Optional[str]:
-    try:
-        return path.read_text(encoding="utf-8")
-    except (IOError, UnicodeDecodeError):
-        return None
-
-
-def _read_json(path: Path) -> Optional[Any]:
-    content = _read(path)
-    if content is None:
-        return None
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError:
-        return None
+def _strip_fences(text: str) -> str:
+    """Remove leading/trailing code fences from a block."""
+    lines = text.strip().splitlines()
+    if len(lines) >= 2 and lines[0].startswith("```") and lines[-1].startswith("```"):
+        return "\n".join(lines[1:-1]).strip()
+    return text.strip()

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -34,14 +34,16 @@ def format_html(
 
     def location(v: RuleViolation) -> str:
         rel = relative_path(v.file_path, context.root_path)
-        if rel and v.line:
-            return html.escape(f"{rel}:{v.line}")
+        if rel and v.file_line:
+            return html.escape(f"{rel}:{v.file_line}")
         if rel:
             return html.escape(rel)
         return "-"
 
     severity_order = {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2}
-    visible.sort(key=lambda v: (severity_order[v.severity], str(v.file_path or ""), v.line or 0))
+    visible.sort(
+        key=lambda v: (severity_order[v.severity], str(v.file_path or ""), v.file_line or 0)
+    )
 
     rows = ""
     for v in visible:

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -44,7 +44,7 @@ def format_json(
                 "severity": v.severity.value,
                 "message": v.message,
                 "file_path": relative_path(v.file_path, context.root_path),
-                "line": v.line,
+                "line": v.file_line,
             }
             for v in violations
             if verbose or v.severity != Severity.INFO

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -65,8 +65,9 @@ def format_sarif(
                     },
                 },
             }
-            if v.line is not None and v.line >= 1:
-                location["physicalLocation"]["region"] = {"startLine": v.line}
+            fl = v.file_line
+            if fl is not None and fl >= 1:
+                location["physicalLocation"]["region"] = {"startLine": fl}
             result["locations"] = [location]
         results.append(result)
 

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -35,7 +35,7 @@ def format_text(
         rel = relative_path(v.file_path, context.root_path)
         location = ""
         if rel:
-            location = f" [{rel}:{v.line}]" if v.line else f" [{rel}]"
+            location = f" [{rel}:{v.file_line}]" if v.file_line else f" [{rel}]"
         return f"{icon} {v.severity.value.upper()}{location}: {v.message}"
 
     output = []

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -46,14 +46,22 @@ class LintTarget:
     def tree_label(self) -> str:
         return self.path.name
 
+    def estimate_tokens(self) -> int:
+        return sum(c.estimate_tokens() for c in self.children)
+
+    def _format_tokens(self, tokens: int) -> str:
+        return f"{tokens:,}"
+
     def print_tree(
         self, *, _prefix: str = "", _last: bool = True, root_path: Path | None = None
     ) -> str:
         lines: list[str] = []
+        tokens = self.estimate_tokens()
+        token_str = f" ({self._format_tokens(tokens)} tokens)"
         if root_path and self.path == root_path:
-            label = f"{self.path.name}/"
+            label = f"{self.path.name}/{token_str}"
         else:
-            label = self.tree_label()
+            label = f"{self.tree_label()}{token_str}"
 
         if _prefix or not root_path:
             connector = "└── " if _last else "├── "
@@ -65,6 +73,63 @@ class LintTarget:
         for i, child in enumerate(self.children):
             is_last = i == len(self.children) - 1
             lines.append(child.print_tree(_prefix=child_prefix, _last=is_last, root_path=root_path))
+        return "\n".join(lines)
+
+    def print_dot(self, *, root_path: Path | None = None) -> str:
+        _COLORS = {
+            "LintTarget": "#e8e8e8",
+            "MarketplaceConfigNode": "#fff3cd",
+            "MarketplaceNode": "#f8d7da",
+            "PluginNode": "#d4edda",
+            "SkillNode": "#cce5ff",
+            "ApmConfigNode": "#fff3cd",
+            "ApmNode": "#e2d9f3",
+            "CodeRabbitNode": "#fde2e4",
+            "ContentBlock": "#d1ecf1",
+        }
+
+        lines: list[str] = []
+        lines.append("digraph lint_tree {")
+        lines.append("    rankdir=TB;")
+        lines.append('    node [shape=box, fontname="Helvetica", fontsize=10];')
+
+        counter = [0]
+        node_ids: dict[int, str] = {}
+
+        def _node_id(node: "LintTarget") -> str:
+            obj_id = id(node)
+            if obj_id not in node_ids:
+                node_ids[obj_id] = f"n{counter[0]}"
+                counter[0] += 1
+            return node_ids[obj_id]
+
+        def _color(node: "LintTarget") -> str:
+            from .rules.builtin.content_analysis import ContentBlock
+
+            if isinstance(node, ContentBlock):
+                return _COLORS["ContentBlock"]
+            return _COLORS.get(type(node).__name__, _COLORS["LintTarget"])
+
+        def _dot_label(node: "LintTarget") -> str:
+            if root_path and node.path == root_path:
+                name = f"{node.path.name}/"
+            else:
+                name = node.tree_label()
+            tokens = node.estimate_tokens()
+            return f"{name}\\n({node._format_tokens(tokens)} tokens)"
+
+        def _emit(node: "LintTarget", parent_id: str | None) -> None:
+            nid = _node_id(node)
+            label = _dot_label(node).replace('"', '\\"')
+            color = _color(node)
+            lines.append(f'    {nid} [label="{label}" style=filled fillcolor="{color}"];')
+            if parent_id:
+                lines.append(f"    {parent_id} -> {nid};")
+            for child in node.children:
+                _emit(child, nid)
+
+        _emit(self, None)
+        lines.append("}")
         return "\n".join(lines)
 
 

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -17,6 +17,7 @@ class LintTarget:
 
     path: Path
     children: List["LintTarget"] = field(default_factory=list)
+    parent: Optional["LintTarget"] = field(default=None, repr=False)
 
     def walk(self) -> Iterator["LintTarget"]:
         yield self
@@ -27,16 +28,19 @@ class LintTarget:
         return [n for n in self.walk() if isinstance(n, target_type)]
 
     def find_parent(self, target: "LintTarget", parent_type: Type[T]) -> Optional[T]:
-        """Find the nearest ancestor of ``target`` that is an instance of ``parent_type``."""
-        result: Optional[T] = None
-        for node in self.walk():
-            if not isinstance(node, parent_type):
-                continue
-            for child in node.walk():
-                if child is target:
-                    result = node
-                    break
-        return result
+        """Find the nearest ancestor of ``target`` that is ``parent_type``."""
+        node = target.parent
+        while node is not None:
+            if isinstance(node, parent_type):
+                return node
+            node = node.parent
+        return None
+
+    def set_parents(self) -> None:
+        """Set parent back-pointers for the entire subtree."""
+        for child in self.children:
+            child.parent = self
+            child.set_parents()
 
     def content_blocks(self) -> list:
         from .rules.builtin.content_analysis import ContentBlock

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -91,6 +91,14 @@ class SkillNode(LintTarget):
 
 
 @dataclass
+class ApmNode(LintTarget):
+    """The .apm/ directory container."""
+
+    def tree_label(self) -> str:
+        return ".apm/"
+
+
+@dataclass
 class CodeRabbitNode(LintTarget):
     """A .coderabbit.yaml file container."""
 

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -28,13 +28,15 @@ class LintTarget:
 
     def find_parent(self, target: "LintTarget", parent_type: Type[T]) -> Optional[T]:
         """Find the nearest ancestor of ``target`` that is an instance of ``parent_type``."""
+        result: Optional[T] = None
         for node in self.walk():
             if not isinstance(node, parent_type):
                 continue
             for child in node.walk():
                 if child is target:
-                    return node
-        return None
+                    result = node
+                    break
+        return result
 
     def content_blocks(self) -> list:
         from .rules.builtin.content_analysis import ContentBlock

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -60,8 +60,10 @@ class LintTarget:
         self, *, _prefix: str = "", _last: bool = True, root_path: Path | None = None
     ) -> str:
         lines: list[str] = []
-        tokens = self.estimate_tokens()
-        token_str = f" ({self._format_tokens(tokens)} tokens)"
+        token_str = ""
+        if getattr(self, "show_tokens", True):
+            tokens = self.estimate_tokens()
+            token_str = f" ({self._format_tokens(tokens)} tokens)"
         if root_path and self.path == root_path:
             label = f"{self.path.name}/{token_str}"
         else:

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -69,6 +69,14 @@ class LintTarget:
 
 
 @dataclass
+class MarketplaceConfigNode(LintTarget):
+    """The .claude-plugin/marketplace.json manifest file."""
+
+    def tree_label(self) -> str:
+        return "marketplace.json"
+
+
+@dataclass
 class MarketplaceNode(LintTarget):
     """A marketplace plugins directory."""
 

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -1,0 +1,72 @@
+"""
+Base class for all nodes in the repository lint tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, List, Type, TypeVar
+
+T = TypeVar("T", bound="LintTarget")
+
+
+@dataclass
+class LintTarget:
+    """A node in the repository lint tree."""
+
+    path: Path
+    children: List["LintTarget"] = field(default_factory=list)
+
+    def walk(self) -> Iterator["LintTarget"]:
+        yield self
+        for child in self.children:
+            yield from child.walk()
+
+    def find(self, target_type: Type[T]) -> List[T]:
+        return [n for n in self.walk() if isinstance(n, target_type)]
+
+    def content_blocks(self) -> list:
+        from .rules.builtin.content_analysis import ContentBlock
+
+        return self.find(ContentBlock)
+
+    def tree_label(self) -> str:
+        return self.path.name
+
+    def print_tree(
+        self, *, _prefix: str = "", _last: bool = True, root_path: Path | None = None
+    ) -> str:
+        lines: list[str] = []
+        if root_path and self.path == root_path:
+            label = f"{self.path.name}/"
+        else:
+            label = self.tree_label()
+
+        if _prefix or not root_path:
+            connector = "└── " if _last else "├── "
+            lines.append(f"{_prefix}{connector}{label}")
+        else:
+            lines.append(label)
+
+        child_prefix = _prefix + ("    " if _last else "│   ")
+        for i, child in enumerate(self.children):
+            is_last = i == len(self.children) - 1
+            lines.append(child.print_tree(_prefix=child_prefix, _last=is_last, root_path=root_path))
+        return "\n".join(lines)
+
+
+@dataclass
+class PluginNode(LintTarget):
+    """A plugin directory."""
+
+    def tree_label(self) -> str:
+        return f"{self.path.name}/ [plugin]"
+
+
+@dataclass
+class SkillNode(LintTarget):
+    """A skill directory."""
+
+    def tree_label(self) -> str:
+        return f"{self.path.name}/ [skill]"

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -57,6 +57,14 @@ class LintTarget:
 
 
 @dataclass
+class MarketplaceNode(LintTarget):
+    """A marketplace plugins directory."""
+
+    def tree_label(self) -> str:
+        return f"{self.path.name}/ [marketplace]"
+
+
+@dataclass
 class PluginNode(LintTarget):
     """A plugin directory."""
 

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator, List, Type, TypeVar
+from typing import Iterator, List, Optional, Type, TypeVar
 
 T = TypeVar("T", bound="LintTarget")
 
@@ -25,6 +25,16 @@ class LintTarget:
 
     def find(self, target_type: Type[T]) -> List[T]:
         return [n for n in self.walk() if isinstance(n, target_type)]
+
+    def find_parent(self, target: "LintTarget", parent_type: Type[T]) -> Optional[T]:
+        """Find the nearest ancestor of ``target`` that is an instance of ``parent_type``."""
+        for node in self.walk():
+            if not isinstance(node, parent_type):
+                continue
+            for child in node.walk():
+                if child is target:
+                    return node
+        return None
 
     def content_blocks(self) -> list:
         from .rules.builtin.content_analysis import ContentBlock
@@ -78,3 +88,11 @@ class SkillNode(LintTarget):
 
     def tree_label(self) -> str:
         return f"{self.path.name}/ [skill]"
+
+
+@dataclass
+class CodeRabbitNode(LintTarget):
+    """A .coderabbit.yaml file container."""
+
+    def tree_label(self) -> str:
+        return ".coderabbit.yaml"

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -91,6 +91,14 @@ class SkillNode(LintTarget):
 
 
 @dataclass
+class ApmConfigNode(LintTarget):
+    """The apm.yml manifest file."""
+
+    def tree_label(self) -> str:
+        return "apm.yml"
+
+
+@dataclass
 class ApmNode(LintTarget):
     """The .apm/ directory container."""
 

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import fnmatch
 from pathlib import Path
-from typing import Callable, List, Set, TYPE_CHECKING
+from typing import Set, TYPE_CHECKING
 
-from .lint_target import LintTarget, MarketplaceNode, PluginNode, SkillNode
+from .lint_target import LintTarget, MarketplaceNode, PluginNode, SkillNode, CodeRabbitNode
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
@@ -17,10 +17,28 @@ if TYPE_CHECKING:
 def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     """Build a tree of all lintable objects in the repository."""
     from .rules.builtin.content_analysis import (
+        AgentBlock,
+        AgentsMdBlock,
+        ChatmodeBlock,
+        ClaudeMdBlock,
         CodeRabbitContentBlock,
-        FileContentBlock,
-        FrontmatterContentBlock,
+        CommandBlock,
+        ContextFileBlock,
+        CursorRuleBlock,
+        ExtraBlock,
+        GeminiMdBlock,
+        InstructionBlock,
+        PluginRuleBlock,
+        PromptBlock,
+        SkillBlock,
+        SkillRefBlock,
     )
+
+    _INSTRUCTION_FILE_BLOCK_TYPES = {
+        "AGENTS.md": AgentsMdBlock,
+        "CLAUDE.md": ClaudeMdBlock,
+        "GEMINI.md": GeminiMdBlock,
+    }
 
     root = LintTarget(path=context.root_path)
     seen: Set[Path] = set()
@@ -51,53 +69,43 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         resolved = p.resolve()
         return any(resolved == excl or resolved.is_relative_to(excl) for excl in apm_compiled_roots)
 
-    _INSTRUCTION_FILE_CATEGORIES = {
-        "AGENTS.md": "agents-md",
-        "CLAUDE.md": "claude-md",
-        "GEMINI.md": "gemini-md",
-    }
-
-    def _add_content(
+    def _add_block(
         parent: LintTarget,
         p: Path,
-        category: str,
+        block_cls: type,
     ) -> None:
         resolved = p.resolve()
         if resolved in seen or not p.exists() or _is_excluded(p):
             return
         seen.add(resolved)
-        if p.suffix == ".mdc":
-            block = FrontmatterContentBlock(path=p, category=category)
-        else:
-            block = FileContentBlock(path=p, category=category)
-        parent.children.append(block)
+        parent.children.append(block_cls(path=p))
 
     # --- Root-level instruction files ---
     for f in context.instruction_files:
-        cat = _INSTRUCTION_FILE_CATEGORIES.get(f.name, "instruction")
-        _add_content(root, f, cat)
+        block_cls = _INSTRUCTION_FILE_BLOCK_TYPES.get(f.name, InstructionBlock)
+        _add_block(root, f, block_cls)
 
-    _add_content(root, context.root_path / ".github" / "copilot-instructions.md", "instruction")
-    _add_content(root, context.root_path / ".cursorrules", "instruction")
+    _add_block(root, context.root_path / ".github" / "copilot-instructions.md", InstructionBlock)
+    _add_block(root, context.root_path / ".cursorrules", InstructionBlock)
 
     cursor_rules_dir = context.root_path / ".cursor" / "rules"
     if cursor_rules_dir.is_dir() and not _is_in_compiled_dir(cursor_rules_dir):
         for mdc in sorted(cursor_rules_dir.glob("*.mdc")):
-            _add_content(root, mdc, "instruction")
+            _add_block(root, mdc, CursorRuleBlock)
 
     kiro_steering = context.root_path / ".kiro" / "steering"
     if kiro_steering.is_dir():
         for md in sorted(kiro_steering.glob("*.md")):
-            _add_content(root, md, "instruction")
+            _add_block(root, md, InstructionBlock)
 
-    _add_content(root, context.root_path / ".windsurfrules", "instruction")
+    _add_block(root, context.root_path / ".windsurfrules", InstructionBlock)
 
     clinerules = context.root_path / ".clinerules"
     if clinerules.is_file():
-        _add_content(root, clinerules, "instruction")
+        _add_block(root, clinerules, InstructionBlock)
     elif clinerules.is_dir():
         for md in sorted(clinerules.glob("*.md")):
-            _add_content(root, md, "instruction")
+            _add_block(root, md, InstructionBlock)
 
     # --- Plugins (build first so skills can nest inside them) ---
     plugin_nodes: dict[Path, PluginNode] = {}
@@ -115,17 +123,17 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         commands_dir = plugin_path / "commands"
         if commands_dir.is_dir():
             for cmd_file in sorted(commands_dir.glob("*.md")):
-                _add_content(plugin_node, cmd_file, "command")
+                _add_block(plugin_node, cmd_file, CommandBlock)
 
         agents_dir = plugin_path / "agents"
         if agents_dir.is_dir():
             for agent_file in sorted(agents_dir.glob("*.md")):
-                _add_content(plugin_node, agent_file, "agent")
+                _add_block(plugin_node, agent_file, AgentBlock)
 
         rules_dir = plugin_path / "rules"
         if rules_dir.is_dir():
             for rule_file in sorted(rules_dir.rglob("*.md")):
-                _add_content(plugin_node, rule_file, "rule")
+                _add_block(plugin_node, rule_file, PluginRuleBlock)
 
         plugin_nodes[plugin_path.resolve()] = plugin_node
         if marketplace_node is not None and plugin_path.resolve().is_relative_to(
@@ -138,11 +146,11 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     # --- Skills (nest inside parent plugin when applicable) ---
     for skill_path in context.skills:
         skill_node = SkillNode(path=skill_path)
-        _add_content(skill_node, skill_path / "SKILL.md", "skill")
+        _add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
         refs_dir = skill_path / "references"
         if refs_dir.is_dir():
             for ref_file in sorted(refs_dir.glob("*.md")):
-                _add_content(skill_node, ref_file, "skill-ref")
+                _add_block(skill_node, ref_file, SkillRefBlock)
 
         parent_plugin = None
         for plugin_resolved, plugin_node in plugin_nodes.items():
@@ -157,7 +165,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     # --- .coderabbit.yaml ---
     cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)
     if cr_blocks:
-        cr_container = LintTarget(path=context.root_path / ".coderabbit.yaml")
+        cr_container = CodeRabbitNode(path=context.root_path / ".coderabbit.yaml")
         cr_container.children.extend(cr_blocks)
         root.children.append(cr_container)
 
@@ -168,32 +176,32 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         apm_instructions = apm_dir / "instructions"
         if apm_instructions.is_dir():
             for md in sorted(apm_instructions.glob("*.instructions.md")):
-                _add_content(root, md, "instruction")
+                _add_block(root, md, InstructionBlock)
 
         apm_agents = apm_dir / "agents"
         if apm_agents.is_dir():
             for md in sorted(apm_agents.glob("*.agent.md")):
-                _add_content(root, md, "agent")
+                _add_block(root, md, AgentBlock)
 
         apm_prompts = apm_dir / "prompts"
         if apm_prompts.is_dir():
             for md in sorted(apm_prompts.glob("*.md")):
-                _add_content(root, md, "prompt")
+                _add_block(root, md, PromptBlock)
 
         apm_chatmodes = apm_dir / "chatmodes"
         if apm_chatmodes.is_dir():
             for md in sorted(apm_chatmodes.glob("*.md")):
-                _add_content(root, md, "chatmode")
+                _add_block(root, md, ChatmodeBlock)
 
         apm_context = apm_dir / "context"
         if apm_context.is_dir():
             for md in sorted(apm_context.glob("*.md")):
-                _add_content(root, md, "context")
+                _add_block(root, md, ContextFileBlock)
 
     # --- Extra content paths from config ---
     for glob_pattern in getattr(context, "content_paths", []):
         for extra in sorted(context.root_path.glob(glob_pattern)):
             if extra.is_file():
-                _add_content(root, extra, "extra")
+                _add_block(root, extra, ExtraBlock)
 
     return root

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -8,7 +8,15 @@ import fnmatch
 from pathlib import Path
 from typing import Set, TYPE_CHECKING
 
-from .lint_target import LintTarget, ApmNode, MarketplaceNode, PluginNode, SkillNode, CodeRabbitNode
+from .lint_target import (
+    LintTarget,
+    ApmConfigNode,
+    ApmNode,
+    MarketplaceNode,
+    PluginNode,
+    SkillNode,
+    CodeRabbitNode,
+)
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
@@ -170,8 +178,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         cr_container.children.extend(cr_blocks)
         root.children.append(cr_container)
 
-    # --- APM source directories ---
+    # --- APM ---
     if context.has_apm:
+        apm_yml = context.root_path / "apm.yml"
+        if apm_yml.exists() and not _is_excluded(apm_yml):
+            root.children.append(ApmConfigNode(path=apm_yml))
+
         apm_dir = context.root_path / ".apm"
         apm_node = ApmNode(path=apm_dir)
 

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -8,7 +8,7 @@ import fnmatch
 from pathlib import Path
 from typing import Callable, List, Set, TYPE_CHECKING
 
-from .lint_target import LintTarget, PluginNode, SkillNode
+from .lint_target import LintTarget, MarketplaceNode, PluginNode, SkillNode
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
@@ -101,6 +101,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
 
     # --- Plugins (build first so skills can nest inside them) ---
     plugin_nodes: dict[Path, PluginNode] = {}
+    marketplace_dir = context.root_path / "plugins"
+    marketplace_node: MarketplaceNode | None = None
+    if context.has_marketplace() and marketplace_dir.is_dir():
+        marketplace_node = MarketplaceNode(path=marketplace_dir)
+        root.children.append(marketplace_node)
+
     for plugin_path in context.plugins:
         if _is_in_compiled_dir(plugin_path):
             continue
@@ -122,7 +128,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 _add_content(plugin_node, rule_file, "rule")
 
         plugin_nodes[plugin_path.resolve()] = plugin_node
-        root.children.append(plugin_node)
+        if marketplace_node is not None and plugin_path.resolve().is_relative_to(
+            marketplace_dir.resolve()
+        ):
+            marketplace_node.children.append(plugin_node)
+        else:
+            root.children.append(plugin_node)
 
     # --- Skills (nest inside parent plugin when applicable) ---
     for skill_path in context.skills:

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -99,17 +99,8 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         for md in sorted(clinerules.glob("*.md")):
             _add_content(root, md, "instruction")
 
-    # --- Skills ---
-    for skill_path in context.skills:
-        skill_node = SkillNode(path=skill_path)
-        _add_content(skill_node, skill_path / "SKILL.md", "skill")
-        refs_dir = skill_path / "references"
-        if refs_dir.is_dir():
-            for ref_file in sorted(refs_dir.glob("*.md")):
-                _add_content(skill_node, ref_file, "skill-ref")
-        root.children.append(skill_node)
-
-    # --- Plugins ---
+    # --- Plugins (build first so skills can nest inside them) ---
+    plugin_nodes: dict[Path, PluginNode] = {}
     for plugin_path in context.plugins:
         if _is_in_compiled_dir(plugin_path):
             continue
@@ -130,7 +121,27 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             for rule_file in sorted(rules_dir.rglob("*.md")):
                 _add_content(plugin_node, rule_file, "rule")
 
+        plugin_nodes[plugin_path.resolve()] = plugin_node
         root.children.append(plugin_node)
+
+    # --- Skills (nest inside parent plugin when applicable) ---
+    for skill_path in context.skills:
+        skill_node = SkillNode(path=skill_path)
+        _add_content(skill_node, skill_path / "SKILL.md", "skill")
+        refs_dir = skill_path / "references"
+        if refs_dir.is_dir():
+            for ref_file in sorted(refs_dir.glob("*.md")):
+                _add_content(skill_node, ref_file, "skill-ref")
+
+        parent_plugin = None
+        for plugin_resolved, plugin_node in plugin_nodes.items():
+            if skill_path.resolve().is_relative_to(plugin_resolved):
+                parent_plugin = plugin_node
+                break
+        if parent_plugin is not None:
+            parent_plugin.children.append(skill_node)
+        else:
+            root.children.append(skill_node)
 
     # --- .coderabbit.yaml ---
     cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -1,0 +1,177 @@
+"""
+Build the repository lint tree — single discovery entrypoint.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+from typing import Callable, List, Set, TYPE_CHECKING
+
+from .lint_target import LintTarget, PluginNode, SkillNode
+
+if TYPE_CHECKING:
+    from .context import RepositoryContext
+
+
+def build_lint_tree(context: "RepositoryContext") -> LintTarget:
+    """Build a tree of all lintable objects in the repository."""
+    from .rules.builtin.content_analysis import (
+        CodeRabbitContentBlock,
+        FileContentBlock,
+        FrontmatterContentBlock,
+    )
+
+    root = LintTarget(path=context.root_path)
+    seen: Set[Path] = set()
+    exclude = getattr(context, "exclude_patterns", [])
+    resolved_root = context.root_path.resolve()
+
+    apm_compiled_roots: Set[Path] = set()
+    if context.has_apm:
+        from .context import RepositoryContext as _RC
+
+        for compiled_dir_name in _RC.APM_COMPILED_DIRS:
+            compiled_path = (context.root_path / compiled_dir_name).resolve()
+            if compiled_path.is_dir():
+                apm_compiled_roots.add(compiled_path)
+
+    def _is_excluded(p: Path) -> bool:
+        if not exclude:
+            return False
+        try:
+            rel = str(p.resolve().relative_to(resolved_root))
+        except ValueError:
+            return False
+        return any(fnmatch.fnmatch(rel, pat) for pat in exclude)
+
+    def _is_in_compiled_dir(p: Path) -> bool:
+        if not apm_compiled_roots:
+            return False
+        resolved = p.resolve()
+        return any(resolved == excl or resolved.is_relative_to(excl) for excl in apm_compiled_roots)
+
+    _INSTRUCTION_FILE_CATEGORIES = {
+        "AGENTS.md": "agents-md",
+        "CLAUDE.md": "claude-md",
+        "GEMINI.md": "gemini-md",
+    }
+
+    def _add_content(
+        parent: LintTarget,
+        p: Path,
+        category: str,
+    ) -> None:
+        resolved = p.resolve()
+        if resolved in seen or not p.exists() or _is_excluded(p):
+            return
+        seen.add(resolved)
+        if p.suffix == ".mdc":
+            block = FrontmatterContentBlock(path=p, category=category)
+        else:
+            block = FileContentBlock(path=p, category=category)
+        parent.children.append(block)
+
+    # --- Root-level instruction files ---
+    for f in context.instruction_files:
+        cat = _INSTRUCTION_FILE_CATEGORIES.get(f.name, "instruction")
+        _add_content(root, f, cat)
+
+    _add_content(root, context.root_path / ".github" / "copilot-instructions.md", "instruction")
+    _add_content(root, context.root_path / ".cursorrules", "instruction")
+
+    cursor_rules_dir = context.root_path / ".cursor" / "rules"
+    if cursor_rules_dir.is_dir() and not _is_in_compiled_dir(cursor_rules_dir):
+        for mdc in sorted(cursor_rules_dir.glob("*.mdc")):
+            _add_content(root, mdc, "instruction")
+
+    kiro_steering = context.root_path / ".kiro" / "steering"
+    if kiro_steering.is_dir():
+        for md in sorted(kiro_steering.glob("*.md")):
+            _add_content(root, md, "instruction")
+
+    _add_content(root, context.root_path / ".windsurfrules", "instruction")
+
+    clinerules = context.root_path / ".clinerules"
+    if clinerules.is_file():
+        _add_content(root, clinerules, "instruction")
+    elif clinerules.is_dir():
+        for md in sorted(clinerules.glob("*.md")):
+            _add_content(root, md, "instruction")
+
+    # --- Skills ---
+    for skill_path in context.skills:
+        skill_node = SkillNode(path=skill_path)
+        _add_content(skill_node, skill_path / "SKILL.md", "skill")
+        refs_dir = skill_path / "references"
+        if refs_dir.is_dir():
+            for ref_file in sorted(refs_dir.glob("*.md")):
+                _add_content(skill_node, ref_file, "skill-ref")
+        root.children.append(skill_node)
+
+    # --- Plugins ---
+    for plugin_path in context.plugins:
+        if _is_in_compiled_dir(plugin_path):
+            continue
+        plugin_node = PluginNode(path=plugin_path)
+
+        commands_dir = plugin_path / "commands"
+        if commands_dir.is_dir():
+            for cmd_file in sorted(commands_dir.glob("*.md")):
+                _add_content(plugin_node, cmd_file, "command")
+
+        agents_dir = plugin_path / "agents"
+        if agents_dir.is_dir():
+            for agent_file in sorted(agents_dir.glob("*.md")):
+                _add_content(plugin_node, agent_file, "agent")
+
+        rules_dir = plugin_path / "rules"
+        if rules_dir.is_dir():
+            for rule_file in sorted(rules_dir.rglob("*.md")):
+                _add_content(plugin_node, rule_file, "rule")
+
+        root.children.append(plugin_node)
+
+    # --- .coderabbit.yaml ---
+    cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)
+    if cr_blocks:
+        cr_container = LintTarget(path=context.root_path / ".coderabbit.yaml")
+        cr_container.children.extend(cr_blocks)
+        root.children.append(cr_container)
+
+    # --- APM source directories ---
+    if context.has_apm:
+        apm_dir = context.root_path / ".apm"
+
+        apm_instructions = apm_dir / "instructions"
+        if apm_instructions.is_dir():
+            for md in sorted(apm_instructions.glob("*.instructions.md")):
+                _add_content(root, md, "instruction")
+
+        apm_agents = apm_dir / "agents"
+        if apm_agents.is_dir():
+            for md in sorted(apm_agents.glob("*.agent.md")):
+                _add_content(root, md, "agent")
+
+        apm_prompts = apm_dir / "prompts"
+        if apm_prompts.is_dir():
+            for md in sorted(apm_prompts.glob("*.md")):
+                _add_content(root, md, "prompt")
+
+        apm_chatmodes = apm_dir / "chatmodes"
+        if apm_chatmodes.is_dir():
+            for md in sorted(apm_chatmodes.glob("*.md")):
+                _add_content(root, md, "chatmode")
+
+        apm_context = apm_dir / "context"
+        if apm_context.is_dir():
+            for md in sorted(apm_context.glob("*.md")):
+                _add_content(root, md, "context")
+
+    # --- Extra content paths from config ---
+    for glob_pattern in getattr(context, "content_paths", []):
+        for extra in sorted(context.root_path.glob(glob_pattern)):
+            if extra.is_file():
+                _add_content(root, extra, "extra")
+
+    return root

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -39,7 +39,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         CursorRuleBlock,
         ExtraBlock,
         GeminiMdBlock,
+        HooksBlock,
         InstructionBlock,
+        McpBlock,
+        ReadmeBlock,
         PluginRuleBlock,
         PromptBlock,
         SkillBlock,
@@ -161,6 +164,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         if rules_dir.is_dir():
             for rule_file in sorted(rules_dir.rglob("*.md")):
                 _add_block(plugin_node, rule_file, PluginRuleBlock)
+
+        _add_block(plugin_node, plugin_path / "hooks" / "hooks.json", HooksBlock)
+        _add_block(plugin_node, plugin_path / ".mcp.json", McpBlock)
+        _add_block(plugin_node, plugin_path / "README.md", ReadmeBlock)
 
         plugin_nodes[plugin_path.resolve()] = plugin_node
         if marketplace_node is not None and plugin_path.resolve().is_relative_to(

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -12,6 +12,7 @@ from .lint_target import (
     LintTarget,
     ApmConfigNode,
     ApmNode,
+    MarketplaceConfigNode,
     MarketplaceNode,
     PluginNode,
     SkillNode,
@@ -114,6 +115,11 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     elif clinerules.is_dir():
         for md in sorted(clinerules.glob("*.md")):
             _add_block(root, md, InstructionBlock)
+
+    # --- Marketplace config ---
+    marketplace_json = context.root_path / ".claude-plugin" / "marketplace.json"
+    if marketplace_json.exists() and not _is_excluded(marketplace_json):
+        root.children.append(MarketplaceConfigNode(path=marketplace_json))
 
     # --- Plugins (build first so skills can nest inside them) ---
     plugin_nodes: dict[Path, PluginNode] = {}

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -5,8 +5,11 @@ Build the repository lint tree — single discovery entrypoint.
 from __future__ import annotations
 
 import fnmatch
+import logging
 from pathlib import Path
 from typing import Set, TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 from .lint_target import (
     LintTarget,
@@ -72,6 +75,14 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             return False
         return any(fnmatch.fnmatch(rel, pat) for pat in exclude)
 
+    apm_source_root = (context.root_path / ".apm").resolve() if context.has_apm else None
+
+    def _is_in_apm_source(p: Path) -> bool:
+        if apm_source_root is None:
+            return False
+        resolved = p.resolve()
+        return resolved == apm_source_root or resolved.is_relative_to(apm_source_root)
+
     def _is_in_compiled_dir(p: Path) -> bool:
         if not apm_compiled_roots:
             return False
@@ -89,8 +100,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         seen.add(resolved)
         parent.children.append(block_cls(path=p))
 
-    # --- Root-level instruction files ---
+    # --- Root-level instruction files (skip .apm/ — handled in APM section) ---
     for f in context.instruction_files:
+        if _is_in_apm_source(f):
+            continue
         block_cls = _INSTRUCTION_FILE_BLOCK_TYPES.get(f.name, InstructionBlock)
         _add_block(root, f, block_cls)
 
@@ -157,8 +170,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         else:
             root.children.append(plugin_node)
 
-    # --- Skills (nest inside parent plugin when applicable) ---
+    # --- Skills (nest inside parent plugin when applicable; skip .apm/) ---
     for skill_path in context.skills:
+        if _is_in_apm_source(skill_path):
+            continue
         skill_node = SkillNode(path=skill_path)
         _add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
         refs_dir = skill_path / "references"
@@ -218,6 +233,18 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             for md in sorted(apm_context.glob("*.md")):
                 _add_block(apm_node, md, ContextFileBlock)
 
+        apm_skills = apm_dir / "skills"
+        if apm_skills.is_dir():
+            for skill_path in context.skills:
+                if skill_path.resolve().is_relative_to(apm_skills.resolve()):
+                    skill_node = SkillNode(path=skill_path)
+                    _add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
+                    refs_dir = skill_path / "references"
+                    if refs_dir.is_dir():
+                        for ref_file in sorted(refs_dir.glob("*.md")):
+                            _add_block(skill_node, ref_file, SkillRefBlock)
+                    apm_node.children.append(skill_node)
+
         root.children.append(apm_node)
 
     # --- Extra content paths from config ---
@@ -226,4 +253,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             if extra.is_file():
                 _add_block(root, extra, ExtraBlock)
 
+    root.set_parents()
+    nodes = list(root.walk())
+    logger.info("Built lint tree: %d nodes", len(nodes))
     return root

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -8,7 +8,7 @@ import fnmatch
 from pathlib import Path
 from typing import Set, TYPE_CHECKING
 
-from .lint_target import LintTarget, MarketplaceNode, PluginNode, SkillNode, CodeRabbitNode
+from .lint_target import LintTarget, ApmNode, MarketplaceNode, PluginNode, SkillNode, CodeRabbitNode
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
@@ -163,40 +163,44 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             root.children.append(skill_node)
 
     # --- .coderabbit.yaml ---
-    cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)
-    if cr_blocks:
-        cr_container = CodeRabbitNode(path=context.root_path / ".coderabbit.yaml")
+    cr_path = context.root_path / ".coderabbit.yaml"
+    if cr_path.exists() and not _is_excluded(cr_path):
+        cr_container = CodeRabbitNode(path=cr_path)
+        cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)
         cr_container.children.extend(cr_blocks)
         root.children.append(cr_container)
 
     # --- APM source directories ---
     if context.has_apm:
         apm_dir = context.root_path / ".apm"
+        apm_node = ApmNode(path=apm_dir)
 
         apm_instructions = apm_dir / "instructions"
         if apm_instructions.is_dir():
             for md in sorted(apm_instructions.glob("*.instructions.md")):
-                _add_block(root, md, InstructionBlock)
+                _add_block(apm_node, md, InstructionBlock)
 
         apm_agents = apm_dir / "agents"
         if apm_agents.is_dir():
             for md in sorted(apm_agents.glob("*.agent.md")):
-                _add_block(root, md, AgentBlock)
+                _add_block(apm_node, md, AgentBlock)
 
         apm_prompts = apm_dir / "prompts"
         if apm_prompts.is_dir():
             for md in sorted(apm_prompts.glob("*.md")):
-                _add_block(root, md, PromptBlock)
+                _add_block(apm_node, md, PromptBlock)
 
         apm_chatmodes = apm_dir / "chatmodes"
         if apm_chatmodes.is_dir():
             for md in sorted(apm_chatmodes.glob("*.md")):
-                _add_block(root, md, ChatmodeBlock)
+                _add_block(apm_node, md, ChatmodeBlock)
 
         apm_context = apm_dir / "context"
         if apm_context.is_dir():
             for md in sorted(apm_context.glob("*.md")):
-                _add_block(root, md, ContextFileBlock)
+                _add_block(apm_node, md, ContextFileBlock)
+
+        root.children.append(apm_node)
 
     # --- Extra content paths from config ---
     for glob_pattern in getattr(context, "content_paths", []):

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -307,6 +307,38 @@ class Linter:
             "different edit before linting again"
         )
 
+    @staticmethod
+    def _build_block_system_prompt(block, violations_list, llm_rules):
+        prompts = set()
+        for v in violations_list:
+            prompt = llm_rules[v.rule_id].llm_fix_prompt
+            if prompt:
+                prompts.add(prompt)
+        formatted = "\n".join(str(v) for v in violations_list)
+        combined = "\n\n".join(prompts)
+        return (
+            f"You are fixing lint violations in a content block from: "
+            f"{block.path.name} ({block.category})\n\n"
+            f"VIOLATIONS TO FIX:\n{formatted}\n\n"
+            f"RULE GUIDANCE:\n{combined}\n\n"
+            "TOOLS:\n"
+            "- read_block() — read the content block\n"
+            "- replace_block_section(old_text, new_text) — surgical edit\n"
+            "- write_block(content) — overwrite the entire block\n"
+            "- lint_block() — re-run lint to check your work\n"
+            "- diff_block() — see changes vs original\n"
+            "- read_file(path) — read another file for context (read-only)\n\n"
+            "INSTRUCTIONS:\n"
+            "1. read_block() to see the content\n"
+            "2. Fix each violation using replace_block_section\n"
+            "3. After all edits, call lint_block() to verify\n"
+            "4. When done, call diff_block() then respond with a brief summary\n\n"
+            "IMPORTANT:\n"
+            "- Only modify text that triggers violations\n"
+            "- Preserve meaning and structure\n"
+            "- NEVER call lint_block() without making changes first"
+        )
+
     def _relint_file(self, fpath, violations_list, threshold):
         from .rules.builtin.utils import invalidate_read_caches
 
@@ -465,6 +497,136 @@ class Linter:
             "changed": changed,
         }
 
+    def _llm_process_one_block(
+        self,
+        block_idx,
+        block,
+        block_violations,
+        *,
+        provider,
+        llm_rules,
+        block_count,
+        root_resolved,
+        base_max_iter,
+        threshold,
+        emit,
+    ):
+        from .llm.tools import (
+            ReadFileTool,
+            BlockState,
+            ReadBlockTool,
+            WriteBlockTool,
+            ReplaceBlockSectionTool,
+            LintBlockTool,
+            DiffBlockTool,
+        )
+        from .llm.engine import LLMEngine
+        from .llm._litellm import TokenUsage
+        import difflib
+
+        block_usage = TokenUsage(0, 0)
+        block_max_iter = max(base_max_iter, len(block_violations) * 5)
+        rel_path = block.path.relative_to(root_resolved)
+
+        rules_for_block = sorted({v.rule_id for v in block_violations})
+        emit(
+            "file_start",
+            file_idx=block_idx,
+            file_count=block_count,
+            rel_path=rel_path,
+            num_violations=len(block_violations),
+            rule_ids=rules_for_block,
+        )
+
+        def _on_engine_event(event_type, **kwargs):
+            emit(
+                event_type,
+                file_idx=block_idx,
+                file_count=block_count,
+                rel_path=rel_path,
+                **kwargs,
+            )
+
+        state = BlockState(block)
+        original_body = state.original
+        tools = [
+            ReadBlockTool(state),
+            WriteBlockTool(state),
+            ReplaceBlockSectionTool(state),
+            LintBlockTool(
+                state,
+                self.config,
+                root=self.context.root_path,
+                rule_ids={v.rule_id for v in block_violations},
+            ),
+            DiffBlockTool(state),
+            ReadFileTool(self.context.root_path),
+        ]
+
+        current_violations = block_violations
+        total_iterations = 0
+        remaining = []
+        for attempt in range(2):
+            engine = LLMEngine(
+                provider,
+                tools,
+                model=self.config.llm.model,
+                max_iterations=block_max_iter,
+                max_tokens=self.config.llm.max_tokens,
+                on_event=_on_engine_event,
+            )
+            result = engine.run(
+                system_prompt=self._build_block_system_prompt(block, current_violations, llm_rules),
+                user_message="Please fix the violations in this content block.",
+            )
+            block_usage.prompt_tokens += result.usage.prompt_tokens
+            block_usage.completion_tokens += result.usage.completion_tokens
+            total_iterations += result.iterations
+
+            remaining = self._relint_file(block.path.resolve(), current_violations, threshold)
+            if not remaining:
+                break
+
+            if attempt == 0:
+                emit(
+                    "retry",
+                    file_idx=block_idx,
+                    file_count=block_count,
+                    rel_path=rel_path,
+                    remaining=len(remaining),
+                )
+                current_violations = remaining
+
+        changed = state.body != original_body
+        diff_text = None
+        if changed:
+            diff_lines = difflib.unified_diff(
+                original_body.splitlines(keepends=True),
+                state.body.splitlines(keepends=True),
+                fromfile=f"a/{rel_path}",
+                tofile=f"b/{rel_path}",
+            )
+            diff_text = "".join(diff_lines)
+
+        emit(
+            "file_done",
+            file_idx=block_idx,
+            file_count=block_count,
+            rel_path=rel_path,
+            num_violations=len(block_violations),
+            iterations=total_iterations,
+            remaining=len(remaining),
+            changed=changed,
+        )
+
+        return {
+            "block": block,
+            "original_body": original_body,
+            "usage": block_usage,
+            "diff_text": diff_text,
+            "changed": changed,
+        }
+
     def _llm_rollback_or_keep(self, files_to_violations, originals, all_diffs, threshold):
         from .rules.builtin.utils import invalidate_read_caches
 
@@ -528,20 +690,28 @@ class Linter:
                 success=True,
             )
 
-        files_to_violations: Dict[Path, List[RuleViolation]] = {}
+        # Split violations into block-based and file-based
+        block_violations: Dict[int, List[RuleViolation]] = {}
+        file_violations: Dict[Path, List[RuleViolation]] = {}
+        block_map: Dict[int, Any] = {}
+
         for v in llm_violations:
-            if v.file_path:
-                files_to_violations.setdefault(v.file_path.resolve(), []).append(v)
+            if v.block is not None:
+                bid = id(v.block)
+                block_violations.setdefault(bid, []).append(v)
+                block_map[bid] = v.block
+            elif v.file_path:
+                file_violations.setdefault(v.file_path.resolve(), []).append(v)
 
         originals: Dict[Path, Optional[str]] = {}
-        for fpath in files_to_violations:
+        for fpath in file_violations:
             if fpath.exists():
                 originals[fpath] = fpath.read_text(encoding="utf-8")
             else:
-                originals[fpath] = None  # sentinel: file doesn't exist yet
+                originals[fpath] = None
 
         violations_before = len(llm_violations)
-        file_count = len(files_to_violations)
+        total_units = len(block_violations) + len(file_violations)
         root_resolved = self.context.root_path.resolve()
 
         _cb_lock = threading.Lock()
@@ -556,60 +726,125 @@ class Linter:
         files_modified: List[Path] = []
         completed = 0
 
-        _emit("progress", completed=0, file_count=file_count)
+        _emit("progress", completed=0, file_count=total_units)
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_to_idx = {}
-            for file_idx, (fpath, fv) in enumerate(files_to_violations.items(), 1):
+            unit_idx = 0
+
+            for bid, bv in block_violations.items():
+                unit_idx += 1
                 future = executor.submit(
-                    self._llm_process_one_file,
-                    file_idx,
-                    fpath,
-                    fv,
+                    self._llm_process_one_block,
+                    unit_idx,
+                    block_map[bid],
+                    bv,
                     provider=provider,
                     llm_rules=llm_rules,
-                    originals=originals,
-                    file_count=file_count,
+                    block_count=total_units,
                     root_resolved=root_resolved,
                     base_max_iter=self.config.llm.max_iterations,
                     threshold=threshold,
                     emit=_emit,
                 )
-                future_to_idx[future] = file_idx
+                future_to_idx[future] = unit_idx
+
+            for fpath, fv in file_violations.items():
+                unit_idx += 1
+                future = executor.submit(
+                    self._llm_process_one_file,
+                    unit_idx,
+                    fpath,
+                    fv,
+                    provider=provider,
+                    llm_rules=llm_rules,
+                    originals=originals,
+                    file_count=total_units,
+                    root_resolved=root_resolved,
+                    base_max_iter=self.config.llm.max_iterations,
+                    threshold=threshold,
+                    emit=_emit,
+                )
+                future_to_idx[future] = unit_idx
+
+            block_results: List[dict] = []
 
             for future in as_completed(future_to_idx):
                 try:
-                    file_result = future.result()
+                    result = future.result()
                 except Exception as e:
                     completed += 1
-                    logger.error("Error processing file: %s", e)
-                    _emit("progress", completed=completed, file_count=file_count)
+                    logger.error("Error processing unit: %s", e)
+                    _emit("progress", completed=completed, file_count=total_units)
                     continue
 
                 completed += 1
-                _emit("progress", completed=completed, file_count=file_count)
+                _emit("progress", completed=completed, file_count=total_units)
 
-                total_usage.prompt_tokens += file_result["usage"].prompt_tokens
-                total_usage.completion_tokens += file_result["usage"].completion_tokens
-                if file_result["diff_text"]:
-                    all_diffs[file_result["fpath"]] = file_result["diff_text"]
-                    files_modified.append(file_result["fpath"])
+                total_usage.prompt_tokens += result["usage"].prompt_tokens
+                total_usage.completion_tokens += result["usage"].completion_tokens
 
-        violations_after, kept_files, kept_diffs = self._llm_rollback_or_keep(
-            files_to_violations,
-            originals,
-            all_diffs,
-            threshold,
-        )
+                if "block" in result:
+                    block_results.append(result)
+                elif result["diff_text"]:
+                    fpath = result.get("fpath")
+                    if fpath:
+                        all_diffs[fpath] = result["diff_text"]
+                        files_modified.append(fpath)
 
+        # Rollback file-based fixes that didn't help
+        violations_after = 0
+        kept_files: List[Path] = []
+        kept_diffs: Dict[Path, str] = {}
+
+        if file_violations:
+            va, kf, kd = self._llm_rollback_or_keep(
+                file_violations,
+                originals,
+                all_diffs,
+                threshold,
+            )
+            violations_after += va
+            kept_files.extend(kf)
+            kept_diffs.update(kd)
+
+        # Handle block-based results: rollback if no improvement, track diffs
+        for br in block_results:
+            block = br["block"]
+            original_body = br["original_body"]
+            if not br["changed"]:
+                continue
+
+            bid = id(block)
+            before_count = len(block_violations.get(bid, []))
+            after_remaining = self._relint_file(
+                block.path.resolve(),
+                block_violations.get(bid, []),
+                threshold,
+            )
+            after_count = len(after_remaining)
+
+            if after_count >= before_count:
+                block.write_body(original_body)
+                violations_after += before_count
+            else:
+                violations_after += after_count
+                fpath = block.path
+                if br["diff_text"]:
+                    kept_diffs[fpath] = br["diff_text"]
+                    kept_files.append(fpath)
+
+        # Dry-run: restore all originals
         if dry_run:
             for fpath, original_content in originals.items():
                 if original_content is None:
-                    # File didn't exist before — remove the LLM-created file
                     if fpath.exists():
                         fpath.unlink()
                 else:
                     fpath.write_text(original_content, encoding="utf-8")
+            for br in block_results:
+                if br["changed"]:
+                    br["block"].write_body(br["original_body"])
 
         return LLMFixResult(
             files_modified=[] if dry_run else kept_files,
@@ -617,5 +852,5 @@ class Linter:
             violations_after=violations_after,
             total_usage=total_usage,
             diffs=kept_diffs,
-            success=len(kept_files) > 0,
+            success=len(kept_files) > 0 or len(kept_diffs) > 0,
         )

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -314,7 +314,7 @@ class Linter:
         )
 
     @staticmethod
-    def _build_block_system_prompt(block, violations_list, llm_rules):
+    def _build_block_system_prompt(block, violations_list, llm_rules, *, body_context=None):
         prompts = set()
         for v in violations_list:
             prompt = llm_rules[v.rule_id].llm_fix_prompt
@@ -322,11 +322,20 @@ class Linter:
                 prompts.add(prompt)
         formatted = "\n".join(str(v) for v in violations_list)
         combined = "\n\n".join(prompts)
+
+        body_section = ""
+        if body_context:
+            body_section = (
+                f"\nFILE BODY (read-only context — do NOT include this in your edits):\n"
+                f"{body_context}\n\n"
+            )
+
         return (
             f"You are fixing lint violations in a content block from: "
             f"{block.path.name} ({block.category})\n\n"
             f"VIOLATIONS TO FIX:\n{formatted}\n\n"
             f"RULE GUIDANCE:\n{combined}\n\n"
+            f"{body_section}"
             "TOOLS:\n"
             "- read_block() — read the content block\n"
             "- replace_block_section(old_text, new_text) — surgical edit\n"
@@ -555,7 +564,8 @@ class Linter:
                 **kwargs,
             )
 
-        state = BlockState(block)
+        fm_mode = any(llm_rules[v.rule_id].llm_fix_frontmatter for v in block_violations)
+        state = BlockState(block, frontmatter_mode=fm_mode)
         original_body = state.original
         tools = [
             ReadBlockTool(state),
@@ -584,7 +594,12 @@ class Linter:
                 on_event=_on_engine_event,
             )
             result = engine.run(
-                system_prompt=self._build_block_system_prompt(block, current_violations, llm_rules),
+                system_prompt=self._build_block_system_prompt(
+                    block,
+                    current_violations,
+                    llm_rules,
+                    body_context=state.body_context,
+                ),
                 user_message="Please fix the violations in this content block.",
             )
             block_usage.prompt_tokens += result.usage.prompt_tokens
@@ -635,6 +650,7 @@ class Linter:
             "usage": block_usage,
             "diff_text": diff_text,
             "changed": changed,
+            "frontmatter_mode": fm_mode,
         }
 
     def _llm_rollback_or_keep(self, files_to_violations, originals, all_diffs, threshold):
@@ -832,7 +848,10 @@ class Linter:
             after_count = len(after_remaining)
 
             if after_count >= before_count:
-                block.write_body(original_body)
+                if br.get("frontmatter_mode"):
+                    block.write_frontmatter_text(original_body)
+                else:
+                    block.write_body(original_body)
                 violations_after += before_count
             else:
                 violations_after += after_count
@@ -853,6 +872,8 @@ class Linter:
                 if br["changed"]:
                     if not br["original_body"] and br["block"].path.exists():
                         br["block"].path.unlink()
+                    elif br.get("frontmatter_mode"):
+                        br["block"].write_frontmatter_text(br["original_body"])
                     else:
                         br["block"].write_body(br["original_body"])
 

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -72,14 +72,12 @@ class Linter:
         from .rules.builtin import BUILTIN_RULES
 
         for rule_class in BUILTIN_RULES:
-            # Instantiate to discover rule_id (a property, not accessible on the class)
             rule_instance = rule_class()
             self._known_rule_ids.add(rule_instance.rule_id)
             config = self.config.get_rule_config(rule_instance.rule_id)
             if config:
                 rule_instance = rule_class(config)
 
-            # Check if enabled for this context
             if self.config.is_rule_enabled(
                 rule_instance.rule_id,
                 self.context,
@@ -88,6 +86,9 @@ class Linter:
                 since_version=rule_instance.since,
             ):
                 self.rules.append(rule_instance)
+                logger.info("Rule %-30s enabled", rule_instance.rule_id)
+            else:
+                logger.info("Rule %-30s skipped (not applicable)", rule_instance.rule_id)
 
     def _load_custom_rule(self, rule_path: str):
         """
@@ -97,7 +98,6 @@ class Linter:
             rule_path: Path to Python file containing Rule subclass
         """
         path = Path(rule_path)
-        # If relative path, resolve relative to repository root
         if not path.is_absolute():
             path = self.context.root_path / path
         path = path.resolve()
@@ -105,23 +105,21 @@ class Linter:
         if not path.exists():
             raise FileNotFoundError(f"Custom rule file not found: {path}")
 
-        # Load the module
+        logger.info("Loading custom rules from %s", path)
+
         spec = importlib.util.spec_from_file_location("custom_rule", path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        # Find Rule subclasses in the module
         for name in dir(module):
             obj = getattr(module, name)
             if isinstance(obj, type) and issubclass(obj, Rule) and obj is not Rule:
-                # Instantiate to discover rule_id (a property, not accessible on the class)
                 rule_instance = obj()
                 self._known_rule_ids.add(rule_instance.rule_id)
                 config = self.config.get_rule_config(rule_instance.rule_id)
                 if config:
                     rule_instance = obj(config)
 
-                # Check if enabled
                 if self.config.is_rule_enabled(
                     rule_instance.rule_id,
                     self.context,
@@ -129,6 +127,9 @@ class Linter:
                     rule_instance.formats,
                 ):
                     self.rules.append(rule_instance)
+                    logger.info("Rule %-30s enabled (custom: %s)", rule_instance.rule_id, path.name)
+                else:
+                    logger.info("Rule %-30s skipped (custom: %s)", rule_instance.rule_id, path.name)
 
     def _validate_config(self) -> List[RuleViolation]:
         """Check for unknown rule IDs in config"""
@@ -159,9 +160,14 @@ class Linter:
         """
         violations = self._validate_config()
 
+        logger.info("Running %d enabled rules", len(self.rules))
         for rule in self.rules:
             try:
                 rule_violations = rule.check(self.context)
+                if rule_violations:
+                    logger.info(
+                        "Rule %-30s found %d violation(s)", rule.rule_id, len(rule_violations)
+                    )
                 violations.extend(rule_violations)
             except Exception as e:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -358,13 +358,17 @@ class Linter:
         from .rules.builtin.utils import invalidate_read_caches
 
         invalidate_read_caches(fpath)
-        self.context.rebuild_lint_tree()
+        context = RepositoryContext(self.context.root_path)
+        context.content_paths = self.config.content_paths
+        context.exclude_patterns = self.config.exclude_patterns
+        context.apply_excludes()
+
         failed_rule_ids = {v.rule_id for v in violations_list}
         failed_rules = [r for r in self.rules if r.rule_id in failed_rule_ids]
         remaining = []
         for rule in failed_rules:
             try:
-                re_violations = rule.check(self.context)
+                re_violations = rule.check(context)
                 for v in re_violations:
                     if self._SEVERITY_ORDER.get(v.severity, 99) > threshold:
                         continue

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -339,23 +339,25 @@ class Linter:
             "- NEVER call lint_block() without making changes first"
         )
 
-    def _relint_file(self, fpath, violations_list, threshold):
+    def _relint_file(self, fpath, violations_list, threshold, *, block=None):
         from .rules.builtin.utils import invalidate_read_caches
 
         invalidate_read_caches(fpath)
+        self.context.rebuild_lint_tree()
         failed_rule_ids = {v.rule_id for v in violations_list}
         failed_rules = [r for r in self.rules if r.rule_id in failed_rule_ids]
         remaining = []
         for rule in failed_rules:
             try:
                 re_violations = rule.check(self.context)
-                remaining.extend(
-                    v
-                    for v in re_violations
-                    if v.file_path
-                    and v.file_path.resolve() == fpath
-                    and self._SEVERITY_ORDER.get(v.severity, 99) <= threshold
-                )
+                for v in re_violations:
+                    if self._SEVERITY_ORDER.get(v.severity, 99) > threshold:
+                        continue
+                    if block is not None:
+                        if v.block == block:
+                            remaining.append(v)
+                    elif v.file_path and v.file_path.resolve() == fpath:
+                        remaining.append(v)
             except Exception as e:
                 logger.warning("Rule %s failed during re-lint of %s: %s", rule.rule_id, fpath, e)
                 remaining.extend(v for v in violations_list if v.rule_id == rule.rule_id)
@@ -583,7 +585,9 @@ class Linter:
             block_usage.completion_tokens += result.usage.completion_tokens
             total_iterations += result.iterations
 
-            remaining = self._relint_file(block.path.resolve(), current_violations, threshold)
+            remaining = self._relint_file(
+                block.path.resolve(), current_violations, threshold, block=block
+            )
             if not remaining:
                 break
 
@@ -690,16 +694,13 @@ class Linter:
                 success=True,
             )
 
-        # Split violations into block-based and file-based
-        block_violations: Dict[int, List[RuleViolation]] = {}
+        # Group violations by block (all violations now have blocks via auto-wrap)
+        block_violations: Dict[Any, List[RuleViolation]] = {}
         file_violations: Dict[Path, List[RuleViolation]] = {}
-        block_map: Dict[int, Any] = {}
 
         for v in llm_violations:
             if v.block is not None:
-                bid = id(v.block)
-                block_violations.setdefault(bid, []).append(v)
-                block_map[bid] = v.block
+                block_violations.setdefault(v.block, []).append(v)
             elif v.file_path:
                 file_violations.setdefault(v.file_path.resolve(), []).append(v)
 
@@ -732,12 +733,12 @@ class Linter:
             future_to_idx = {}
             unit_idx = 0
 
-            for bid, bv in block_violations.items():
+            for block, bv in block_violations.items():
                 unit_idx += 1
                 future = executor.submit(
                     self._llm_process_one_block,
                     unit_idx,
-                    block_map[bid],
+                    block,
                     bv,
                     provider=provider,
                     llm_rules=llm_rules,
@@ -812,15 +813,15 @@ class Linter:
         for br in block_results:
             block = br["block"]
             original_body = br["original_body"]
+            before_count = len(block_violations.get(block, []))
             if not br["changed"]:
+                violations_after += before_count
                 continue
-
-            bid = id(block)
-            before_count = len(block_violations.get(bid, []))
             after_remaining = self._relint_file(
                 block.path.resolve(),
-                block_violations.get(bid, []),
+                block_violations.get(block, []),
                 threshold,
+                block=block,
             )
             after_count = len(after_remaining)
 
@@ -844,7 +845,10 @@ class Linter:
                     fpath.write_text(original_content, encoding="utf-8")
             for br in block_results:
                 if br["changed"]:
-                    br["block"].write_body(br["original_body"])
+                    if not br["original_body"] and br["block"].path.exists():
+                        br["block"].path.unlink()
+                    else:
+                        br["block"].write_body(br["original_body"])
 
         return LLMFixResult(
             files_modified=[] if dry_run else kept_files,

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import difflib
 from pathlib import Path
-from typing import Any, Dict, Optional, Protocol, Set, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Protocol, Set, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..config import LinterConfig
+    from ..rules.builtin.content_analysis import ContentBlock
 
 
 class LLMTool(Protocol):
@@ -211,5 +212,153 @@ class DiffTool:
         original = [] if orig is None else orig.splitlines(keepends=True)
         current = resolved.read_text(encoding="utf-8").splitlines(keepends=True)
         diff = difflib.unified_diff(original, current, fromfile=f"a/{path}", tofile=f"b/{path}")
+        result = "".join(diff)
+        return result or "No changes."
+
+
+# ---------------------------------------------------------------------------
+# Block-scoped tools — pathless, one LLM session per ContentBlock
+# ---------------------------------------------------------------------------
+
+
+class BlockState:
+    """Mutable shared state for block tools within a single LLM session."""
+
+    def __init__(self, block: "ContentBlock"):
+        self.block = block
+        self.original = block.read_body(strip_code_blocks=False) or ""
+        self.body = self.original
+
+
+class ReadBlockTool:
+    name = "read_block"
+    description = "Read the content block being fixed"
+    parameters: Dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(self, state: BlockState):
+        self._state = state
+
+    def execute(self) -> str:
+        return self._state.body
+
+
+class WriteBlockTool:
+    name = "write_block"
+    description = "Overwrite the entire content block"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "New block content"},
+        },
+        "required": ["content"],
+    }
+
+    def __init__(self, state: BlockState):
+        self._state = state
+
+    def execute(self, *, content: str) -> str:
+        self._state.body = content
+        return f"Updated block ({len(content)} chars)"
+
+
+class ReplaceBlockSectionTool:
+    name = "replace_block_section"
+    description = "Replace a section of text in the content block (surgical edit)"
+    parameters = {
+        "type": "object",
+        "properties": {
+            "old_text": {"type": "string", "description": "Text to find and replace"},
+            "new_text": {"type": "string", "description": "Replacement text"},
+        },
+        "required": ["old_text", "new_text"],
+    }
+
+    def __init__(self, state: BlockState):
+        self._state = state
+
+    def execute(self, *, old_text: str, new_text: str) -> str:
+        count = self._state.body.count(old_text)
+        if count == 0:
+            return "Error: old_text not found in block"
+        if count > 1:
+            return f"Error: old_text found {count} times — provide a more unique string"
+        self._state.body = self._state.body.replace(old_text, new_text, 1)
+        return "Replaced 1 occurrence"
+
+
+class LintBlockTool:
+    name = "lint_block"
+    description = "Write current block to disk and re-run lint to check your work"
+    parameters: Dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(
+        self,
+        state: BlockState,
+        config: "LinterConfig",
+        root: Path,
+        rule_ids: Optional[Set[str]] = None,
+    ):
+        self._state = state
+        self._config = config
+        self._root = root
+        self._rule_ids = rule_ids
+
+    def execute(self) -> str:
+        block = self._state.block
+        block.body = self._state.body
+        block.write_body(self._state.body)
+
+        from ..context import RepositoryContext
+        from ..rules.builtin import BUILTIN_RULES
+        from ..rules.builtin.utils import invalidate_read_caches
+
+        invalidate_read_caches(block.path)
+        context = RepositoryContext(self._root)
+        context.content_paths = self._config.content_paths
+        context.exclude_patterns = self._config.exclude_patterns
+        context.apply_excludes()
+
+        violations = []
+        resolved = block.path.resolve()
+        for rule_class in BUILTIN_RULES:
+            rule = rule_class()
+            if self._rule_ids and rule.rule_id not in self._rule_ids:
+                continue
+            config = self._config.get_rule_config(rule.rule_id)
+            if config:
+                rule = rule_class(config)
+            if not self._config.is_rule_enabled(
+                rule.rule_id,
+                context,
+                rule.repo_types,
+                rule.formats,
+                since_version=rule.since,
+            ):
+                continue
+            try:
+                rule_violations = rule.check(context)
+                violations.extend(
+                    v for v in rule_violations if v.file_path and v.file_path.resolve() == resolved
+                )
+            except Exception as e:
+                return f"Error running lint ({rule.rule_id}): {e}"
+
+        if not violations:
+            return "No violations found."
+        return "\n".join(str(v) for v in violations)
+
+
+class DiffBlockTool:
+    name = "diff_block"
+    description = "Show unified diff of current block vs original"
+    parameters: Dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(self, state: BlockState):
+        self._state = state
+
+    def execute(self) -> str:
+        original = self._state.original.splitlines(keepends=True)
+        current = self._state.body.splitlines(keepends=True)
+        diff = difflib.unified_diff(original, current, fromfile="a/block", tofile="b/block")
         result = "".join(diff)
         return result or "No changes."

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -319,7 +319,7 @@ class LintBlockTool:
         context.apply_excludes()
 
         violations = []
-        resolved = block.path.resolve()
+        target_block = self._state.block
         for rule_class in BUILTIN_RULES:
             rule = rule_class()
             if self._rule_ids and rule.rule_id not in self._rule_ids:
@@ -337,9 +337,7 @@ class LintBlockTool:
                 continue
             try:
                 rule_violations = rule.check(context)
-                violations.extend(
-                    v for v in rule_violations if v.file_path and v.file_path.resolve() == resolved
-                )
+                violations.extend(v for v in rule_violations if v.block == target_block)
             except Exception as e:
                 return f"Error running lint ({rule.rule_id}): {e}"
 

--- a/src/skillsaw/llm/tools.py
+++ b/src/skillsaw/llm/tools.py
@@ -224,9 +224,15 @@ class DiffTool:
 class BlockState:
     """Mutable shared state for block tools within a single LLM session."""
 
-    def __init__(self, block: "ContentBlock"):
+    def __init__(self, block: "ContentBlock", *, frontmatter_mode: bool = False):
         self.block = block
-        self.original = block.read_body(strip_code_blocks=False) or ""
+        self.frontmatter_mode = frontmatter_mode
+        if frontmatter_mode:
+            self.original = block.read_frontmatter_text()
+            self.body_context = block.body_text
+        else:
+            self.original = block.read_body(strip_code_blocks=False) or ""
+            self.body_context = None
         self.body = self.original
 
 
@@ -305,8 +311,14 @@ class LintBlockTool:
 
     def execute(self) -> str:
         block = self._state.block
-        block.body = self._state.body
-        block.write_body(self._state.body)
+        if self._state.frontmatter_mode:
+            try:
+                block.write_frontmatter_text(self._state.body)
+            except ValueError as e:
+                return f"Error: {e}"
+        else:
+            block.body = self._state.body
+            block.write_body(self._state.body)
 
         from ..context import RepositoryContext
         from ..rules.builtin import BUILTIN_RULES

--- a/src/skillsaw/marketplace/templates/claude-code/agent.md
+++ b/src/skillsaw/marketplace/templates/claude-code/agent.md
@@ -1,6 +1,6 @@
 ---
 name: {{AGENT_NAME}}
-description: TODO: Add description
+description: "TODO: Add description"
 subagent_type: {{AGENT_ID}}
 ---
 

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
-    from .rules.builtin.content_analysis import ContentBlock
+    from .rules.builtin.content_analysis import ContentBlock, FileContentBlock
 
 
 class Severity(Enum):
@@ -39,6 +39,10 @@ class RuleViolation:
     block: Optional["ContentBlock"] = field(default=None, repr=False)
 
     def __post_init__(self):
+        if self.block is None and self.file_path is not None:
+            from .rules.builtin.content_analysis import FileContentBlock
+
+            self.block = FileContentBlock(path=self.file_path, category="file")
         if self.file_path is None and self.block is not None:
             self.file_path = self.block.path
 

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
+    from .rules.builtin.content_analysis import ContentBlock
 
 
 class Severity(Enum):
@@ -35,16 +36,29 @@ class RuleViolation:
     message: str
     file_path: Optional[Path] = None
     line: Optional[int] = None
+    block: Optional["ContentBlock"] = field(default=None, repr=False)
+
+    def __post_init__(self):
+        if self.file_path is None and self.block is not None:
+            self.file_path = self.block.path
+
+    @property
+    def file_line(self) -> Optional[int]:
+        """File line number, translated through block offset if available."""
+        if self.block is not None and self.line is not None:
+            return self.block.file_line(self.line)
+        return self.line
 
     def __str__(self):
         """Format violation for display"""
         icon = {Severity.ERROR: "✗", Severity.WARNING: "⚠", Severity.INFO: "ℹ"}[self.severity]
 
         location = ""
+        display_line = self.file_line
         if self.file_path:
             location = f" [{self.file_path}]"
-            if self.line:
-                location = f" [{self.file_path}:{self.line}]"
+            if display_line:
+                location = f" [{self.file_path}:{display_line}]"
 
         return f"{icon} {self.severity.value.upper()}{location}: {self.message}"
 
@@ -137,13 +151,13 @@ class Rule(ABC):
         self,
         context: "RepositoryContext",
         violations: List[RuleViolation],
+        *,
+        provider: Any = None,
     ) -> List[AutofixResult]:
-        """
-        Attempt to fix violations found by check().
+        """Attempt to fix violations.
 
-        Override in subclasses to provide autofix capability.
-        Rules without a fix() override continue to work — this default
-        returns an empty list.
+        Override in subclasses.  ``provider`` is an optional
+        ``CompletionProvider`` for LLM-assisted fixes.
         """
         return []
 
@@ -161,18 +175,12 @@ class Rule(ABC):
         file_path: Path = None,
         line: int = None,
         severity: Severity = None,
+        block: "ContentBlock" = None,
     ) -> RuleViolation:
-        """
-        Create a violation for this rule
+        """Create a violation for this rule.
 
-        Args:
-            message: Violation message
-            file_path: Optional file path where violation occurred
-            line: Optional line number
-            severity: Override severity (defaults to rule's configured severity)
-
-        Returns:
-            RuleViolation instance
+        Pass ``block`` for content-based violations.  ``file_path`` is
+        accepted for backward compatibility and auto-wraps into a block.
         """
         return RuleViolation(
             rule_id=self.rule_id,
@@ -180,4 +188,5 @@ class Rule(ABC):
             message=message,
             file_path=file_path,
             line=line,
+            block=block,
         )

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -173,6 +173,11 @@ class Rule(ABC):
     def llm_fix_prompt(self) -> Optional[str]:
         return None
 
+    @property
+    def llm_fix_frontmatter(self) -> bool:
+        """When True, LLM fix operates on frontmatter YAML only (not the body)."""
+        return False
+
     def violation(
         self,
         message: str,

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -9,6 +9,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
+from skillsaw.rules.builtin.content_analysis import AgentBlock
 from skillsaw.rules.builtin.utils import read_text
 
 
@@ -29,38 +30,23 @@ class AgentFrontmatterRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        from skillsaw.rules.builtin.content_analysis import AgentBlock
-
-        for agent_block in context.lint_tree.find(AgentBlock):
-            agent_file = agent_block.path
-            content = read_text(agent_file)
-            if content is None:
-                violations.append(
-                    self.violation(f"Failed to read file: {agent_file}", file_path=agent_file)
-                )
+        for block in context.lint_tree.find(AgentBlock):
+            if block.frontmatter_error:
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
                 continue
 
-            if not content.startswith("---"):
-                violations.append(self.violation("Missing frontmatter", file_path=agent_file))
+            if block.frontmatter is None:
+                violations.append(self.violation("Missing frontmatter", file_path=block.path))
                 continue
 
-            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-            if not frontmatter_match:
+            if "name" not in block.frontmatter:
                 violations.append(
-                    self.violation("Invalid frontmatter format", file_path=agent_file)
-                )
-                continue
-
-            frontmatter = frontmatter_match.group(1)
-
-            if "name:" not in frontmatter:
-                violations.append(
-                    self.violation("Missing 'name' in frontmatter", file_path=agent_file)
+                    self.violation("Missing 'name' in frontmatter", file_path=block.path)
                 )
 
-            if "description:" not in frontmatter:
+            if "description" not in block.frontmatter:
                 violations.append(
-                    self.violation("Missing 'description' in frontmatter", file_path=agent_file)
+                    self.violation("Missing 'description' in frontmatter", file_path=block.path)
                 )
 
         return violations

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -29,45 +29,39 @@ class AgentFrontmatterRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
-            agents_dir = plugin_path / "agents"
-            if not agents_dir.exists():
+        from skillsaw.rules.builtin.content_analysis import AgentBlock
+
+        for agent_block in context.lint_tree.find(AgentBlock):
+            agent_file = agent_block.path
+            content = read_text(agent_file)
+            if content is None:
+                violations.append(
+                    self.violation(f"Failed to read file: {agent_file}", file_path=agent_file)
+                )
                 continue
 
-            # Check all .md files in agents directory
-            for agent_file in agents_dir.glob("*.md"):
-                content = read_text(agent_file)
-                if content is None:
-                    violations.append(
-                        self.violation(f"Failed to read file: {agent_file}", file_path=agent_file)
-                    )
-                    continue
+            if not content.startswith("---"):
+                violations.append(self.violation("Missing frontmatter", file_path=agent_file))
+                continue
 
-                # Check for frontmatter
-                if not content.startswith("---"):
-                    violations.append(self.violation("Missing frontmatter", file_path=agent_file))
-                    continue
+            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+            if not frontmatter_match:
+                violations.append(
+                    self.violation("Invalid frontmatter format", file_path=agent_file)
+                )
+                continue
 
-                # Parse frontmatter
-                frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-                if not frontmatter_match:
-                    violations.append(
-                        self.violation("Invalid frontmatter format", file_path=agent_file)
-                    )
-                    continue
+            frontmatter = frontmatter_match.group(1)
 
-                frontmatter = frontmatter_match.group(1)
+            if "name:" not in frontmatter:
+                violations.append(
+                    self.violation("Missing 'name' in frontmatter", file_path=agent_file)
+                )
 
-                # Check for required fields
-                if "name:" not in frontmatter:
-                    violations.append(
-                        self.violation("Missing 'name' in frontmatter", file_path=agent_file)
-                    )
-
-                if "description:" not in frontmatter:
-                    violations.append(
-                        self.violation("Missing 'description' in frontmatter", file_path=agent_file)
-                    )
+            if "description:" not in frontmatter:
+                violations.append(
+                    self.violation("Missing 'description' in frontmatter", file_path=agent_file)
+                )
 
         return violations
 

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -27,26 +27,52 @@ class AgentFrontmatterRule(Rule):
     def default_severity(self) -> Severity:
         return Severity.ERROR
 
+    @property
+    def llm_fix_prompt(self):
+        return (
+            "You are fixing YAML frontmatter for an agent markdown file.\n\n"
+            "The block you are editing is the raw YAML between the --- delimiters.\n"
+            "Do NOT include the --- delimiters in your output.\n\n"
+            "Rules:\n"
+            "- Must have 'name' and 'description' fields\n"
+            "- 'name' should be the agent file stem (filename without .md)\n"
+            "- 'description' should be a concise one-line summary derived from the body content\n"
+            "- If the YAML is malformed, fix the syntax\n"
+            "- Preserve any other existing frontmatter fields"
+        )
+
+    @property
+    def llm_fix_frontmatter(self) -> bool:
+        return True
+
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
         for block in context.lint_tree.find(AgentBlock):
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                violations.append(
+                    self.violation(block.frontmatter_error, file_path=block.path, block=block)
+                )
                 continue
 
             if block.frontmatter is None:
-                violations.append(self.violation("Missing frontmatter", file_path=block.path))
+                violations.append(
+                    self.violation("Missing frontmatter", file_path=block.path, block=block)
+                )
                 continue
 
             if "name" not in block.frontmatter:
                 violations.append(
-                    self.violation("Missing 'name' in frontmatter", file_path=block.path)
+                    self.violation(
+                        "Missing 'name' in frontmatter", file_path=block.path, block=block
+                    )
                 )
 
             if "description" not in block.frontmatter:
                 violations.append(
-                    self.violation("Missing 'description' in frontmatter", file_path=block.path)
+                    self.violation(
+                        "Missing 'description' in frontmatter", file_path=block.path, block=block
+                    )
                 )
 
         return violations

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -36,7 +36,9 @@ class AgentFrontmatterRule(Rule):
             "Rules:\n"
             "- Must have 'name' and 'description' fields\n"
             "- 'name' should be the agent file stem (filename without .md)\n"
-            "- 'description' should be a concise one-line summary derived from the body content\n"
+            "- 'description' should be imperative and tell the model when to invoke it, "
+            "e.g. 'Use when the user asks to review a PR' — "
+            "derive it from the body content\n"
             "- If the YAML is malformed, fix the syntax\n"
             "- Preserve any other existing frontmatter fields"
         )

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -38,7 +38,7 @@ class AgentFrontmatterRule(Rule):
             "- 'name' should be the agent file stem (filename without .md)\n"
             "- 'description' should be imperative and tell the model when to invoke it, "
             "e.g. 'Use when the user asks to review a PR' — "
-            "derive it from the body content\n"
+            "derive it from the body content, keep it under 200 tokens\n"
             "- If the YAML is malformed, fix the syntax\n"
             "- Preserve any other existing frontmatter fields"
         )

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -4,15 +4,13 @@ Rules for validating agentskills.io skill format
 
 import json
 import re
-from functools import lru_cache
-from typing import List, Optional, Tuple, Dict
-
-import yaml
+from typing import List, Optional
 
 from skillsaw.rule import Rule, RuleViolation, AutofixResult, AutofixConfidence, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import SkillNode
-from skillsaw.rules.builtin.utils import read_text, read_json, frontmatter_key_line, register_cache
+from skillsaw.rules.builtin.content_analysis import SkillBlock
+from skillsaw.rules.builtin.utils import read_json
 
 # agentskills.io spec constraints
 NAME_MAX_LENGTH = 64
@@ -28,46 +26,6 @@ def _to_kebab(name: str) -> str:
     s = re.sub(r"[^a-z0-9]+", "-", s.lower())
     s = re.sub(r"-+", "-", s).strip("-")
     return s
-
-
-@register_cache
-@lru_cache(maxsize=512)
-def _parse_skill_md(skill_path) -> Tuple[Optional[Dict], Optional[str]]:
-    """
-    Parse SKILL.md frontmatter from a skill directory.
-
-    Returns (frontmatter_dict, error_string). If error_string is set,
-    frontmatter_dict is None. Results are cached per path.
-    """
-    skill_md = skill_path / "SKILL.md"
-    if not skill_md.exists():
-        return None, "SKILL.md not found"
-
-    content = read_text(skill_md)
-    if content is None:
-        return None, f"Failed to read SKILL.md: {skill_md}"
-
-    if not content.startswith("---"):
-        return None, "Missing YAML frontmatter (must start with ---)"
-
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", content, re.DOTALL)
-    if not match:
-        return None, "Invalid frontmatter (missing closing ---)"
-
-    try:
-        frontmatter = yaml.safe_load(match.group(1))
-    except yaml.YAMLError as e:
-        return None, f"Invalid YAML in frontmatter: {e}"
-
-    if not isinstance(frontmatter, dict):
-        return None, "Frontmatter must be a YAML mapping"
-
-    return frontmatter, None
-
-
-def _frontmatter_key_line(skill_path, key: str) -> Optional[int]:
-    """Find the line number of a top-level key in SKILL.md frontmatter."""
-    return frontmatter_key_line(skill_path / "SKILL.md", key)
 
 
 class AgentSkillValidRule(Rule):
@@ -138,71 +96,90 @@ class AgentSkillValidRule(Rule):
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
-            skill_path = skill_node.path
-            skill_md = skill_path / "SKILL.md"
-            frontmatter, error = _parse_skill_md(skill_path)
+            blocks = skill_node.find(SkillBlock)
+            if not blocks:
+                violations.append(
+                    self.violation(
+                        "SKILL.md not found",
+                        file_path=skill_node.path / "SKILL.md",
+                    )
+                )
+                continue
 
-            if error:
-                violations.append(self.violation(error, file_path=skill_md))
+            block = blocks[0]
+            if block.frontmatter_error:
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                continue
+
+            frontmatter = block.frontmatter
+            if frontmatter is None:
+                violations.append(
+                    self.violation(
+                        "Missing YAML frontmatter (must start with ---)",
+                        file_path=block.path,
+                    )
+                )
                 continue
 
             name = frontmatter.get("name")
             if not name:
                 violations.append(
-                    self.violation("Missing required 'name' field", file_path=skill_md)
+                    self.violation("Missing required 'name' field", file_path=block.path)
                 )
             elif not isinstance(name, str):
                 violations.append(
                     self.violation(
                         "'name' must be a string",
-                        file_path=skill_md,
-                        line=_frontmatter_key_line(skill_path, "name"),
+                        file_path=block.path,
+                        line=block.key_line("name"),
                     )
                 )
             elif len(name) > NAME_MAX_LENGTH:
                 violations.append(
                     self.violation(
                         f"'name' exceeds {NAME_MAX_LENGTH} characters ({len(name)})",
-                        file_path=skill_md,
-                        line=_frontmatter_key_line(skill_path, "name"),
+                        file_path=block.path,
+                        line=block.key_line("name"),
                     )
                 )
 
             desc = frontmatter.get("description")
             if not desc:
                 violations.append(
-                    self.violation("Missing required 'description' field", file_path=skill_md)
+                    self.violation("Missing required 'description' field", file_path=block.path)
                 )
             elif not isinstance(desc, str):
                 violations.append(
                     self.violation(
                         "'description' must be a string",
-                        file_path=skill_md,
-                        line=_frontmatter_key_line(skill_path, "description"),
+                        file_path=block.path,
+                        line=block.key_line("description"),
                     )
                 )
 
             if "license" in frontmatter and not isinstance(frontmatter["license"], str):
-                violations.append(self.violation("'license' must be a string", file_path=skill_md))
+                violations.append(
+                    self.violation("'license' must be a string", file_path=block.path)
+                )
 
             if "compatibility" in frontmatter:
                 compat = frontmatter["compatibility"]
                 if not isinstance(compat, str):
                     violations.append(
-                        self.violation("'compatibility' must be a string", file_path=skill_md)
+                        self.violation("'compatibility' must be a string", file_path=block.path)
                     )
                 elif not compat.strip():
                     violations.append(
                         self.violation(
                             "'compatibility' must not be empty if provided",
-                            file_path=skill_md,
+                            file_path=block.path,
                         )
                     )
                 elif len(compat) > COMPATIBILITY_MAX_LENGTH:
                     violations.append(
                         self.violation(
                             f"'compatibility' exceeds {COMPATIBILITY_MAX_LENGTH} characters ({len(compat)})",
-                            file_path=skill_md,
+                            file_path=block.path,
                         )
                     )
 
@@ -210,7 +187,7 @@ class AgentSkillValidRule(Rule):
                 meta = frontmatter["metadata"]
                 if not isinstance(meta, dict):
                     violations.append(
-                        self.violation("'metadata' must be a mapping", file_path=skill_md)
+                        self.violation("'metadata' must be a mapping", file_path=block.path)
                     )
                 else:
                     for k, v in meta.items():
@@ -218,7 +195,7 @@ class AgentSkillValidRule(Rule):
                             violations.append(
                                 self.violation(
                                     f"'metadata' key {k!r} must be a string",
-                                    file_path=skill_md,
+                                    file_path=block.path,
                                 )
                             )
 
@@ -229,14 +206,14 @@ class AgentSkillValidRule(Rule):
                         violations.append(
                             self.violation(
                                 "'allowed-tools' list items must all be strings",
-                                file_path=skill_md,
+                                file_path=block.path,
                             )
                         )
                 elif not isinstance(at, str):
                     violations.append(
                         self.violation(
                             "'allowed-tools' must be a string or list of strings",
-                            file_path=skill_md,
+                            file_path=block.path,
                         )
                     )
 
@@ -268,24 +245,24 @@ class AgentSkillNameRule(Rule):
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
-            skill_path = skill_node.path
-            skill_md = skill_path / "SKILL.md"
-            frontmatter, error = _parse_skill_md(skill_path)
-
-            if error or not frontmatter:
+            blocks = skill_node.find(SkillBlock)
+            if not blocks:
+                continue
+            block = blocks[0]
+            if block.frontmatter_error or block.frontmatter is None:
                 continue
 
-            name = frontmatter.get("name")
+            name = block.frontmatter.get("name")
             if not name or not isinstance(name, str):
                 continue
 
-            name_line = _frontmatter_key_line(skill_path, "name")
+            name_line = block.key_line("name")
 
             if not NAME_PATTERN.match(name):
                 violations.append(
                     self.violation(
                         f"Name '{name}' must contain only lowercase letters, numbers, and hyphens",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=name_line,
                     )
                 )
@@ -295,7 +272,7 @@ class AgentSkillNameRule(Rule):
                 violations.append(
                     self.violation(
                         f"Name '{name}' must not end with a hyphen",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=name_line,
                     )
                 )
@@ -304,16 +281,16 @@ class AgentSkillNameRule(Rule):
                 violations.append(
                     self.violation(
                         f"Name '{name}' must not contain consecutive hyphens",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=name_line,
                     )
                 )
 
-            if skill_path != context.root_path and name != skill_path.name:
+            if skill_node.path != context.root_path and name != skill_node.path.name:
                 violations.append(
                     self.violation(
-                        f"Name '{name}' does not match directory name '{skill_path.name}'",
-                        file_path=skill_md,
+                        f"Name '{name}' does not match directory name '{skill_node.path.name}'",
+                        file_path=block.path,
                         line=name_line,
                     )
                 )
@@ -378,24 +355,24 @@ class AgentSkillDescriptionRule(Rule):
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
-            skill_path = skill_node.path
-            skill_md = skill_path / "SKILL.md"
-            frontmatter, error = _parse_skill_md(skill_path)
-
-            if error or not frontmatter:
+            blocks = skill_node.find(SkillBlock)
+            if not blocks:
+                continue
+            block = blocks[0]
+            if block.frontmatter_error or block.frontmatter is None:
                 continue
 
-            desc = frontmatter.get("description")
+            desc = block.frontmatter.get("description")
             if not desc or not isinstance(desc, str):
                 continue
 
-            desc_line = _frontmatter_key_line(skill_path, "description")
+            desc_line = block.key_line("description")
             stripped = desc.strip()
             if not stripped:
                 violations.append(
                     self.violation(
                         "Description is empty or whitespace-only",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=desc_line,
                     )
                 )
@@ -405,7 +382,7 @@ class AgentSkillDescriptionRule(Rule):
                 violations.append(
                     self.violation(
                         f"Description exceeds {DESCRIPTION_MAX_LENGTH} characters ({len(stripped)})",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=desc_line,
                     )
                 )
@@ -565,12 +542,13 @@ class AgentSkillEvalsRule(Rule):
                     self.violation("'skill_name' must be a string", file_path=evals_json)
                 )
             elif isinstance(skill_name, str):
-                frontmatter, _ = _parse_skill_md(skill_path)
-                if frontmatter and frontmatter.get("name") != skill_name:
+                skill_blocks = skill_node.find(SkillBlock)
+                fm = skill_blocks[0].frontmatter if skill_blocks else None
+                if fm and fm.get("name") != skill_name:
                     violations.append(
                         self.violation(
                             f"'skill_name' ({skill_name!r}) does not match "
-                            f"SKILL.md name ({frontmatter.get('name')!r})",
+                            f"SKILL.md name ({fm.get('name')!r})",
                             file_path=evals_json,
                         )
                     )

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -11,6 +11,7 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, AutofixResult, AutofixConfidence, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import SkillNode
 from skillsaw.rules.builtin.utils import read_text, read_json, frontmatter_key_line, register_cache
 
 # agentskills.io spec constraints
@@ -136,7 +137,8 @@ class AgentSkillValidRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             skill_md = skill_path / "SKILL.md"
             frontmatter, error = _parse_skill_md(skill_path)
 
@@ -265,7 +267,8 @@ class AgentSkillNameRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             skill_md = skill_path / "SKILL.md"
             frontmatter, error = _parse_skill_md(skill_path)
 
@@ -374,7 +377,8 @@ class AgentSkillDescriptionRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             skill_md = skill_path / "SKILL.md"
             frontmatter, error = _parse_skill_md(skill_path)
 
@@ -443,7 +447,8 @@ class AgentSkillStructureRule(Rule):
         violations = []
         allowed = set(self.config.get("allowed_dirs", DEFAULT_ALLOWED_DIRS))
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             try:
                 for item in skill_path.iterdir():
                     if not item.is_dir() or item.name.startswith("."):
@@ -486,7 +491,8 @@ class AgentSkillEvalsRequiredRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             evals_json = skill_path / "evals" / "evals.json"
             if not evals_json.exists():
                 violations.append(
@@ -523,7 +529,8 @@ class AgentSkillEvalsRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             evals_dir = skill_path / "evals"
             evals_json = evals_dir / "evals.json"
 

--- a/src/skillsaw/rules/builtin/apm.py
+++ b/src/skillsaw/rules/builtin/apm.py
@@ -8,7 +8,7 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
-from skillsaw.lint_target import ApmNode
+from skillsaw.lint_target import ApmConfigNode, ApmNode
 from skillsaw.rules.builtin.utils import read_text, yaml_key_line
 
 
@@ -45,16 +45,16 @@ class ApmYamlValidRule(Rule):
         if not context.has_apm:
             return []
 
-        violations = []
-        apm_yml = context.root_path / "apm.yml"
-
-        if not apm_yml.exists():
-            violations.append(
+        config_nodes = context.lint_tree.find(ApmConfigNode)
+        if not config_nodes:
+            return [
                 self.violation(
                     "Missing apm.yml at repository root (required for APM repos)",
                 )
-            )
-            return violations
+            ]
+
+        violations = []
+        apm_yml = config_nodes[0].path
 
         content = read_text(apm_yml)
         if content is None:

--- a/src/skillsaw/rules/builtin/apm.py
+++ b/src/skillsaw/rules/builtin/apm.py
@@ -8,6 +8,7 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import ApmNode
 from skillsaw.rules.builtin.utils import read_text, yaml_key_line
 
 
@@ -130,10 +131,13 @@ class ApmStructureValidRule(Rule):
         if not context.has_apm:
             return []
 
-        violations = []
-        apm_dir = context.root_path / ".apm"
+        apm_nodes = context.lint_tree.find(ApmNode)
+        if not apm_nodes:
+            return []
 
-        # Check that .apm/ has at least one of the expected subdirectories
+        violations = []
+        apm_dir = apm_nodes[0].path
+
         has_skills = (apm_dir / "skills").is_dir()
         has_instructions = (apm_dir / "instructions").is_dir()
 
@@ -145,7 +149,6 @@ class ApmStructureValidRule(Rule):
                 )
             )
 
-        # Validate that each skill subdirectory has SKILL.md
         if has_skills:
             skills_dir = apm_dir / "skills"
             try:

--- a/src/skillsaw/rules/builtin/coderabbit.py
+++ b/src/skillsaw/rules/builtin/coderabbit.py
@@ -14,13 +14,8 @@ import yaml
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import CodeRabbitNode
 from skillsaw.rules.builtin.utils import read_text
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-_CODERABBIT_FILENAME = ".coderabbit.yaml"
 
 # ---------------------------------------------------------------------------
 # Rules
@@ -45,16 +40,18 @@ class CoderabbitYamlValidRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations: List[RuleViolation] = []
-        cr_path = context.root_path / _CODERABBIT_FILENAME
 
-        if not cr_path.exists():
+        cr_nodes = context.lint_tree.find(CodeRabbitNode)
+        if not cr_nodes:
             return violations
+
+        cr_path = cr_nodes[0].path
 
         raw = read_text(cr_path)
         if raw is None:
             violations.append(
                 self.violation(
-                    f"Failed to read {_CODERABBIT_FILENAME} (invalid encoding or I/O error)",
+                    "Failed to read .coderabbit.yaml (invalid encoding or I/O error)",
                     file_path=cr_path,
                 )
             )
@@ -65,10 +62,10 @@ class CoderabbitYamlValidRule(Rule):
         except yaml.YAMLError as exc:
             line: Optional[int] = None
             if hasattr(exc, "problem_mark") and exc.problem_mark is not None:
-                line = exc.problem_mark.line + 1  # 0-based → 1-based
+                line = exc.problem_mark.line + 1
             violations.append(
                 self.violation(
-                    f"Invalid YAML in {_CODERABBIT_FILENAME}: {exc}",
+                    f"Invalid YAML in .coderabbit.yaml: {exc}",
                     file_path=cr_path,
                     line=line,
                 )
@@ -78,7 +75,7 @@ class CoderabbitYamlValidRule(Rule):
         if not isinstance(data, dict):
             violations.append(
                 self.violation(
-                    f"{_CODERABBIT_FILENAME} must be a YAML mapping at the top level",
+                    ".coderabbit.yaml must be a YAML mapping at the top level",
                     file_path=cr_path,
                 )
             )

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -8,6 +8,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import PluginNode
 from skillsaw.rules.builtin.utils import read_text, heading_line
 
 
@@ -26,21 +27,19 @@ class CommandNamingRule(Rule):
         return Severity.WARNING
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        from skillsaw.rules.builtin.content_analysis import CommandBlock
+
         violations = []
 
-        for plugin_path in context.plugins:
-            commands_dir = plugin_path / "commands"
-            if not commands_dir.exists():
-                continue
-
-            for cmd_file in commands_dir.glob("*.md"):
-                cmd_name = cmd_file.stem
-                if not self._is_kebab_case(cmd_name):
-                    violations.append(
-                        self.violation(
-                            f"Command name '{cmd_name}' should use kebab-case", file_path=cmd_file
-                        )
+        for cmd_block in context.lint_tree.find(CommandBlock):
+            cmd_file = cmd_block.path
+            cmd_name = cmd_file.stem
+            if not self._is_kebab_case(cmd_name):
+                violations.append(
+                    self.violation(
+                        f"Command name '{cmd_name}' should use kebab-case", file_path=cmd_file
                     )
+                )
 
         return violations
 
@@ -106,41 +105,34 @@ class CommandFrontmatterRule(Rule):
         return Severity.ERROR
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        from skillsaw.rules.builtin.content_analysis import CommandBlock
+
         violations = []
 
-        for plugin_path in context.plugins:
-            commands_dir = plugin_path / "commands"
-            if not commands_dir.exists():
+        for cmd_block in context.lint_tree.find(CommandBlock):
+            cmd_file = cmd_block.path
+            content = read_text(cmd_file)
+            if content is None:
+                violations.append(
+                    self.violation(f"Failed to read file: {cmd_file}", file_path=cmd_file)
+                )
                 continue
 
-            for cmd_file in commands_dir.glob("*.md"):
-                content = read_text(cmd_file)
-                if content is None:
-                    violations.append(
-                        self.violation(f"Failed to read file: {cmd_file}", file_path=cmd_file)
-                    )
-                    continue
+            if not content.startswith("---"):
+                violations.append(self.violation("Missing frontmatter", file_path=cmd_file))
+                continue
 
-                # Check for frontmatter
-                if not content.startswith("---"):
-                    violations.append(self.violation("Missing frontmatter", file_path=cmd_file))
-                    continue
+            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+            if not frontmatter_match:
+                violations.append(self.violation("Invalid frontmatter format", file_path=cmd_file))
+                continue
 
-                # Parse frontmatter
-                frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-                if not frontmatter_match:
-                    violations.append(
-                        self.violation("Invalid frontmatter format", file_path=cmd_file)
-                    )
-                    continue
+            frontmatter = frontmatter_match.group(1)
 
-                frontmatter = frontmatter_match.group(1)
-
-                # Check for required fields
-                if "description:" not in frontmatter:
-                    violations.append(
-                        self.violation("Missing 'description' in frontmatter", file_path=cmd_file)
-                    )
+            if "description:" not in frontmatter:
+                violations.append(
+                    self.violation("Missing 'description' in frontmatter", file_path=cmd_file)
+                )
 
         return violations
 
@@ -200,28 +192,26 @@ class CommandSectionsRule(Rule):
         return Severity.WARNING
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        from skillsaw.rules.builtin.content_analysis import CommandBlock
+
         violations = []
 
         required_sections = ["Name", "Synopsis", "Description", "Implementation"]
 
-        for plugin_path in context.plugins:
-            commands_dir = plugin_path / "commands"
-            if not commands_dir.exists():
+        for cmd_block in context.lint_tree.find(CommandBlock):
+            cmd_file = cmd_block.path
+            content = read_text(cmd_file)
+            if content is None:
                 continue
 
-            for cmd_file in commands_dir.glob("*.md"):
-                content = read_text(cmd_file)
-                if content is None:
-                    continue
-
-                for section in required_sections:
-                    pattern = rf"^##\s+{section}\s*$"
-                    if not re.search(pattern, content, re.MULTILINE):
-                        violations.append(
-                            self.violation(
-                                f"Missing recommended section '## {section}'", file_path=cmd_file
-                            )
+            for section in required_sections:
+                pattern = rf"^##\s+{section}\s*$"
+                if not re.search(pattern, content, re.MULTILINE):
+                    violations.append(
+                        self.violation(
+                            f"Missing recommended section '## {section}'", file_path=cmd_file
                         )
+                    )
 
         return violations
 
@@ -241,35 +231,34 @@ class CommandNameFormatRule(Rule):
         return Severity.WARNING
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        from skillsaw.rules.builtin.content_analysis import CommandBlock
+
         violations = []
 
-        for plugin_path in context.plugins:
-            plugin_name = context.get_plugin_name(plugin_path)
-            commands_dir = plugin_path / "commands"
+        for cmd_block in context.lint_tree.find(CommandBlock):
+            cmd_file = cmd_block.path
+            parent_plugin = context.lint_tree.find_parent(cmd_block, PluginNode)
+            if parent_plugin is None:
+                continue
+            plugin_name = context.get_plugin_name(parent_plugin.path)
+            cmd_name = cmd_file.stem
+            expected_name = f"{plugin_name}:{cmd_name}"
 
-            if not commands_dir.exists():
+            content = read_text(cmd_file)
+            if content is None:
                 continue
 
-            for cmd_file in commands_dir.glob("*.md"):
-                cmd_name = cmd_file.stem
-                expected_name = f"{plugin_name}:{cmd_name}"
-
-                content = read_text(cmd_file)
-                if content is None:
-                    continue
-
-                # Find Name section
-                name_match = re.search(r"^##\s+Name\s*\n+([^\n#]+)", content, re.MULTILINE)
-                if name_match:
-                    name_content = name_match.group(1).strip()
-                    if expected_name not in name_content:
-                        name_line = heading_line(cmd_file, "Name")
-                        violations.append(
-                            self.violation(
-                                f"Name section should contain '{expected_name}', found: '{name_content}'",
-                                file_path=cmd_file,
-                                line=name_line,
-                            )
+            name_match = re.search(r"^##\s+Name\s*\n+([^\n#]+)", content, re.MULTILINE)
+            if name_match:
+                name_content = name_match.group(1).strip()
+                if expected_name not in name_content:
+                    name_line = heading_line(cmd_file, "Name")
+                    violations.append(
+                        self.violation(
+                            f"Name section should contain '{expected_name}', found: '{name_content}'",
+                            file_path=cmd_file,
+                            line=name_line,
                         )
+                    )
 
         return violations

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -109,29 +109,18 @@ class CommandFrontmatterRule(Rule):
 
         violations = []
 
-        for cmd_block in context.lint_tree.find(CommandBlock):
-            cmd_file = cmd_block.path
-            content = read_text(cmd_file)
-            if content is None:
+        for block in context.lint_tree.find(CommandBlock):
+            if block.frontmatter_error:
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                continue
+
+            if block.frontmatter is None:
+                violations.append(self.violation("Missing frontmatter", file_path=block.path))
+                continue
+
+            if "description" not in block.frontmatter:
                 violations.append(
-                    self.violation(f"Failed to read file: {cmd_file}", file_path=cmd_file)
-                )
-                continue
-
-            if not content.startswith("---"):
-                violations.append(self.violation("Missing frontmatter", file_path=cmd_file))
-                continue
-
-            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-            if not frontmatter_match:
-                violations.append(self.violation("Invalid frontmatter format", file_path=cmd_file))
-                continue
-
-            frontmatter = frontmatter_match.group(1)
-
-            if "description:" not in frontmatter:
-                violations.append(
-                    self.violation("Missing 'description' in frontmatter", file_path=cmd_file)
+                    self.violation("Missing 'description' in frontmatter", file_path=block.path)
                 )
 
         return violations

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -6,6 +6,8 @@ in instruction files across all formats (CLAUDE.md, AGENTS.md, GEMINI.md,
 .cursorrules, copilot-instructions.md, .cursor/rules/*.mdc, .coderabbit.yaml).
 """
 
+from __future__ import annotations
+
 import fnmatch
 import re
 from abc import abstractmethod

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -15,6 +15,8 @@ from typing import Any, Callable, List, Optional, Set, Tuple
 import yaml
 
 from skillsaw.context import RepositoryContext
+from ruamel.yaml import YAML as _RuamelYAML
+
 from skillsaw.rules.builtin.utils import (
     read_text,
     parse_frontmatter,
@@ -174,12 +176,13 @@ _INSTRUCTION_FILE_CATEGORIES = {
 
 
 @dataclass
-class ContentFile:
+class ContentBlock:
     path: Path
     category: str
     line_offset: int = 0
     body: Optional[str] = None
     _line_map: Optional[Callable[[int], int]] = field(default=None, repr=False)
+    _writer: Optional[Callable[[str], None]] = field(default=None, repr=False)
 
     def file_line(self, body_line: int) -> int:
         """Translate a 1-based body line number to a 1-based file line number."""
@@ -187,13 +190,89 @@ class ContentFile:
             return self._line_map(body_line)
         return body_line + self.line_offset
 
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
+        """Return the block's text content."""
+        if self.body is not None:
+            body = self.body
+        else:
+            content = read_text(self.path)
+            if content is None:
+                return None
+            if self.path.suffix == ".mdc":
+                _, body = parse_frontmatter(content)
+            else:
+                body = content
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+        return body
 
-def _gather_coderabbit_files(
+    def write_body(self, new_body: str) -> None:
+        """Write fixed content back to the correct location."""
+        if self._writer is not None:
+            self._writer(new_body)
+        else:
+            self.path.write_text(new_body, encoding="utf-8")
+
+
+ContentFile = ContentBlock
+
+
+def _make_coderabbit_writer(path: Path, yaml_path: str) -> Callable[[str], None]:
+    """Return a closure that updates one instruction value in .coderabbit.yaml.
+
+    Uses ruamel.yaml round-trip to preserve comments, ordering, and formatting.
+    ``yaml_path`` is a dotted path like ``reviews.instructions`` or
+    ``reviews.tools.biome.instructions``.  Array entries use bracket syntax
+    like ``reviews.path_instructions[src/**].instructions``.
+    """
+
+    def _write(new_body: str) -> None:
+        ruyaml = _RuamelYAML()
+        ruyaml.preserve_quotes = True
+        raw = path.read_text(encoding="utf-8")
+        data = ruyaml.load(raw)
+        if data is None:
+            return
+
+        parts = yaml_path.split(".")
+        node = data
+        for i, part in enumerate(parts[:-1]):
+            if "[" in part:
+                key = part[: part.index("[")]
+                node = node.get(key) if isinstance(node, dict) else None
+            else:
+                node = node.get(part) if isinstance(node, dict) else None
+            if node is None:
+                return
+
+            if isinstance(node, list) and "[" in parts[i]:
+                bracket_val = parts[i][parts[i].index("[") + 1 : parts[i].index("]")]
+                for item in node:
+                    if isinstance(item, dict):
+                        name = item.get("name") or item.get("path")
+                        if str(name) == bracket_val:
+                            node = item
+                            break
+
+        last_key = parts[-1]
+        if isinstance(node, dict) and last_key in node:
+            node[last_key] = new_body
+
+        from io import StringIO
+
+        buf = StringIO()
+        ruyaml.dump(data, buf)
+        path.write_text(buf.getvalue(), encoding="utf-8")
+
+    return _write
+
+
+def _gather_coderabbit_blocks(
     context: RepositoryContext,
     seen: Set[Path],
     _is_excluded: Callable,
-) -> List[ContentFile]:
-    """Yield one ContentFile per instruction block in .coderabbit.yaml."""
+) -> List[ContentBlock]:
+    """Yield one ContentBlock per instruction block in .coderabbit.yaml."""
     cr_path = context.root_path / ".coderabbit.yaml"
     cr_resolved = cr_path.resolve()
     if cr_resolved in seen or not cr_path.exists() or _is_excluded(cr_path):
@@ -208,26 +287,32 @@ def _gather_coderabbit_files(
         return []
     if not cr_data:
         return []
-    results: List[ContentFile] = []
-    for _label, text, line in _extract_instructions(cr_data, cr_raw):
+    results: List[ContentBlock] = []
+    for label, text, line in _extract_instructions(cr_data, cr_raw):
         offset = (line - 1) if line else 0
         results.append(
-            ContentFile(path=cr_path, category="coderabbit", line_offset=offset, body=text)
+            ContentBlock(
+                path=cr_path,
+                category="coderabbit",
+                line_offset=offset,
+                body=text,
+                _writer=_make_coderabbit_writer(cr_path, label),
+            )
         )
     return results
 
 
-def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
-    """Gather all contextual content files across all formats.
+def gather_all_content_blocks(context: RepositoryContext) -> List[ContentBlock]:
+    """Gather all content blocks across all formats.
 
-    Returns tagged ContentFile objects with category matching context_budget limit keys.
+    Returns tagged ContentBlock objects with category matching context_budget limit keys.
     Deduplicates by resolved path.
 
     When APM (.apm/) is present, content is gathered from the APM source
     directories instead of compiled output directories (.claude/, .cursor/,
     .gemini/, .opencode/, .agents/).
     """
-    files: List[ContentFile] = []
+    files: List[ContentBlock] = []
     seen: Set[Path] = set()
     exclude = getattr(context, "exclude_patterns", [])
     root = context.root_path.resolve()
@@ -262,7 +347,7 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
         resolved = p.resolve()
         if resolved not in seen and p.exists() and not _is_excluded(p):
             seen.add(resolved)
-            files.append(ContentFile(path=p, category=category))
+            files.append(ContentBlock(path=p, category=category))
 
     # --- Root-level instruction files (not compiled output) ---
     for f in context.instruction_files:
@@ -320,8 +405,8 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
             for rule_file in sorted(rules_dir.rglob("*.md")):
                 _add(rule_file, "rule")
 
-    # .coderabbit.yaml: yield one ContentFile per instruction block
-    files.extend(_gather_coderabbit_files(context, seen, _is_excluded))
+    # .coderabbit.yaml: yield one ContentBlock per instruction block
+    files.extend(_gather_coderabbit_blocks(context, seen, _is_excluded))
 
     # --- APM source directories ---
     if context.has_apm:
@@ -366,44 +451,25 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
     return files
 
 
-def gather_all_instruction_files(context: RepositoryContext) -> List[Path]:
-    """Gather all contextual content files across all formats.
+gather_all_content_files = gather_all_content_blocks
 
-    Thin wrapper around gather_all_content_files for backward compatibility.
-    """
-    return [cf.path for cf in gather_all_content_files(context)]
+
+def gather_all_instruction_files(context: RepositoryContext) -> List[Path]:
+    """Thin wrapper for backward compatibility."""
+    return [block.path for block in gather_all_content_blocks(context)]
 
 
 def _get_body(path: Path, *, strip_code_blocks: bool = True) -> Optional[str]:
     """Read file and return the instruction body text.
 
-    Handles special file types:
-    - ``.mdc``: strips YAML frontmatter.
+    Prefer ``ContentBlock.read_body()`` for new code.
     """
-    content = read_text(path)
-    if content is None:
-        return None
-    if path.suffix == ".mdc":
-        _, body = parse_frontmatter(content)
-    else:
-        body = content
-    if strip_code_blocks:
-        body = _strip_fenced_code_blocks(body)
-    return body
+    return ContentBlock(path=path, category="file").read_body(strip_code_blocks=strip_code_blocks)
 
 
-def _get_body_from_cf(cf: ContentFile, *, strip_code_blocks: bool = True) -> Optional[str]:
-    """Return instruction body text for a ContentFile.
-
-    If ``cf.body`` is pre-populated (e.g. coderabbit instruction fragments),
-    returns that directly.  Otherwise falls through to ``_get_body(cf.path)``.
-    """
-    if cf.body is not None:
-        body = cf.body
-        if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
-        return body
-    return _get_body(cf.path, strip_code_blocks=strip_code_blocks)
+def _get_body_from_cf(cf: ContentBlock, *, strip_code_blocks: bool = True) -> Optional[str]:
+    """Backward-compat wrapper around ``ContentBlock.read_body()``."""
+    return cf.read_body(strip_code_blocks=strip_code_blocks)
 
 
 # ---------------------------------------------------------------------------
@@ -549,7 +615,7 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
 
 
 class WeakLanguageDetector:
-    def analyze(self, cf: ContentFile) -> List[WeakLanguageMatch]:
+    def analyze(self, cf: ContentBlock) -> List[WeakLanguageMatch]:
         content = _get_body_from_cf(cf)
         if not content:
             return []
@@ -568,15 +634,13 @@ class WeakLanguageDetector:
             for pattern, fix in _NON_ACTIONABLE:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
                     results.append(
-                        WeakLanguageMatch(
-                            cf.file_line(line_num), m.group(), "non-actionable", fix
-                        )
+                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "non-actionable", fix)
                     )
         return results
 
 
 class TautologicalDetector:
-    def analyze(self, cf: ContentFile) -> List[TautologicalMatch]:
+    def analyze(self, cf: ContentBlock) -> List[TautologicalMatch]:
         content = _get_body_from_cf(cf)
         if not content:
             return []
@@ -593,7 +657,7 @@ class CriticalPositionAnalyzer:
     def __init__(self, min_lines: int = 50):
         self._min_lines = min_lines
 
-    def analyze(self, cf: ContentFile) -> List[PositionIssue]:
+    def analyze(self, cf: ContentBlock) -> List[PositionIssue]:
         content = _get_body_from_cf(cf)
         if not content:
             return []
@@ -628,7 +692,7 @@ class RedundancyDetector:
         (re.compile(r"\bindent\s+with\s+tabs\b", re.IGNORECASE), "indent_style"),
     ]
 
-    def analyze(self, cf: ContentFile, root: Path) -> List[RedundancyMatch]:
+    def analyze(self, cf: ContentBlock, root: Path) -> List[RedundancyMatch]:
         content = _get_body_from_cf(cf)
         if not content:
             return []
@@ -718,7 +782,7 @@ class InstructionBudgetAnalyzer:
     )
     BUDGET = 150
 
-    def analyze_file(self, cf: ContentFile) -> InstructionBudget:
+    def analyze_file(self, cf: ContentBlock) -> InstructionBudget:
         content = _get_body_from_cf(cf)
         if not content:
             return InstructionBudget(

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -587,6 +587,57 @@ class ParsedFrontmatterBlock(FileContentBlock):
             label += f" [desc: {desc_tokens:,} tokens]"
         return label
 
+    def read_frontmatter_text(self) -> str:
+        """Return the raw YAML text between the --- delimiters (no delimiters)."""
+        content = read_text(self.path)
+        if not content or not content.startswith("---"):
+            return ""
+        fm_text, _ = _extract_frontmatter_text(content)
+        return fm_text or ""
+
+    def write_frontmatter_text(self, new_fm_text: str) -> None:
+        """Replace just the frontmatter YAML, preserving the body.
+
+        Raises ValueError if new_fm_text is not valid YAML.
+        """
+        try:
+            data = yaml.safe_load(new_fm_text)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError("Frontmatter must be a YAML mapping")
+
+        fm = new_fm_text.rstrip("\n") + "\n"
+
+        content = read_text(self.path)
+        if not content:
+            self.path.write_text(f"---\n{fm}---\n", encoding="utf-8")
+            self._fm_parsed = None
+            return
+
+        m = re.match(r"^---[ \t]*\n(.*?\n)---[ \t]*\n?", content, re.DOTALL)
+        if m:
+            body_after = content[m.end() :]
+            self.path.write_text(f"---\n{fm}---\n{body_after}", encoding="utf-8")
+        elif content.startswith("---"):
+            lines = content.split("\n")
+            close_idx = None
+            for i, line in enumerate(lines[1:], 1):
+                if line.strip() == "---":
+                    close_idx = i
+                    break
+            if close_idx is not None:
+                body_after = "\n".join(lines[close_idx + 1 :])
+                if body_after and not body_after.startswith("\n"):
+                    body_after = "\n" + body_after
+                self.path.write_text(f"---\n{fm}---{body_after}", encoding="utf-8")
+            else:
+                body_after = "\n".join(lines[1:])
+                self.path.write_text(f"---\n{fm}---\n{body_after}", encoding="utf-8")
+        else:
+            self.path.write_text(f"---\n{fm}---\n{content}", encoding="utf-8")
+        self._fm_parsed = None
+
 
 @dataclass(eq=False)
 class CommandBlock(ParsedFrontmatterBlock):

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -177,6 +177,8 @@ _INSTRUCTION_FILE_CATEGORIES = {
 class ContentFile:
     path: Path
     category: str
+    line_offset: int = 0
+    body: Optional[str] = None
 
 
 def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
@@ -282,7 +284,28 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
             for rule_file in sorted(rules_dir.rglob("*.md")):
                 _add(rule_file, "rule")
 
-    _add(context.root_path / ".coderabbit.yaml", "coderabbit")
+    # .coderabbit.yaml: yield one ContentFile per instruction block
+    cr_path = context.root_path / ".coderabbit.yaml"
+    cr_resolved = cr_path.resolve()
+    if cr_resolved not in seen and cr_path.exists() and not _is_excluded(cr_path):
+        seen.add(cr_resolved)
+        cr_raw = read_text(cr_path)
+        if cr_raw:
+            try:
+                cr_data = yaml.safe_load(cr_raw)
+            except yaml.YAMLError:
+                cr_data = None
+            if cr_data:
+                for _label, text, line in _extract_instructions(cr_data, cr_raw):
+                    offset = (line - 1) if line else 0
+                    files.append(
+                        ContentFile(
+                            path=cr_path,
+                            category="coderabbit",
+                            line_offset=offset,
+                            body=text,
+                        )
+                    )
 
     # --- APM source directories ---
     if context.has_apm:
@@ -340,21 +363,31 @@ def _get_body(path: Path, *, strip_code_blocks: bool = True) -> Optional[str]:
 
     Handles special file types:
     - ``.mdc``: strips YAML frontmatter.
-    - ``.coderabbit.yaml``: extracts and concatenates all ``instructions``
-      field values so content analyzers see only instruction text.
     """
     content = read_text(path)
     if content is None:
         return None
-    if path.name == ".coderabbit.yaml":
-        body = _extract_coderabbit_instructions_body(content)
-    elif path.suffix == ".mdc":
+    if path.suffix == ".mdc":
         _, body = parse_frontmatter(content)
     else:
         body = content
     if strip_code_blocks:
         body = _strip_fenced_code_blocks(body)
     return body
+
+
+def _get_body_from_cf(cf: ContentFile, *, strip_code_blocks: bool = True) -> Optional[str]:
+    """Return instruction body text for a ContentFile.
+
+    If ``cf.body`` is pre-populated (e.g. coderabbit instruction fragments),
+    returns that directly.  Otherwise falls through to ``_get_body(cf.path)``.
+    """
+    if cf.body is not None:
+        body = cf.body
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+        return body
+    return _get_body(cf.path, strip_code_blocks=strip_code_blocks)
 
 
 # ---------------------------------------------------------------------------
@@ -499,43 +532,36 @@ def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[
     return results
 
 
-def _extract_coderabbit_instructions_body(raw: str) -> str:
-    """Extract instruction text from raw .coderabbit.yaml content.
-
-    Parses the YAML and concatenates all ``instructions`` field values
-    separated by double newlines so content analyzers see only plain text.
-    Returns an empty string on parse failure or when no instructions exist.
-    """
-    try:
-        data = yaml.safe_load(raw)
-    except yaml.YAMLError:
-        return ""
-    instructions = _extract_instructions(data, raw)
-    return "\n\n".join(text for _, text, _ in instructions)
-
-
 class WeakLanguageDetector:
-    def analyze(self, path: Path) -> List[WeakLanguageMatch]:
-        content = _get_body(path)
+    def analyze(self, cf: ContentFile) -> List[WeakLanguageMatch]:
+        content = _get_body_from_cf(cf)
         if not content:
             return []
         results: List[WeakLanguageMatch] = []
         for line_num, line in enumerate(content.splitlines(), 1):
             for pattern, fix in _HEDGING:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(WeakLanguageMatch(line_num, m.group(), "hedging", fix))
+                    results.append(
+                        WeakLanguageMatch(line_num + cf.line_offset, m.group(), "hedging", fix)
+                    )
             for pattern, fix in _VAGUENESS:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(WeakLanguageMatch(line_num, m.group(), "vagueness", fix))
+                    results.append(
+                        WeakLanguageMatch(line_num + cf.line_offset, m.group(), "vagueness", fix)
+                    )
             for pattern, fix in _NON_ACTIONABLE:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(WeakLanguageMatch(line_num, m.group(), "non-actionable", fix))
+                    results.append(
+                        WeakLanguageMatch(
+                            line_num + cf.line_offset, m.group(), "non-actionable", fix
+                        )
+                    )
         return results
 
 
 class TautologicalDetector:
-    def analyze(self, path: Path) -> List[TautologicalMatch]:
-        content = _get_body(path)
+    def analyze(self, cf: ContentFile) -> List[TautologicalMatch]:
+        content = _get_body_from_cf(cf)
         if not content:
             return []
         results: List[TautologicalMatch] = []
@@ -543,7 +569,7 @@ class TautologicalDetector:
             for pattern, reason in _TAUTOLOGICAL_PHRASES:
                 m = re.search(pattern, line, re.IGNORECASE)
                 if m:
-                    results.append(TautologicalMatch(line_num, m.group(), reason))
+                    results.append(TautologicalMatch(line_num + cf.line_offset, m.group(), reason))
         return results
 
 
@@ -551,8 +577,8 @@ class CriticalPositionAnalyzer:
     def __init__(self, min_lines: int = 50):
         self._min_lines = min_lines
 
-    def analyze(self, path: Path) -> List[PositionIssue]:
-        content = _get_body(path)
+    def analyze(self, cf: ContentFile) -> List[PositionIssue]:
+        content = _get_body_from_cf(cf)
         if not content:
             return []
         lines = content.splitlines()
@@ -569,7 +595,7 @@ class CriticalPositionAnalyzer:
                 score = 0.5
                 results.append(
                     PositionIssue(
-                        line_num,
+                        line_num + cf.line_offset,
                         m.group(),
                         score,
                         "Move to the first 20% or last 20% of the file for better attention",
@@ -586,8 +612,8 @@ class RedundancyDetector:
         (re.compile(r"\bindent\s+with\s+tabs\b", re.IGNORECASE), "indent_style"),
     ]
 
-    def analyze(self, path: Path, root: Path) -> List[RedundancyMatch]:
-        content = _get_body(path)
+    def analyze(self, cf: ContentFile, root: Path) -> List[RedundancyMatch]:
+        content = _get_body_from_cf(cf)
         if not content:
             return []
         results: List[RedundancyMatch] = []
@@ -618,12 +644,13 @@ class RedundancyDetector:
         has_tsconfig = (root / "tsconfig.json").exists()
 
         for line_num, line in enumerate(content.splitlines(), 1):
+            adjusted = line_num + cf.line_offset
             if has_editorconfig:
                 for pattern, config_key in self._INDENT_PATTERNS:
                     if pattern.search(line):
                         results.append(
                             RedundancyMatch(
-                                line_num,
+                                adjusted,
                                 line.strip(),
                                 ".editorconfig",
                                 config_key,
@@ -643,7 +670,7 @@ class RedundancyDetector:
                     )
                     results.append(
                         RedundancyMatch(
-                            line_num,
+                            adjusted,
                             line.strip(),
                             config_file,
                             "style rule",
@@ -658,7 +685,7 @@ class RedundancyDetector:
                 ):
                     results.append(
                         RedundancyMatch(
-                            line_num,
+                            adjusted,
                             line.strip(),
                             "tsconfig.json",
                             "strict mode",
@@ -675,8 +702,8 @@ class InstructionBudgetAnalyzer:
     )
     BUDGET = 150
 
-    def analyze_file(self, path: Path) -> InstructionBudget:
-        content = _get_body(path)
+    def analyze_file(self, cf: ContentFile) -> InstructionBudget:
+        content = _get_body_from_cf(cf)
         if not content:
             return InstructionBudget(
                 total_count=0,
@@ -691,7 +718,7 @@ class InstructionBudgetAnalyzer:
         remaining = self.BUDGET - total
         return InstructionBudget(
             total_count=total,
-            files_counted=[path],
+            files_counted=[cf.path],
             budget_remaining=max(0, remaining),
             over_budget=total > self.BUDGET,
         )

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -579,6 +579,14 @@ class ParsedFrontmatterBlock(FileContentBlock):
             return {}
         return _yaml_line_map(fm_text, line_offset=offset)
 
+    def tree_label(self) -> str:
+        label = super().tree_label()
+        fm = self.frontmatter
+        if fm and isinstance(fm.get("description"), str):
+            desc_tokens = len(fm["description"]) // 4
+            label += f" [desc: {desc_tokens:,} tokens]"
+        return label
+
 
 @dataclass(eq=False)
 class CommandBlock(ParsedFrontmatterBlock):

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -657,6 +657,217 @@ class ExtraBlock(FileContentBlock):
     category: str = "extra"
 
 
+@dataclass(eq=False)
+class ReadmeBlock(LintTarget):
+    """README.md in a plugin (not injected into context)."""
+
+    show_tokens = False
+
+    def tree_label(self) -> str:
+        return self.path.name
+
+
+# ---------------------------------------------------------------------------
+# JSON-based blocks: hooks and MCP
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HookHandler:
+    """A single hook handler entry."""
+
+    type: str
+    command: Optional[str] = None
+    url: Optional[str] = None
+    headers: Optional[Dict[str, Any]] = None
+    server: Optional[str] = None
+    tool: Optional[str] = None
+    input: Optional[Dict[str, Any]] = None
+    prompt: Optional[str] = None
+    model: Optional[str] = None
+    timeout: Optional[float] = None
+    async_: Optional[bool] = None
+    async_rewake: Optional[bool] = None
+    once: Optional[bool] = None
+    if_: Optional[str] = None
+    status_message: Optional[str] = None
+    shell: Optional[str] = None
+    allowed_env_vars: Optional[List[str]] = None
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "HookHandler":
+        return cls(
+            type=d.get("type", ""),
+            command=d.get("command"),
+            url=d.get("url"),
+            headers=d.get("headers"),
+            server=d.get("server"),
+            tool=d.get("tool"),
+            input=d.get("input"),
+            prompt=d.get("prompt"),
+            model=d.get("model"),
+            timeout=d.get("timeout"),
+            async_=d.get("async"),
+            async_rewake=d.get("asyncRewake"),
+            once=d.get("once"),
+            if_=d.get("if"),
+            status_message=d.get("statusMessage"),
+            shell=d.get("shell"),
+            allowed_env_vars=d.get("allowedEnvVars"),
+        )
+
+
+@dataclass
+class HookEventConfig:
+    """A single event config entry (matcher + handlers)."""
+
+    matcher: str = ".*"
+    handlers: List[HookHandler] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "HookEventConfig":
+        handlers: List[HookHandler] = []
+        raw_hooks = d.get("hooks", [])
+        if isinstance(raw_hooks, list):
+            for h in raw_hooks:
+                if isinstance(h, dict):
+                    handlers.append(HookHandler.from_dict(h))
+        return cls(
+            matcher=d.get("matcher", ".*"),
+            handlers=handlers,
+        )
+
+
+def _parse_json_file(path: Path) -> Tuple[Optional[Any], Optional[str]]:
+    from .utils import read_json
+
+    data, error = read_json(path)
+    return data, error
+
+
+@dataclass(eq=False)
+class HooksBlock(FileContentBlock):
+    """hooks/hooks.json in a plugin."""
+
+    category: str = "hooks"
+    _parsed: Optional[Tuple[Optional[Any], Optional[str]]] = field(
+        default=None, init=False, repr=False
+    )
+
+    def _ensure_parsed(self) -> None:
+        if self._parsed is None:
+            self._parsed = _parse_json_file(self.path)
+
+    @property
+    def parse_error(self) -> Optional[str]:
+        self._ensure_parsed()
+        return self._parsed[1]
+
+    @property
+    def raw_data(self) -> Optional[Dict[str, Any]]:
+        self._ensure_parsed()
+        data = self._parsed[0]
+        return data if isinstance(data, dict) else None
+
+    @property
+    def events(self) -> Dict[str, List[HookEventConfig]]:
+        data = self.raw_data
+        if data is None:
+            return {}
+        hooks_obj = data.get("hooks", {})
+        if not isinstance(hooks_obj, dict):
+            return {}
+        result: Dict[str, List[HookEventConfig]] = {}
+        for event_type, configs in hooks_obj.items():
+            if not isinstance(configs, list):
+                continue
+            entries: List[HookEventConfig] = []
+            for cfg in configs:
+                if isinstance(cfg, dict):
+                    entries.append(HookEventConfig.from_dict(cfg))
+            if entries:
+                result[event_type] = entries
+        return result
+
+
+@dataclass
+class McpServerConfig:
+    """A single MCP server configuration."""
+
+    name: str
+    type: str = "stdio"
+    command: Optional[str] = None
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+    cwd: Optional[str] = None
+    url: Optional[str] = None
+    headers: Optional[Dict[str, Any]] = None
+    headers_helper: Optional[str] = None
+    startup_timeout: Optional[float] = None
+    always_load: Optional[bool] = None
+    oauth: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_dict(cls, name: str, d: Dict[str, Any]) -> "McpServerConfig":
+        return cls(
+            name=name,
+            type=d.get("type", "stdio"),
+            command=d.get("command"),
+            args=d.get("args"),
+            env=d.get("env"),
+            cwd=d.get("cwd"),
+            url=d.get("url"),
+            headers=d.get("headers"),
+            headers_helper=d.get("headersHelper"),
+            startup_timeout=d.get("startupTimeout"),
+            always_load=d.get("alwaysLoad"),
+            oauth=d.get("oauth"),
+        )
+
+
+@dataclass(eq=False)
+class McpBlock(FileContentBlock):
+    """.mcp.json in a plugin."""
+
+    category: str = "mcp"
+    _parsed: Optional[Tuple[Optional[Any], Optional[str]]] = field(
+        default=None, init=False, repr=False
+    )
+
+    def _ensure_parsed(self) -> None:
+        if self._parsed is None:
+            self._parsed = _parse_json_file(self.path)
+
+    @property
+    def parse_error(self) -> Optional[str]:
+        self._ensure_parsed()
+        return self._parsed[1]
+
+    @property
+    def raw_data(self) -> Optional[Dict[str, Any]]:
+        self._ensure_parsed()
+        data = self._parsed[0]
+        return data if isinstance(data, dict) else None
+
+    @property
+    def servers(self) -> List[McpServerConfig]:
+        data = self.raw_data
+        if data is None:
+            return []
+        servers_dict = data.get("mcpServers", data)
+        if not isinstance(servers_dict, dict):
+            return []
+        return [
+            McpServerConfig.from_dict(name, cfg)
+            for name, cfg in servers_dict.items()
+            if isinstance(cfg, dict)
+        ]
+
+    @property
+    def server_names(self) -> Set[str]:
+        return {s.name for s in self.servers}
+
+
 # Backward compat aliases
 ContentFile = FileContentBlock
 

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -287,9 +287,14 @@ def _gather_coderabbit_blocks(
         return []
     if not cr_data:
         return []
+    cr_lines = cr_raw.splitlines()
     results: List[ContentBlock] = []
     for label, text, line in _extract_instructions(cr_data, cr_raw):
-        offset = (line - 1) if line else 0
+        offset = 0
+        if line:
+            key_text = cr_lines[line - 1] if line <= len(cr_lines) else ""
+            is_block_scalar = bool(re.search(r":\s*[|>]", key_text))
+            offset = line if is_block_scalar else (line - 1)
         results.append(
             ContentBlock(
                 path=cr_path,

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -14,7 +14,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import yaml
 
@@ -25,6 +25,10 @@ from ruamel.yaml import YAML as _RuamelYAML
 from skillsaw.rules.builtin.utils import (
     read_text,
     parse_frontmatter,
+    extract_section,
+    frontmatter_key_line as _frontmatter_key_line,
+    _extract_frontmatter_text,
+    yaml_line_map as _yaml_line_map,
     yaml_key_line as _yaml_key_line_util,
     yaml_key_line_after as _yaml_key_line_after_util,
     yaml_key_lines as _yaml_key_lines_util,
@@ -518,22 +522,86 @@ class CursorRuleBlock(FrontmatterContentBlock):
     category: str = "instruction"
 
 
+def _parse_file_frontmatter(
+    path: Path,
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], str]:
+    """Parse YAML frontmatter from a markdown file.
+
+    Returns (frontmatter_dict, error_string, body_after_frontmatter).
+    """
+    content = read_text(path)
+    if content is None:
+        return None, f"Failed to read file: {path}", ""
+    if not content.startswith("---"):
+        return None, None, content
+    fm, body = parse_frontmatter(content)
+    if fm is None:
+        return None, "Invalid frontmatter (malformed YAML or missing closing ---)", body
+    return fm, None, body
+
+
 @dataclass(eq=False)
-class CommandBlock(FileContentBlock):
+class ParsedFrontmatterBlock(FileContentBlock):
+    """File content block with lazy-parsed YAML frontmatter."""
+
+    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], str]] = field(
+        default=None, init=False, repr=False
+    )
+
+    def _ensure_parsed(self) -> None:
+        if self._fm_parsed is None:
+            self._fm_parsed = _parse_file_frontmatter(self.path)
+
+    @property
+    def frontmatter(self) -> Optional[Dict[str, Any]]:
+        self._ensure_parsed()
+        return self._fm_parsed[0]
+
+    @property
+    def frontmatter_error(self) -> Optional[str]:
+        self._ensure_parsed()
+        return self._fm_parsed[1]
+
+    @property
+    def body_text(self) -> str:
+        self._ensure_parsed()
+        return self._fm_parsed[2]
+
+    def key_line(self, key: str) -> Optional[int]:
+        return _frontmatter_key_line(self.path, key)
+
+    def line_map(self) -> Dict[str, int]:
+        content = read_text(self.path)
+        if content is None:
+            return {}
+        fm_text, offset = _extract_frontmatter_text(content)
+        if fm_text is None:
+            return {}
+        return _yaml_line_map(fm_text, line_offset=offset)
+
+
+@dataclass(eq=False)
+class CommandBlock(ParsedFrontmatterBlock):
     """commands/*.md in plugins."""
 
     category: str = "command"
 
+    def section(self, heading: str, level: int = 2) -> str:
+        content = read_text(self.path)
+        if content is None:
+            return ""
+        return extract_section(content, heading, level)
+
 
 @dataclass(eq=False)
-class AgentBlock(FileContentBlock):
+class AgentBlock(ParsedFrontmatterBlock):
     """agents/*.md in plugins or APM agent files."""
 
     category: str = "agent"
 
 
 @dataclass(eq=False)
-class SkillBlock(FileContentBlock):
+class SkillBlock(ParsedFrontmatterBlock):
     """SKILL.md in skills."""
 
     category: str = "skill"
@@ -547,7 +615,7 @@ class SkillRefBlock(FileContentBlock):
 
 
 @dataclass(eq=False)
-class PluginRuleBlock(FileContentBlock):
+class PluginRuleBlock(ParsedFrontmatterBlock):
     """rules/*.md in plugins."""
 
     category: str = "rule"

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -8,7 +8,7 @@ in instruction files across all formats (CLAUDE.md, AGENTS.md, GEMINI.md,
 
 import fnmatch
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Set, Tuple
 
@@ -179,9 +179,12 @@ class ContentFile:
     category: str
     line_offset: int = 0
     body: Optional[str] = None
+    _line_map: Optional[Callable[[int], int]] = field(default=None, repr=False)
 
     def file_line(self, body_line: int) -> int:
         """Translate a 1-based body line number to a 1-based file line number."""
+        if self._line_map is not None:
+            return self._line_map(body_line)
         return body_line + self.line_offset
 
 

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -470,6 +470,111 @@ class CodeRabbitContentBlock(ContentBlock):
         return results
 
 
+# ---------------------------------------------------------------------------
+# Typed content blocks — each hardcodes its category as a class default.
+# Rules discover blocks via ``find(BlockType)``; ``category`` is kept for
+# backward compat (context_budget limits key on it).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(eq=False)
+class InstructionBlock(FileContentBlock):
+    """Generic instruction files: .cursorrules, .windsurfrules, copilot-instructions, etc."""
+
+    category: str = "instruction"
+
+
+@dataclass(eq=False)
+class ClaudeMdBlock(InstructionBlock):
+    """CLAUDE.md instruction file."""
+
+    category: str = "claude-md"
+
+
+@dataclass(eq=False)
+class AgentsMdBlock(InstructionBlock):
+    """AGENTS.md instruction file."""
+
+    category: str = "agents-md"
+
+
+@dataclass(eq=False)
+class GeminiMdBlock(InstructionBlock):
+    """GEMINI.md instruction file."""
+
+    category: str = "gemini-md"
+
+
+@dataclass(eq=False)
+class CursorRuleBlock(FrontmatterContentBlock):
+    """.cursor/rules/*.mdc files."""
+
+    category: str = "instruction"
+
+
+@dataclass(eq=False)
+class CommandBlock(FileContentBlock):
+    """commands/*.md in plugins."""
+
+    category: str = "command"
+
+
+@dataclass(eq=False)
+class AgentBlock(FileContentBlock):
+    """agents/*.md in plugins or APM agent files."""
+
+    category: str = "agent"
+
+
+@dataclass(eq=False)
+class SkillBlock(FileContentBlock):
+    """SKILL.md in skills."""
+
+    category: str = "skill"
+
+
+@dataclass(eq=False)
+class SkillRefBlock(FileContentBlock):
+    """references/*.md in skills."""
+
+    category: str = "skill-ref"
+
+
+@dataclass(eq=False)
+class PluginRuleBlock(FileContentBlock):
+    """rules/*.md in plugins."""
+
+    category: str = "rule"
+
+
+@dataclass(eq=False)
+class PromptBlock(FileContentBlock):
+    """APM prompt files."""
+
+    category: str = "prompt"
+
+
+@dataclass(eq=False)
+class ChatmodeBlock(FileContentBlock):
+    """APM chatmode files."""
+
+    category: str = "chatmode"
+
+
+@dataclass(eq=False)
+class ContextFileBlock(FileContentBlock):
+    """APM context files."""
+
+    category: str = "context"
+
+
+@dataclass(eq=False)
+class ExtraBlock(FileContentBlock):
+    """Extra content paths from config."""
+
+    category: str = "extra"
+
+
 # Backward compat aliases
 ContentFile = FileContentBlock
 

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -8,13 +8,16 @@ in instruction files across all formats (CLAUDE.md, AGENTS.md, GEMINI.md,
 
 import fnmatch
 import re
+from abc import abstractmethod
 from dataclasses import dataclass, field
+from io import StringIO
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Set, Tuple
 
 import yaml
 
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import LintTarget
 from ruamel.yaml import YAML as _RuamelYAML
 
 from skillsaw.rules.builtin.utils import (
@@ -32,13 +35,7 @@ _CLOSING_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*$")
 
 
 def _strip_fenced_code_blocks(text: str) -> str:
-    """Replace content inside fenced code blocks with blank lines to preserve line numbers.
-
-    Implements CommonMark fenced code block detection:
-    - Opening fence: 0-3 spaces indent, then 3+ backticks or tildes
-    - Closing fence: 0-3 spaces indent (independent of opening), same character,
-      length >= opening fence length, no other content on the line
-    """
+    """Replace content inside fenced code blocks with blank lines to preserve line numbers."""
     lines = text.split("\n")
     result: list[str] = []
     fence_char: str | None = None
@@ -49,7 +46,7 @@ def _strip_fenced_code_blocks(text: str) -> str:
         if not in_fence:
             m = _OPENING_FENCE_RE.match(line)
             if m:
-                fence_char = m.group(2)[0]  # '`' or '~'
+                fence_char = m.group(2)[0]
                 fence_len = len(m.group(2))
                 in_fence = True
                 result.append("")
@@ -175,14 +172,19 @@ _INSTRUCTION_FILE_CATEGORIES = {
 }
 
 
-@dataclass
-class ContentBlock:
-    path: Path
-    category: str
+# ---------------------------------------------------------------------------
+# ContentBlock hierarchy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(eq=False)
+class ContentBlock(LintTarget):
+    """Abstract base for leaf nodes with lintable text content."""
+
+    category: str = ""
     line_offset: int = 0
     body: Optional[str] = None
     _line_map: Optional[Callable[[int], int]] = field(default=None, repr=False)
-    _writer: Optional[Callable[[str], None]] = field(default=None, repr=False)
 
     def file_line(self, body_line: int) -> int:
         """Translate a 1-based body line number to a 1-based file line number."""
@@ -190,51 +192,101 @@ class ContentBlock:
             return self._line_map(body_line)
         return body_line + self.line_offset
 
+    @abstractmethod
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]: ...
+
+    @abstractmethod
+    def write_body(self, new_body: str) -> None: ...
+
+    def tree_label(self) -> str:
+        return f"{self.path.name} ({self.category})"
+
+    def __eq__(self, other):
+        if not isinstance(other, ContentBlock):
+            return NotImplemented
+        return type(self) is type(other) and self.path.resolve() == other.path.resolve()
+
+    def __hash__(self):
+        return hash((type(self), self.path.resolve()))
+
+
+@dataclass(eq=False)
+class FileContentBlock(ContentBlock):
+    """A plain file whose entire content is lintable."""
+
     def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
-        """Return the block's text content."""
         if self.body is not None:
             body = self.body
         else:
             content = read_text(self.path)
             if content is None:
                 return None
-            if self.path.suffix == ".mdc":
-                _, body = parse_frontmatter(content)
-            else:
-                body = content
+            body = content
         if strip_code_blocks:
             body = _strip_fenced_code_blocks(body)
         return body
 
     def write_body(self, new_body: str) -> None:
-        """Write fixed content back to the correct location."""
-        if self._writer is not None:
-            self._writer(new_body)
+        self.path.write_text(new_body, encoding="utf-8")
+
+
+@dataclass(eq=False)
+class FrontmatterContentBlock(ContentBlock):
+    """A file with YAML frontmatter (e.g. .mdc) — frontmatter is stripped on read, preserved on write."""
+
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
+        if self.body is not None:
+            body = self.body
         else:
-            self.path.write_text(new_body, encoding="utf-8")
+            content = read_text(self.path)
+            if content is None:
+                return None
+            _, body = parse_frontmatter(content)
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+        return body
+
+    def write_body(self, new_body: str) -> None:
+        content = read_text(self.path)
+        if content:
+            front, _ = parse_frontmatter(content)
+            if front:
+                self.path.write_text(front + "\n---\n" + new_body, encoding="utf-8")
+                return
+        self.path.write_text(new_body, encoding="utf-8")
+
+    @property
+    def frontmatter_line_offset(self) -> int:
+        content = read_text(self.path)
+        if not content:
+            return 0
+        front, _ = parse_frontmatter(content)
+        if not front:
+            return 0
+        return front.count("\n") + 2  # frontmatter + closing ---
 
 
-ContentFile = ContentBlock
+@dataclass(eq=False)
+class CodeRabbitContentBlock(ContentBlock):
+    """One instruction fragment from .coderabbit.yaml."""
 
+    yaml_path: str = ""
 
-def _make_coderabbit_writer(path: Path, yaml_path: str) -> Callable[[str], None]:
-    """Return a closure that updates one instruction value in .coderabbit.yaml.
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
+        body = self.body if self.body is not None else ""
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+        return body
 
-    Uses ruamel.yaml round-trip to preserve comments, ordering, and formatting.
-    ``yaml_path`` is a dotted path like ``reviews.instructions`` or
-    ``reviews.tools.biome.instructions``.  Array entries use bracket syntax
-    like ``reviews.path_instructions[src/**].instructions``.
-    """
-
-    def _write(new_body: str) -> None:
+    def write_body(self, new_body: str) -> None:
         ruyaml = _RuamelYAML()
         ruyaml.preserve_quotes = True
-        raw = path.read_text(encoding="utf-8")
+        raw = self.path.read_text(encoding="utf-8")
         data = ruyaml.load(raw)
         if data is None:
             return
 
-        parts = yaml_path.split(".")
+        parts = self.yaml_path.split(".")
         node = data
         for i, part in enumerate(parts[:-1]):
             if "[" in part:
@@ -258,202 +310,178 @@ def _make_coderabbit_writer(path: Path, yaml_path: str) -> Callable[[str], None]
         if isinstance(node, dict) and last_key in node:
             node[last_key] = new_body
 
-        from io import StringIO
-
         buf = StringIO()
         ruyaml.dump(data, buf)
-        path.write_text(buf.getvalue(), encoding="utf-8")
+        self.path.write_text(buf.getvalue(), encoding="utf-8")
 
-    return _write
+    def tree_label(self) -> str:
+        return f"{self.yaml_path} ({self.category})"
 
+    def __eq__(self, other):
+        if not isinstance(other, CodeRabbitContentBlock):
+            return NotImplemented
+        return self.path.resolve() == other.path.resolve() and self.yaml_path == other.yaml_path
 
-def _gather_coderabbit_blocks(
-    context: RepositoryContext,
-    seen: Set[Path],
-    _is_excluded: Callable,
-) -> List[ContentBlock]:
-    """Yield one ContentBlock per instruction block in .coderabbit.yaml."""
-    cr_path = context.root_path / ".coderabbit.yaml"
-    cr_resolved = cr_path.resolve()
-    if cr_resolved in seen or not cr_path.exists() or _is_excluded(cr_path):
-        return []
-    seen.add(cr_resolved)
-    cr_raw = read_text(cr_path)
-    if not cr_raw:
-        return []
-    try:
-        cr_data = yaml.safe_load(cr_raw)
-    except yaml.YAMLError:
-        return []
-    if not cr_data:
-        return []
-    cr_lines = cr_raw.splitlines()
-    results: List[ContentBlock] = []
-    for label, text, line in _extract_instructions(cr_data, cr_raw):
-        offset = 0
-        if line:
-            key_text = cr_lines[line - 1] if line <= len(cr_lines) else ""
-            is_block_scalar = bool(re.search(r":\s*[|>]", key_text))
-            offset = line if is_block_scalar else (line - 1)
-        results.append(
-            ContentBlock(
-                path=cr_path,
-                category="coderabbit",
-                line_offset=offset,
-                body=text,
-                _writer=_make_coderabbit_writer(cr_path, label),
+    def __hash__(self):
+        return hash((type(self), self.path.resolve(), self.yaml_path))
+
+    # --- CodeRabbit extraction helpers (classmethods) ---
+
+    @classmethod
+    def gather(
+        cls,
+        context: RepositoryContext,
+        seen: Set[Path],
+        is_excluded: Callable[[Path], bool],
+    ) -> List["CodeRabbitContentBlock"]:
+        cr_path = context.root_path / ".coderabbit.yaml"
+        cr_resolved = cr_path.resolve()
+        if cr_resolved in seen or not cr_path.exists() or is_excluded(cr_path):
+            return []
+        seen.add(cr_resolved)
+        cr_raw = read_text(cr_path)
+        if not cr_raw:
+            return []
+        try:
+            cr_data = yaml.safe_load(cr_raw)
+        except yaml.YAMLError:
+            return []
+        if not cr_data:
+            return []
+        cr_lines = cr_raw.splitlines()
+        results: List[CodeRabbitContentBlock] = []
+        for label, text, line in cls._extract_instructions(cr_data, cr_raw):
+            offset = 0
+            if line:
+                key_text = cr_lines[line - 1] if line <= len(cr_lines) else ""
+                is_block_scalar = bool(re.search(r":\s*[|>]", key_text))
+                offset = line if is_block_scalar else (line - 1)
+            results.append(
+                CodeRabbitContentBlock(
+                    path=cr_path,
+                    category="coderabbit",
+                    line_offset=offset,
+                    body=text,
+                    yaml_path=label,
+                )
             )
-        )
-    return results
+        return results
+
+    @staticmethod
+    def _find_yaml_key_line(raw: str, key: str) -> Optional[int]:
+        all_lines = _yaml_key_lines_util(raw, key)
+        return all_lines[-1] if all_lines else None
+
+    @staticmethod
+    def _find_yaml_key_line_after(raw: str, key: str, after_line: int) -> Optional[int]:
+        return _yaml_key_line_after_util(raw, key, after_line)
+
+    @staticmethod
+    def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
+        return _yaml_nth_key_line_util(raw, key, n)
+
+    @staticmethod
+    def _find_nth_list_item_key_line(
+        raw: str, key: str, n: int, after_line: int = 0
+    ) -> Optional[int]:
+        return _yaml_nth_list_item_key_line_util(raw, key, n, after_line=after_line)
+
+    @classmethod
+    def _extract_instructions(cls, data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
+        results: List[Tuple[str, str, Optional[int]]] = []
+        if not isinstance(data, dict):
+            return results
+
+        reviews = data.get("reviews")
+        if isinstance(reviews, dict):
+            instr = reviews.get("instructions")
+            if isinstance(instr, str) and instr.strip():
+                reviews_line = cls._find_yaml_key_line(raw, "reviews")
+                line = None
+                if reviews_line is not None:
+                    line = cls._find_yaml_key_line_after(raw, "instructions", reviews_line)
+                if line is None:
+                    line = cls._find_yaml_key_line(raw, "instructions")
+                results.append(("reviews.instructions", instr, line))
+
+            path_instructions = reviews.get("path_instructions")
+            if isinstance(path_instructions, list):
+                for idx, entry in enumerate(path_instructions):
+                    if not isinstance(entry, dict):
+                        continue
+                    pi = entry.get("instructions")
+                    if isinstance(pi, str) and pi.strip():
+                        path_val = entry.get("path", f"[{idx}]")
+                        line = cls._find_nth_key_line(raw, "instructions", len(results))
+                        results.append(
+                            (f"reviews.path_instructions[{path_val}].instructions", pi, line)
+                        )
+
+            tools = reviews.get("tools")
+            if isinstance(tools, dict):
+                for tool_name, tool_cfg in tools.items():
+                    if not isinstance(tool_cfg, dict):
+                        continue
+                    ti = tool_cfg.get("instructions")
+                    if isinstance(ti, str) and ti.strip():
+                        tool_line = cls._find_yaml_key_line(raw, tool_name)
+                        line = None
+                        if tool_line is not None:
+                            line = cls._find_yaml_key_line_after(raw, "instructions", tool_line)
+                        results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
+
+            pre_merge = reviews.get("pre_merge_checks")
+            if isinstance(pre_merge, dict):
+                custom_checks = pre_merge.get("custom_checks")
+                if isinstance(custom_checks, list):
+                    custom_checks_line = cls._find_yaml_key_line(raw, "custom_checks") or 0
+                    for idx, check in enumerate(custom_checks):
+                        if not isinstance(check, dict):
+                            continue
+                        ci = check.get("instructions")
+                        if isinstance(ci, str) and ci.strip():
+                            check_name = check.get("name", f"[{idx}]")
+                            name_line = cls._find_nth_list_item_key_line(
+                                raw, "name", idx, after_line=custom_checks_line
+                            )
+                            line = None
+                            if name_line is not None:
+                                line = cls._find_yaml_key_line_after(raw, "instructions", name_line)
+                            results.append(
+                                (
+                                    f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
+                                    ci,
+                                    line,
+                                )
+                            )
+
+        chat = data.get("chat")
+        if isinstance(chat, dict):
+            ci = chat.get("instructions")
+            if isinstance(ci, str) and ci.strip():
+                chat_line = cls._find_yaml_key_line(raw, "chat")
+                line = None
+                if chat_line is not None:
+                    line = cls._find_yaml_key_line_after(raw, "instructions", chat_line)
+                if line is None:
+                    line = cls._find_yaml_key_line(raw, "instructions")
+                results.append(("chat.instructions", ci, line))
+
+        return results
+
+
+# Backward compat aliases
+ContentFile = FileContentBlock
+
+
+# ---------------------------------------------------------------------------
+# Gather helpers (delegated to by the lint tree builder)
+# ---------------------------------------------------------------------------
 
 
 def gather_all_content_blocks(context: RepositoryContext) -> List[ContentBlock]:
-    """Gather all content blocks across all formats.
-
-    Returns tagged ContentBlock objects with category matching context_budget limit keys.
-    Deduplicates by resolved path.
-
-    When APM (.apm/) is present, content is gathered from the APM source
-    directories instead of compiled output directories (.claude/, .cursor/,
-    .gemini/, .opencode/, .agents/).
-    """
-    files: List[ContentBlock] = []
-    seen: Set[Path] = set()
-    exclude = getattr(context, "exclude_patterns", [])
-    root = context.root_path.resolve()
-
-    # Build set of compiled output directories to skip when APM is present
-    apm_compiled_roots: Set[Path] = set()
-    if context.has_apm:
-        from skillsaw.context import RepositoryContext as _RC
-
-        for compiled_dir_name in _RC.APM_COMPILED_DIRS:
-            compiled_path = (context.root_path / compiled_dir_name).resolve()
-            if compiled_path.is_dir():
-                apm_compiled_roots.add(compiled_path)
-
-    def _is_excluded(p: Path) -> bool:
-        if not exclude:
-            return False
-        try:
-            rel = str(p.resolve().relative_to(root))
-        except ValueError:
-            return False
-        return any(fnmatch.fnmatch(rel, pat) for pat in exclude)
-
-    def _is_in_compiled_dir(p: Path) -> bool:
-        """Check if a path is inside an APM compiled output directory."""
-        if not apm_compiled_roots:
-            return False
-        resolved = p.resolve()
-        return any(resolved == excl or resolved.is_relative_to(excl) for excl in apm_compiled_roots)
-
-    def _add(p: Path, category: str) -> None:
-        resolved = p.resolve()
-        if resolved not in seen and p.exists() and not _is_excluded(p):
-            seen.add(resolved)
-            files.append(ContentBlock(path=p, category=category))
-
-    # --- Root-level instruction files (not compiled output) ---
-    for f in context.instruction_files:
-        cat = _INSTRUCTION_FILE_CATEGORIES.get(f.name, "instruction")
-        _add(f, cat)
-
-    _add(context.root_path / ".github" / "copilot-instructions.md", "instruction")
-    _add(context.root_path / ".cursorrules", "instruction")
-
-    # Skip compiled output directories when APM is present
-    cursor_rules_dir = context.root_path / ".cursor" / "rules"
-    if cursor_rules_dir.is_dir() and not _is_in_compiled_dir(cursor_rules_dir):
-        for mdc in sorted(cursor_rules_dir.glob("*.mdc")):
-            _add(mdc, "instruction")
-
-    kiro_steering = context.root_path / ".kiro" / "steering"
-    if kiro_steering.is_dir():
-        for md in sorted(kiro_steering.glob("*.md")):
-            _add(md, "instruction")
-
-    _add(context.root_path / ".windsurfrules", "instruction")
-
-    clinerules = context.root_path / ".clinerules"
-    if clinerules.is_file():
-        _add(clinerules, "instruction")
-    elif clinerules.is_dir():
-        for md in sorted(clinerules.glob("*.md")):
-            _add(md, "instruction")
-
-    # --- Skills ---
-    for skill_path in context.skills:
-        _add(skill_path / "SKILL.md", "skill")
-        refs_dir = skill_path / "references"
-        if refs_dir.is_dir():
-            for ref_file in sorted(refs_dir.glob("*.md")):
-                _add(ref_file, "skill-ref")
-
-    # --- Plugin content (skip compiled dirs when APM present) ---
-    for plugin_path in context.plugins:
-        if _is_in_compiled_dir(plugin_path):
-            continue
-
-        commands_dir = plugin_path / "commands"
-        if commands_dir.is_dir():
-            for cmd_file in sorted(commands_dir.glob("*.md")):
-                _add(cmd_file, "command")
-
-        agents_dir = plugin_path / "agents"
-        if agents_dir.is_dir():
-            for agent_file in sorted(agents_dir.glob("*.md")):
-                _add(agent_file, "agent")
-
-        rules_dir = plugin_path / "rules"
-        if rules_dir.is_dir():
-            for rule_file in sorted(rules_dir.rglob("*.md")):
-                _add(rule_file, "rule")
-
-    # .coderabbit.yaml: yield one ContentBlock per instruction block
-    files.extend(_gather_coderabbit_blocks(context, seen, _is_excluded))
-
-    # --- APM source directories ---
-    if context.has_apm:
-        apm_dir = context.root_path / ".apm"
-
-        # .apm/instructions/*.instructions.md
-        apm_instructions = apm_dir / "instructions"
-        if apm_instructions.is_dir():
-            for md in sorted(apm_instructions.glob("*.instructions.md")):
-                _add(md, "instruction")
-
-        # .apm/agents/*.agent.md
-        apm_agents = apm_dir / "agents"
-        if apm_agents.is_dir():
-            for md in sorted(apm_agents.glob("*.agent.md")):
-                _add(md, "agent")
-
-        # .apm/prompts/*.md
-        apm_prompts = apm_dir / "prompts"
-        if apm_prompts.is_dir():
-            for md in sorted(apm_prompts.glob("*.md")):
-                _add(md, "prompt")
-
-        # .apm/chatmodes/*.md
-        apm_chatmodes = apm_dir / "chatmodes"
-        if apm_chatmodes.is_dir():
-            for md in sorted(apm_chatmodes.glob("*.md")):
-                _add(md, "chatmode")
-
-        # .apm/context/*.md
-        apm_context = apm_dir / "context"
-        if apm_context.is_dir():
-            for md in sorted(apm_context.glob("*.md")):
-                _add(md, "context")
-
-    # --- Extra content paths from config ---
-    for glob_pattern in getattr(context, "content_paths", []):
-        for extra in sorted(context.root_path.glob(glob_pattern)):
-            if extra.is_file():
-                _add(extra, "extra")
-
-    return files
+    """Gather all content blocks via the lint tree."""
+    return context.lint_tree.content_blocks()
 
 
 gather_all_content_files = gather_all_content_blocks
@@ -465,11 +493,10 @@ def gather_all_instruction_files(context: RepositoryContext) -> List[Path]:
 
 
 def _get_body(path: Path, *, strip_code_blocks: bool = True) -> Optional[str]:
-    """Read file and return the instruction body text.
-
-    Prefer ``ContentBlock.read_body()`` for new code.
-    """
-    return ContentBlock(path=path, category="file").read_body(strip_code_blocks=strip_code_blocks)
+    """Prefer ``ContentBlock.read_body()`` for new code."""
+    return FileContentBlock(path=path, category="file").read_body(
+        strip_code_blocks=strip_code_blocks
+    )
 
 
 def _get_body_from_cf(cf: ContentBlock, *, strip_code_blocks: bool = True) -> Optional[str]:
@@ -478,145 +505,35 @@ def _get_body_from_cf(cf: ContentBlock, *, strip_code_blocks: bool = True) -> Op
 
 
 # ---------------------------------------------------------------------------
-# CodeRabbit instruction extraction helpers
+# CodeRabbit instruction extraction helpers (kept for backward compat)
 # ---------------------------------------------------------------------------
 
 _CODERABBIT_FILENAME = ".coderabbit.yaml"
 
 
 def _find_yaml_key_line(raw: str, key: str) -> Optional[int]:
-    """Find the line number of a YAML key in raw text.
-
-    Uses ruamel.yaml round-trip parsing for accurate line tracking.
-    Returns the 1-based line number of the *last* occurrence so that nested keys
-    such as ``instructions`` resolve to the most specific location when
-    the caller is walking a particular branch of the tree.  For
-    top-level unique keys the result is the same either way.
-    """
-    all_lines = _yaml_key_lines_util(raw, key)
-    return all_lines[-1] if all_lines else None
+    return CodeRabbitContentBlock._find_yaml_key_line(raw, key)
 
 
 def _find_yaml_key_line_after(raw: str, key: str, after_line: int) -> Optional[int]:
-    """Find the line number of a YAML key occurring after a given line.
-
-    Uses ruamel.yaml round-trip parsing for accurate line tracking.
-    """
-    return _yaml_key_line_after_util(raw, key, after_line)
+    return CodeRabbitContentBlock._find_yaml_key_line_after(raw, key, after_line)
 
 
 def _find_nth_key_line(raw: str, key: str, n: int) -> Optional[int]:
-    """Find the line number of the *n*-th (0-based) occurrence of *key*.
-
-    Uses ruamel.yaml round-trip parsing for accurate line tracking.
-    """
-    return _yaml_nth_key_line_util(raw, key, n)
+    return CodeRabbitContentBlock._find_nth_key_line(raw, key, n)
 
 
 def _find_nth_list_item_key_line(raw: str, key: str, n: int, after_line: int = 0) -> Optional[int]:
-    """Find the *n*-th (0-based) YAML list-item key (``- key:``) after *after_line*.
-
-    Uses ruamel.yaml round-trip parsing for accurate line tracking.
-    In YAML sequences the first key of each item is prefixed with ``- ``,
-    e.g. ``  - name: value``.
-    """
-    return _yaml_nth_list_item_key_line_util(raw, key, n, after_line=after_line)
+    return CodeRabbitContentBlock._find_nth_list_item_key_line(raw, key, n, after_line)
 
 
 def _extract_instructions(data: Any, raw: str) -> List[Tuple[str, str, Optional[int]]]:
-    """Extract all instruction text fields from a parsed CodeRabbit config.
+    return CodeRabbitContentBlock._extract_instructions(data, raw)
 
-    Returns a list of ``(location_label, text, line_number)`` tuples.
-    """
-    results: List[Tuple[str, str, Optional[int]]] = []
-    if not isinstance(data, dict):
-        return results
 
-    # reviews.instructions
-    reviews = data.get("reviews")
-    if isinstance(reviews, dict):
-        instr = reviews.get("instructions")
-        if isinstance(instr, str) and instr.strip():
-            # Find the "instructions" key that appears after "reviews"
-            reviews_line = _find_yaml_key_line(raw, "reviews")
-            line = None
-            if reviews_line is not None:
-                line = _find_yaml_key_line_after(raw, "instructions", reviews_line)
-            if line is None:
-                line = _find_yaml_key_line(raw, "instructions")
-            results.append(("reviews.instructions", instr, line))
-
-        # reviews.path_instructions[].instructions
-        path_instructions = reviews.get("path_instructions")
-        if isinstance(path_instructions, list):
-            for idx, entry in enumerate(path_instructions):
-                if not isinstance(entry, dict):
-                    continue
-                pi = entry.get("instructions")
-                if isinstance(pi, str) and pi.strip():
-                    path_val = entry.get("path", f"[{idx}]")
-                    line = _find_nth_key_line(raw, "instructions", len(results))
-                    results.append(
-                        (f"reviews.path_instructions[{path_val}].instructions", pi, line)
-                    )
-
-        # reviews.tools.<tool>.instructions
-        tools = reviews.get("tools")
-        if isinstance(tools, dict):
-            for tool_name, tool_cfg in tools.items():
-                if not isinstance(tool_cfg, dict):
-                    continue
-                ti = tool_cfg.get("instructions")
-                if isinstance(ti, str) and ti.strip():
-                    tool_line = _find_yaml_key_line(raw, tool_name)
-                    line = None
-                    if tool_line is not None:
-                        line = _find_yaml_key_line_after(raw, "instructions", tool_line)
-                    results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
-
-        # reviews.pre_merge_checks.custom_checks[].instructions
-        pre_merge = reviews.get("pre_merge_checks")
-        if isinstance(pre_merge, dict):
-            custom_checks = pre_merge.get("custom_checks")
-            if isinstance(custom_checks, list):
-                # Find the "custom_checks" key so we only look within it.
-                custom_checks_line = _find_yaml_key_line(raw, "custom_checks") or 0
-                for idx, check in enumerate(custom_checks):
-                    if not isinstance(check, dict):
-                        continue
-                    ci = check.get("instructions")
-                    if isinstance(ci, str) and ci.strip():
-                        check_name = check.get("name", f"[{idx}]")
-                        # Find the nth list-item "- name:" after custom_checks,
-                        # then the "instructions" key following it.
-                        name_line = _find_nth_list_item_key_line(
-                            raw, "name", idx, after_line=custom_checks_line
-                        )
-                        line = None
-                        if name_line is not None:
-                            line = _find_yaml_key_line_after(raw, "instructions", name_line)
-                        results.append(
-                            (
-                                f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
-                                ci,
-                                line,
-                            )
-                        )
-
-    # chat.instructions
-    chat = data.get("chat")
-    if isinstance(chat, dict):
-        ci = chat.get("instructions")
-        if isinstance(ci, str) and ci.strip():
-            chat_line = _find_yaml_key_line(raw, "chat")
-            line = None
-            if chat_line is not None:
-                line = _find_yaml_key_line_after(raw, "instructions", chat_line)
-            if line is None:
-                line = _find_yaml_key_line(raw, "instructions")
-            results.append(("chat.instructions", ci, line))
-
-    return results
+# ---------------------------------------------------------------------------
+# Detectors — all line numbers are body-relative (1-based)
+# ---------------------------------------------------------------------------
 
 
 class WeakLanguageDetector:
@@ -628,19 +545,13 @@ class WeakLanguageDetector:
         for line_num, line in enumerate(content.splitlines(), 1):
             for pattern, fix in _HEDGING:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(
-                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "hedging", fix)
-                    )
+                    results.append(WeakLanguageMatch(line_num, m.group(), "hedging", fix))
             for pattern, fix in _VAGUENESS:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(
-                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "vagueness", fix)
-                    )
+                    results.append(WeakLanguageMatch(line_num, m.group(), "vagueness", fix))
             for pattern, fix in _NON_ACTIONABLE:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
-                    results.append(
-                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "non-actionable", fix)
-                    )
+                    results.append(WeakLanguageMatch(line_num, m.group(), "non-actionable", fix))
         return results
 
 
@@ -654,7 +565,7 @@ class TautologicalDetector:
             for pattern, reason in _TAUTOLOGICAL_PHRASES:
                 m = re.search(pattern, line, re.IGNORECASE)
                 if m:
-                    results.append(TautologicalMatch(cf.file_line(line_num), m.group(), reason))
+                    results.append(TautologicalMatch(line_num, m.group(), reason))
         return results
 
 
@@ -680,7 +591,7 @@ class CriticalPositionAnalyzer:
                 score = 0.5
                 results.append(
                     PositionIssue(
-                        cf.file_line(line_num),
+                        line_num,
                         m.group(),
                         score,
                         "Move to the first 20% or last 20% of the file for better attention",
@@ -729,13 +640,12 @@ class RedundancyDetector:
         has_tsconfig = (root / "tsconfig.json").exists()
 
         for line_num, line in enumerate(content.splitlines(), 1):
-            adjusted = cf.file_line(line_num)
             if has_editorconfig:
                 for pattern, config_key in self._INDENT_PATTERNS:
                     if pattern.search(line):
                         results.append(
                             RedundancyMatch(
-                                adjusted,
+                                line_num,
                                 line.strip(),
                                 ".editorconfig",
                                 config_key,
@@ -755,7 +665,7 @@ class RedundancyDetector:
                     )
                     results.append(
                         RedundancyMatch(
-                            adjusted,
+                            line_num,
                             line.strip(),
                             config_file,
                             "style rule",
@@ -770,7 +680,7 @@ class RedundancyDetector:
                 ):
                     results.append(
                         RedundancyMatch(
-                            adjusted,
+                            line_num,
                             line.strip(),
                             "tsconfig.json",
                             "strict mode",

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -10,7 +10,7 @@ import fnmatch
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, Callable, List, Optional, Set, Tuple
 
 import yaml
 
@@ -180,6 +180,39 @@ class ContentFile:
     line_offset: int = 0
     body: Optional[str] = None
 
+    def file_line(self, body_line: int) -> int:
+        """Translate a 1-based body line number to a 1-based file line number."""
+        return body_line + self.line_offset
+
+
+def _gather_coderabbit_files(
+    context: RepositoryContext,
+    seen: Set[Path],
+    _is_excluded: Callable,
+) -> List[ContentFile]:
+    """Yield one ContentFile per instruction block in .coderabbit.yaml."""
+    cr_path = context.root_path / ".coderabbit.yaml"
+    cr_resolved = cr_path.resolve()
+    if cr_resolved in seen or not cr_path.exists() or _is_excluded(cr_path):
+        return []
+    seen.add(cr_resolved)
+    cr_raw = read_text(cr_path)
+    if not cr_raw:
+        return []
+    try:
+        cr_data = yaml.safe_load(cr_raw)
+    except yaml.YAMLError:
+        return []
+    if not cr_data:
+        return []
+    results: List[ContentFile] = []
+    for _label, text, line in _extract_instructions(cr_data, cr_raw):
+        offset = (line - 1) if line else 0
+        results.append(
+            ContentFile(path=cr_path, category="coderabbit", line_offset=offset, body=text)
+        )
+    return results
+
 
 def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
     """Gather all contextual content files across all formats.
@@ -285,27 +318,7 @@ def gather_all_content_files(context: RepositoryContext) -> List[ContentFile]:
                 _add(rule_file, "rule")
 
     # .coderabbit.yaml: yield one ContentFile per instruction block
-    cr_path = context.root_path / ".coderabbit.yaml"
-    cr_resolved = cr_path.resolve()
-    if cr_resolved not in seen and cr_path.exists() and not _is_excluded(cr_path):
-        seen.add(cr_resolved)
-        cr_raw = read_text(cr_path)
-        if cr_raw:
-            try:
-                cr_data = yaml.safe_load(cr_raw)
-            except yaml.YAMLError:
-                cr_data = None
-            if cr_data:
-                for _label, text, line in _extract_instructions(cr_data, cr_raw):
-                    offset = (line - 1) if line else 0
-                    files.append(
-                        ContentFile(
-                            path=cr_path,
-                            category="coderabbit",
-                            line_offset=offset,
-                            body=text,
-                        )
-                    )
+    files.extend(_gather_coderabbit_files(context, seen, _is_excluded))
 
     # --- APM source directories ---
     if context.has_apm:
@@ -542,18 +555,18 @@ class WeakLanguageDetector:
             for pattern, fix in _HEDGING:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
                     results.append(
-                        WeakLanguageMatch(line_num + cf.line_offset, m.group(), "hedging", fix)
+                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "hedging", fix)
                     )
             for pattern, fix in _VAGUENESS:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
                     results.append(
-                        WeakLanguageMatch(line_num + cf.line_offset, m.group(), "vagueness", fix)
+                        WeakLanguageMatch(cf.file_line(line_num), m.group(), "vagueness", fix)
                     )
             for pattern, fix in _NON_ACTIONABLE:
                 for m in re.finditer(pattern, line, re.IGNORECASE):
                     results.append(
                         WeakLanguageMatch(
-                            line_num + cf.line_offset, m.group(), "non-actionable", fix
+                            cf.file_line(line_num), m.group(), "non-actionable", fix
                         )
                     )
         return results
@@ -569,7 +582,7 @@ class TautologicalDetector:
             for pattern, reason in _TAUTOLOGICAL_PHRASES:
                 m = re.search(pattern, line, re.IGNORECASE)
                 if m:
-                    results.append(TautologicalMatch(line_num + cf.line_offset, m.group(), reason))
+                    results.append(TautologicalMatch(cf.file_line(line_num), m.group(), reason))
         return results
 
 
@@ -595,7 +608,7 @@ class CriticalPositionAnalyzer:
                 score = 0.5
                 results.append(
                     PositionIssue(
-                        line_num + cf.line_offset,
+                        cf.file_line(line_num),
                         m.group(),
                         score,
                         "Move to the first 20% or last 20% of the file for better attention",
@@ -644,7 +657,7 @@ class RedundancyDetector:
         has_tsconfig = (root / "tsconfig.json").exists()
 
         for line_num, line in enumerate(content.splitlines(), 1):
-            adjusted = line_num + cf.line_offset
+            adjusted = cf.file_line(line_num)
             if has_editorconfig:
                 for pattern, config_key in self._INDENT_PATTERNS:
                     if pattern.search(line):

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -200,6 +200,10 @@ class ContentBlock(LintTarget):
     @abstractmethod
     def write_body(self, new_body: str) -> None: ...
 
+    def estimate_tokens(self) -> int:
+        body = self.read_body()
+        return len(body) // 4 if body else 0
+
     def tree_label(self) -> str:
         return f"{self.path.name} ({self.category})"
 

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -15,7 +15,7 @@ from skillsaw.context import RepositoryContext
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_files,
-    _get_body,
+    _get_body_from_cf,
     WeakLanguageDetector,
     TautologicalDetector,
     CriticalPositionAnalyzer,
@@ -64,7 +64,7 @@ class ContentWeakLanguageRule(Rule):
         violations = []
         detector = WeakLanguageDetector()
         for cf in gather_all_content_files(context):
-            for match in detector.analyze(cf.path):
+            for match in detector.analyze(cf):
                 violations.append(
                     self.violation(
                         f"Weak language ({match.category}): '{match.phrase}' — {match.suggested_fix}",
@@ -111,7 +111,7 @@ class ContentTautologicalRule(Rule):
         violations = []
         detector = TautologicalDetector()
         for cf in gather_all_content_files(context):
-            for match in detector.analyze(cf.path):
+            for match in detector.analyze(cf):
                 violations.append(
                     self.violation(
                         f"Tautological: '{match.phrase}' — {match.reason}",
@@ -172,7 +172,7 @@ class ContentCriticalPositionRule(Rule):
         for cf in gather_all_content_files(context):
             if cf.category == "coderabbit":
                 continue
-            for issue in analyzer.analyze(cf.path):
+            for issue in analyzer.analyze(cf):
                 violations.append(
                     self.violation(
                         f"'{issue.keyword}' instruction at line {issue.line} is in the attention dead zone (20-80%) — {issue.suggested_position}",
@@ -218,7 +218,7 @@ class ContentRedundantWithToolingRule(Rule):
         violations = []
         detector = RedundancyDetector()
         for cf in gather_all_content_files(context):
-            for match in detector.analyze(cf.path, context.root_path):
+            for match in detector.analyze(cf, context.root_path):
                 violations.append(
                     self.violation(
                         f"Redundant with {match.existing_config_file} ({match.config_value}): '{match.instruction}'",
@@ -268,7 +268,7 @@ class ContentInstructionBudgetRule(Rule):
         analyzer = InstructionBudgetAnalyzer()
         violations = []
         for cf in content_files:
-            budget = analyzer.analyze_file(cf.path)
+            budget = analyzer.analyze_file(cf)
             if budget.total_count >= 120:
                 sev = Severity.ERROR if budget.over_budget else Severity.WARNING
                 msg = (
@@ -370,7 +370,7 @@ class ContentNegativeOnlyRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body:
                 continue
             lines = body.splitlines()
@@ -385,7 +385,7 @@ class ContentNegativeOnlyRule(Rule):
                         self.violation(
                             f"Negative-only instruction without alternative: '{line.strip()[:80]}'",
                             file_path=cf.path,
-                            line=i + 1,
+                            line=i + 1 + cf.line_offset,
                         )
                     )
         return violations
@@ -442,7 +442,7 @@ class ContentSectionLengthRule(Rule):
         max_tokens = self.config.get("max-tokens", self._DEFAULT_MAX_TOKENS)
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body:
                 continue
             lines = body.splitlines()
@@ -475,7 +475,7 @@ class ContentSectionLengthRule(Rule):
                         self.violation(
                             f"Section '{heading}' is ~{token_count} tokens (max recommended: {max_tokens})",
                             file_path=cf.path,
-                            line=heading_line if heading_line > 0 else None,
+                            line=(heading_line + cf.line_offset) if heading_line > 0 else None,
                         )
                     )
         return violations
@@ -541,7 +541,7 @@ class ContentContradictionRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body:
                 continue
             body_lower = body.lower()
@@ -618,7 +618,7 @@ class ContentHookCandidateRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body:
                 continue
             for line_num, line in enumerate(body.splitlines(), 1):
@@ -628,7 +628,7 @@ class ContentHookCandidateRule(Rule):
                             self.violation(
                                 f"Hook candidate: '{line.strip()[:80]}' — consider automating as a {hook_type}",
                                 file_path=cf.path,
-                                line=line_num,
+                                line=line_num + cf.line_offset,
                             )
                         )
                         break
@@ -682,7 +682,7 @@ class ContentActionabilityScoreRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body:
                 continue
             lines = [l for l in body.splitlines() if l.strip()]
@@ -744,7 +744,7 @@ class ContentCognitiveChunksRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         for cf in gather_all_content_files(context):
-            body = _get_body(cf.path)
+            body = _get_body_from_cf(cf)
             if not body or len(body.strip()) < 100:
                 continue
             lines = body.splitlines()
@@ -850,7 +850,12 @@ class ContentEmbeddedSecretsRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
+        seen_paths: Set[Path] = set()
         for cf in gather_all_content_files(context):
+            resolved = cf.path.resolve()
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
             content = read_text(cf.path)
             if not content:
                 continue
@@ -945,7 +950,12 @@ class ContentBannedReferencesRule(Rule):
         if not patterns:
             return []
         violations = []
+        seen_paths: Set[Path] = set()
         for cf in gather_all_content_files(context):
+            resolved = cf.path.resolve()
+            if resolved in seen_paths:
+                continue
+            seen_paths.add(resolved)
             content = read_text(cf.path)
             if not content:
                 continue
@@ -1037,7 +1047,7 @@ class ContentInconsistentTerminologyRule(Rule):
             term_usage: Dict[str, int] = defaultdict(int)
             files_by_term: Dict[str, List[Path]] = defaultdict(list)
             for cf in content_files:
-                body = _get_body(cf.path)
+                body = _get_body_from_cf(cf)
                 if not body:
                     continue
                 for pattern in patterns:

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -14,8 +14,8 @@ from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
-    gather_all_content_files,
-    _get_body_from_cf,
+    gather_all_content_blocks,
+    ContentBlock,
     WeakLanguageDetector,
     TautologicalDetector,
     CriticalPositionAnalyzer,
@@ -63,12 +63,12 @@ class ContentWeakLanguageRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         detector = WeakLanguageDetector()
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             for match in detector.analyze(cf):
                 violations.append(
                     self.violation(
                         f"Weak language ({match.category}): '{match.phrase}' — {match.suggested_fix}",
-                        file_path=cf.path,
+                        block=cf,
                         line=match.line,
                     )
                 )
@@ -110,12 +110,12 @@ class ContentTautologicalRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         detector = TautologicalDetector()
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             for match in detector.analyze(cf):
                 violations.append(
                     self.violation(
                         f"Tautological: '{match.phrase}' — {match.reason}",
-                        file_path=cf.path,
+                        block=cf,
                         line=match.line,
                     )
                 )
@@ -169,12 +169,12 @@ class ContentCriticalPositionRule(Rule):
         violations = []
         min_lines = self.config.get("min-lines", self._DEFAULT_MIN_LINES)
         analyzer = CriticalPositionAnalyzer(min_lines=min_lines)
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             for issue in analyzer.analyze(cf):
                 violations.append(
                     self.violation(
                         f"'{issue.keyword}' instruction at line {issue.line} is in the attention dead zone (20-80%) — {issue.suggested_position}",
-                        file_path=cf.path,
+                        block=cf,
                         line=issue.line,
                     )
                 )
@@ -215,12 +215,12 @@ class ContentRedundantWithToolingRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         detector = RedundancyDetector()
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             for match in detector.analyze(cf, context.root_path):
                 violations.append(
                     self.violation(
                         f"Redundant with {match.existing_config_file} ({match.config_value}): '{match.instruction}'",
-                        file_path=cf.path,
+                        block=cf,
                         line=match.line,
                     )
                 )
@@ -260,7 +260,7 @@ class ContentInstructionBudgetRule(Rule):
         )
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        content_files = gather_all_content_files(context)
+        content_files = gather_all_content_blocks(context)
         if not content_files:
             return []
         analyzer = InstructionBudgetAnalyzer()
@@ -273,13 +273,13 @@ class ContentInstructionBudgetRule(Rule):
                     f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions "
                     f"({budget.budget_remaining} remaining)"
                 )
-                violations.append(self.violation(msg, file_path=cf.path, severity=sev))
+                violations.append(self.violation(msg, block=cf, severity=sev))
             elif budget.total_count >= 80:
                 msg = (
                     f"Instruction budget: {budget.total_count}/{analyzer.BUDGET} instructions "
                     f"— approaching limit"
                 )
-                violations.append(self.violation(msg, file_path=cf.path, severity=Severity.INFO))
+                violations.append(self.violation(msg, block=cf, severity=Severity.INFO))
         return violations
 
 
@@ -367,8 +367,8 @@ class ContentNegativeOnlyRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body:
                 continue
             lines = body.splitlines()
@@ -382,7 +382,7 @@ class ContentNegativeOnlyRule(Rule):
                     violations.append(
                         self.violation(
                             f"Negative-only instruction without alternative: '{line.strip()[:80]}'",
-                            file_path=cf.path,
+                            block=cf,
                             line=cf.file_line(i + 1),
                         )
                     )
@@ -439,8 +439,8 @@ class ContentSectionLengthRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         max_tokens = self.config.get("max-tokens", self._DEFAULT_MAX_TOKENS)
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body:
                 continue
             lines = body.splitlines()
@@ -472,7 +472,7 @@ class ContentSectionLengthRule(Rule):
                     violations.append(
                         self.violation(
                             f"Section '{heading}' is ~{token_count} tokens (max recommended: {max_tokens})",
-                            file_path=cf.path,
+                            block=cf,
                             line=cf.file_line(heading_line) if heading_line > 0 else None,
                         )
                     )
@@ -538,8 +538,8 @@ class ContentContradictionRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body:
                 continue
             body_lower = body.lower()
@@ -550,7 +550,7 @@ class ContentContradictionRule(Rule):
                     violations.append(
                         self.violation(
                             f"Possible contradiction: {desc}",
-                            file_path=cf.path,
+                            block=cf,
                         )
                     )
         return violations
@@ -615,8 +615,8 @@ class ContentHookCandidateRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body:
                 continue
             for line_num, line in enumerate(body.splitlines(), 1):
@@ -625,7 +625,7 @@ class ContentHookCandidateRule(Rule):
                         violations.append(
                             self.violation(
                                 f"Hook candidate: '{line.strip()[:80]}' — consider automating as a {hook_type}",
-                                file_path=cf.path,
+                                block=cf,
                                 line=cf.file_line(line_num),
                             )
                         )
@@ -679,8 +679,8 @@ class ContentActionabilityScoreRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body:
                 continue
             lines = [l for l in body.splitlines() if l.strip()]
@@ -701,7 +701,7 @@ class ContentActionabilityScoreRule(Rule):
                 violations.append(
                     self.violation(
                         f"Low actionability score: {score}/100 (verbs: {verb_ratio:.0%}, commands: {cmd_ratio:.0%}, paths: {path_ratio:.0%})",
-                        file_path=cf.path,
+                        block=cf,
                     )
                 )
         return violations
@@ -741,8 +741,8 @@ class ContentCognitiveChunksRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        for cf in gather_all_content_files(context):
-            body = _get_body_from_cf(cf)
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body()
             if not body or len(body.strip()) < 100:
                 continue
             lines = body.splitlines()
@@ -752,7 +752,7 @@ class ContentCognitiveChunksRule(Rule):
                 violations.append(
                     self.violation(
                         "No headings in instruction file — add section headings for cognitive chunking",
-                        file_path=cf.path,
+                        block=cf,
                     )
                 )
                 continue
@@ -761,7 +761,7 @@ class ContentCognitiveChunksRule(Rule):
                 violations.append(
                     self.violation(
                         "All content under a single heading — break into task-organized sections",
-                        file_path=cf.path,
+                        block=cf,
                     )
                 )
         return violations
@@ -849,7 +849,7 @@ class ContentEmbeddedSecretsRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         seen_paths: Set[Path] = set()
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             resolved = cf.path.resolve()
             if resolved in seen_paths:
                 continue
@@ -863,7 +863,7 @@ class ContentEmbeddedSecretsRule(Rule):
                         violations.append(
                             self.violation(
                                 f"Potential secret detected: {desc}",
-                                file_path=cf.path,
+                                block=cf,
                                 line=line_num,
                             )
                         )
@@ -949,7 +949,7 @@ class ContentBannedReferencesRule(Rule):
             return []
         violations = []
         seen_paths: Set[Path] = set()
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             resolved = cf.path.resolve()
             if resolved in seen_paths:
                 continue
@@ -963,7 +963,7 @@ class ContentBannedReferencesRule(Rule):
                         violations.append(
                             self.violation(
                                 f"Banned reference: {msg}",
-                                file_path=cf.path,
+                                block=cf,
                                 line=line_num,
                             )
                         )
@@ -1036,7 +1036,7 @@ class ContentInconsistentTerminologyRule(Rule):
         )
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        content_files = gather_all_content_files(context)
+        content_files = gather_all_content_blocks(context)
         if len(content_files) < self.MIN_FILES:
             return []
 
@@ -1045,7 +1045,7 @@ class ContentInconsistentTerminologyRule(Rule):
             term_usage: Dict[str, int] = defaultdict(int)
             files_by_term: Dict[str, List[Path]] = defaultdict(list)
             for cf in content_files:
-                body = _get_body_from_cf(cf)
+                body = cf.read_body()
                 if not body:
                     continue
                 for pattern in patterns:

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -170,8 +170,6 @@ class ContentCriticalPositionRule(Rule):
         min_lines = self.config.get("min-lines", self._DEFAULT_MIN_LINES)
         analyzer = CriticalPositionAnalyzer(min_lines=min_lines)
         for cf in gather_all_content_files(context):
-            if cf.category == "coderabbit":
-                continue
             for issue in analyzer.analyze(cf):
                 violations.append(
                     self.violation(

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -385,7 +385,7 @@ class ContentNegativeOnlyRule(Rule):
                         self.violation(
                             f"Negative-only instruction without alternative: '{line.strip()[:80]}'",
                             file_path=cf.path,
-                            line=i + 1 + cf.line_offset,
+                            line=cf.file_line(i + 1),
                         )
                     )
         return violations
@@ -475,7 +475,7 @@ class ContentSectionLengthRule(Rule):
                         self.violation(
                             f"Section '{heading}' is ~{token_count} tokens (max recommended: {max_tokens})",
                             file_path=cf.path,
-                            line=(heading_line + cf.line_offset) if heading_line > 0 else None,
+                            line=cf.file_line(heading_line) if heading_line > 0 else None,
                         )
                     )
         return violations
@@ -628,7 +628,7 @@ class ContentHookCandidateRule(Rule):
                             self.violation(
                                 f"Hook candidate: '{line.strip()[:80]}' — consider automating as a {hook_type}",
                                 file_path=cf.path,
-                                line=line_num + cf.line_offset,
+                                line=cf.file_line(line_num),
                             )
                         )
                         break

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -383,7 +383,7 @@ class ContentNegativeOnlyRule(Rule):
                         self.violation(
                             f"Negative-only instruction without alternative: '{line.strip()[:80]}'",
                             block=cf,
-                            line=cf.file_line(i + 1),
+                            line=i + 1,
                         )
                     )
         return violations
@@ -473,7 +473,7 @@ class ContentSectionLengthRule(Rule):
                         self.violation(
                             f"Section '{heading}' is ~{token_count} tokens (max recommended: {max_tokens})",
                             block=cf,
-                            line=cf.file_line(heading_line) if heading_line > 0 else None,
+                            line=heading_line if heading_line > 0 else None,
                         )
                     )
         return violations
@@ -626,7 +626,7 @@ class ContentHookCandidateRule(Rule):
                             self.violation(
                                 f"Hook candidate: '{line.strip()[:80]}' — consider automating as a {hook_type}",
                                 block=cf,
-                                line=cf.file_line(line_num),
+                                line=line_num,
                             )
                         )
                         break

--- a/src/skillsaw/rules/builtin/context_budget.py
+++ b/src/skillsaw/rules/builtin/context_budget.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, ALL_INSTRUCTION_FORMATS
 from skillsaw.rules.builtin.utils import read_text
-from skillsaw.rules.builtin.content_analysis import gather_all_content_files
+from skillsaw.rules.builtin.content_analysis import gather_all_content_blocks
 
 # Anthropic recommends keeping instruction files under ~5k tokens to avoid
 # attention degradation.  These defaults use 6k warn / 12k error for primary
@@ -116,7 +116,7 @@ class ContextBudgetRule(Rule):
         violations: List[RuleViolation] = []
         limits = self._get_limits()
 
-        for cf in gather_all_content_files(context):
+        for cf in gather_all_content_blocks(context):
             warn_limit, error_limit = limits.get(cf.category, (None, None))
             if warn_limit is not None or error_limit is not None:
                 self._check_file(cf.path, cf.category, warn_limit, error_limit, violations)

--- a/src/skillsaw/rules/builtin/context_budget.py
+++ b/src/skillsaw/rules/builtin/context_budget.py
@@ -5,7 +5,7 @@ Rule for warning when instruction/config files exceed recommended token limits.
 from typing import Any, Dict, List, Optional, Tuple
 
 from skillsaw.rule import Rule, RuleViolation, Severity
-from skillsaw.context import RepositoryContext, ALL_INSTRUCTION_FORMATS
+from skillsaw.context import RepositoryContext
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_blocks,
@@ -57,7 +57,7 @@ def _estimate_tokens(text: str) -> int:
 class ContextBudgetRule(Rule):
     """Warn or error when files exceed recommended token limits"""
 
-    formats = ALL_INSTRUCTION_FORMATS
+    formats = None
     since = "0.7.0"
 
     config_schema = {

--- a/src/skillsaw/rules/builtin/context_budget.py
+++ b/src/skillsaw/rules/builtin/context_budget.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, ALL_INSTRUCTION_FORMATS
 from skillsaw.rules.builtin.utils import read_text
-from skillsaw.rules.builtin.content_analysis import gather_all_content_blocks
+from skillsaw.rules.builtin.content_analysis import (
+    gather_all_content_blocks,
+    SkillBlock,
+    CommandBlock,
+)
 
 # Anthropic recommends keeping instruction files under ~5k tokens to avoid
 # attention degradation.  These defaults use 6k warn / 12k error for primary
@@ -23,6 +27,8 @@ DEFAULT_LIMITS: Dict[str, Dict[str, int]] = {
     "command": {"warn": 2000, "error": 4000},
     "agent": {"warn": 2000, "error": 4000},
     "rule": {"warn": 2000, "error": 4000},
+    "skill-description": {"warn": 200, "error": 500},
+    "command-description": {"warn": 200, "error": 500},
 }
 
 
@@ -112,6 +118,46 @@ class ContextBudgetRule(Rule):
                 )
             )
 
+    def _check_descriptions(
+        self,
+        context: RepositoryContext,
+        limits: Dict[str, Tuple[Optional[int], Optional[int]]],
+        violations: List[RuleViolation],
+    ) -> None:
+        desc_categories = {
+            SkillBlock: "skill-description",
+            CommandBlock: "command-description",
+        }
+        for block_type, category in desc_categories.items():
+            warn_limit, error_limit = limits.get(category, (None, None))
+            if warn_limit is None and error_limit is None:
+                continue
+            for block in context.lint_tree.find(block_type):
+                fm = block.frontmatter
+                if not fm or not isinstance(fm.get("description"), str):
+                    continue
+                tokens = _estimate_tokens(fm["description"])
+                if error_limit is not None and tokens > error_limit:
+                    violations.append(
+                        self.violation(
+                            f"Frontmatter description is ~{tokens:,} tokens "
+                            f"(exceeds {category} limit of {error_limit:,})",
+                            file_path=block.path,
+                            line=block.key_line("description"),
+                            severity=Severity.ERROR,
+                        )
+                    )
+                elif warn_limit is not None and tokens > warn_limit:
+                    violations.append(
+                        self.violation(
+                            f"Frontmatter description is ~{tokens:,} tokens "
+                            f"(exceeds {category} limit of {warn_limit:,})",
+                            file_path=block.path,
+                            line=block.key_line("description"),
+                            severity=Severity.WARNING,
+                        )
+                    )
+
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations: List[RuleViolation] = []
         limits = self._get_limits()
@@ -120,5 +166,7 @@ class ContextBudgetRule(Rule):
             warn_limit, error_limit = limits.get(cf.category, (None, None))
             if warn_limit is not None or error_limit is not None:
                 self._check_file(cf.path, cf.category, warn_limit, error_limit, violations)
+
+        self._check_descriptions(context, limits, violations)
 
         return violations

--- a/src/skillsaw/rules/builtin/hooks.py
+++ b/src/skillsaw/rules/builtin/hooks.py
@@ -2,12 +2,11 @@
 Rules for validating hook configuration
 """
 
-from typing import List, Dict, Any
+from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
-from skillsaw.lint_target import PluginNode
-from skillsaw.rules.builtin.utils import read_json
+from skillsaw.rules.builtin.content_analysis import HooksBlock
 
 # Valid hook event types
 _VALID_HOOK_EVENTS = {
@@ -116,49 +115,39 @@ class HooksJsonValidRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_node in context.lint_tree.find(PluginNode):
-            plugin_path = plugin_node.path
-            hooks_dir = plugin_path / "hooks"
-            if not hooks_dir.exists():
-                continue
-
-            hooks_json = hooks_dir / "hooks.json"
-            if not hooks_json.exists():
-                continue
-
-            # Try to parse JSON
-            data, error = read_json(hooks_json)
-            if error:
-                violations.append(self.violation(f"Invalid JSON: {error}", file_path=hooks_json))
-                continue
-
-            # Validate structure
-            if not isinstance(data, dict):
+        for block in context.lint_tree.find(HooksBlock):
+            if block.parse_error:
                 violations.append(
-                    self.violation("hooks.json must be a JSON object", file_path=hooks_json)
+                    self.violation(f"Invalid JSON: {block.parse_error}", file_path=block.path)
+                )
+                continue
+
+            data = block.raw_data
+            if data is None or not isinstance(data, dict):
+                violations.append(
+                    self.violation("hooks.json must be a JSON object", file_path=block.path)
                 )
                 continue
 
             if "hooks" not in data:
                 violations.append(
-                    self.violation("hooks.json must contain a 'hooks' key", file_path=hooks_json)
+                    self.violation("hooks.json must contain a 'hooks' key", file_path=block.path)
                 )
                 continue
 
-            hooks = data["hooks"]
-            if not isinstance(hooks, dict):
+            raw_hooks = data["hooks"]
+            if not isinstance(raw_hooks, dict):
                 violations.append(
-                    self.violation("'hooks' must be a JSON object", file_path=hooks_json)
+                    self.violation("'hooks' must be a JSON object", file_path=block.path)
                 )
                 continue
 
-            # Validate event types
-            for event_type, hook_configs in hooks.items():
+            for event_type, hook_configs in raw_hooks.items():
                 if event_type not in _VALID_HOOK_EVENTS:
                     violations.append(
                         self.violation(
                             f"Unknown event type '{event_type}'. Valid types: {', '.join(sorted(_VALID_HOOK_EVENTS))}",
-                            file_path=hooks_json,
+                            file_path=block.path,
                         )
                     )
 
@@ -166,7 +155,7 @@ class HooksJsonValidRule(Rule):
                     violations.append(
                         self.violation(
                             f"Event '{event_type}' must have an array of hook configurations",
-                            file_path=hooks_json,
+                            file_path=block.path,
                         )
                     )
                     continue
@@ -176,17 +165,16 @@ class HooksJsonValidRule(Rule):
                         violations.append(
                             self.violation(
                                 f"Event '{event_type}[{idx}]' configuration must be an object",
-                                file_path=hooks_json,
+                                file_path=block.path,
                             )
                         )
                         continue
 
-                    # Validate hook configuration has required 'hooks' array
                     if "hooks" not in hook_config:
                         violations.append(
                             self.violation(
                                 f"Event '{event_type}[{idx}]' must have a 'hooks' array",
-                                file_path=hooks_json,
+                                file_path=block.path,
                             )
                         )
                         continue
@@ -196,18 +184,17 @@ class HooksJsonValidRule(Rule):
                         violations.append(
                             self.violation(
                                 f"Event '{event_type}[{idx}].hooks' must be an array",
-                                file_path=hooks_json,
+                                file_path=block.path,
                             )
                         )
                         continue
 
-                    # Validate each hook has a type
                     for hook_idx, hook in enumerate(hook_list):
                         if not isinstance(hook, dict):
                             violations.append(
                                 self.violation(
                                     f"Event '{event_type}[{idx}].hooks[{hook_idx}]' must be an object",
-                                    file_path=hooks_json,
+                                    file_path=block.path,
                                 )
                             )
                             continue
@@ -216,7 +203,7 @@ class HooksJsonValidRule(Rule):
                             violations.append(
                                 self.violation(
                                     f"Event '{event_type}[{idx}].hooks[{hook_idx}]' must have a 'type' field",
-                                    file_path=hooks_json,
+                                    file_path=block.path,
                                 )
                             )
                             continue
@@ -224,25 +211,23 @@ class HooksJsonValidRule(Rule):
                         hook_type = hook["type"]
                         hook_path = f"{event_type}[{idx}].hooks[{hook_idx}]"
 
-                        # Validate type value
                         if hook_type not in _VALID_HOOK_TYPES:
                             violations.append(
                                 self.violation(
                                     f"Event '{hook_path}' has invalid type '{hook_type}'. "
                                     f"Valid types: {', '.join(sorted(_VALID_HOOK_TYPES))}",
-                                    file_path=hooks_json,
+                                    file_path=block.path,
                                 )
                             )
                             continue
 
-                        # Validate type-specific required fields
                         for field, expected_type in _TYPE_REQUIRED_FIELDS[hook_type].items():
                             if field not in hook:
                                 violations.append(
                                     self.violation(
                                         f"Event '{hook_path}' of type '{hook_type}' "
                                         f"requires a '{field}' field",
-                                        file_path=hooks_json,
+                                        file_path=block.path,
                                     )
                                 )
                             elif not _check_field_type(hook[field], expected_type):
@@ -251,11 +236,10 @@ class HooksJsonValidRule(Rule):
                                     self.violation(
                                         f"Event '{hook_path}' field '{field}' "
                                         f"must be a {type_name}",
-                                        file_path=hooks_json,
+                                        file_path=block.path,
                                     )
                                 )
 
-                        # Validate type-specific field restrictions (WARNING)
                         for field in hook:
                             if field in _TYPE_SPECIFIC_FIELDS:
                                 valid_types = _TYPE_SPECIFIC_FIELDS[field]
@@ -265,12 +249,11 @@ class HooksJsonValidRule(Rule):
                                             f"Event '{hook_path}' field '{field}' "
                                             f"is only valid on types: "
                                             f"{', '.join(sorted(valid_types))}",
-                                            file_path=hooks_json,
+                                            file_path=block.path,
                                             severity=Severity.WARNING,
                                         )
                                     )
 
-                        # Validate common optional field types
                         for field, expected_type in _OPTIONAL_FIELD_TYPES.items():
                             if field not in hook:
                                 continue
@@ -280,7 +263,7 @@ class HooksJsonValidRule(Rule):
                                     self.violation(
                                         f"Event '{hook_path}' field '{field}' "
                                         f"must be a {type_name}",
-                                        file_path=hooks_json,
+                                        file_path=block.path,
                                     )
                                 )
 

--- a/src/skillsaw/rules/builtin/hooks.py
+++ b/src/skillsaw/rules/builtin/hooks.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import PluginNode
 from skillsaw.rules.builtin.utils import read_json
 
 # Valid hook event types
@@ -115,7 +116,8 @@ class HooksJsonValidRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             hooks_dir = plugin_path / "hooks"
             if not hooks_dir.exists():
                 continue

--- a/src/skillsaw/rules/builtin/instruction_files.py
+++ b/src/skillsaw/rules/builtin/instruction_files.py
@@ -8,11 +8,14 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, ALL_INSTRUCTION_FORMATS
+from skillsaw.rules.builtin.content_analysis import (
+    ClaudeMdBlock,
+    GeminiMdBlock,
+    InstructionBlock,
+)
 from skillsaw.rules.builtin.utils import read_text
 
 INSTRUCTION_FILES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md")
-
-IMPORT_SUPPORTING_FILES = ("CLAUDE.md", "GEMINI.md")
 
 _IMPORT_RE = re.compile(r"^\s*@(\S+)")
 
@@ -36,23 +39,24 @@ class InstructionFileValidRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for filename in INSTRUCTION_FILES:
-            file_path = context.root_path / filename
-            if not file_path.exists():
+        for block in context.lint_tree.find(InstructionBlock):
+            if block.path.name not in INSTRUCTION_FILES:
                 continue
 
-            content = read_text(file_path)
+            content = read_text(block.path)
             if content is None:
                 violations.append(
                     self.violation(
-                        f"Failed to read {filename} (invalid encoding or I/O error)",
-                        file_path=file_path,
+                        f"Failed to read {block.path.name} (invalid encoding or I/O error)",
+                        file_path=block.path,
                     )
                 )
                 continue
 
             if not content.strip():
-                violations.append(self.violation(f"{filename} is empty", file_path=file_path))
+                violations.append(
+                    self.violation(f"{block.path.name} is empty", file_path=block.path)
+                )
 
         return violations
 
@@ -76,11 +80,11 @@ class InstructionImportsValidRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for filename in IMPORT_SUPPORTING_FILES:
-            file_path = context.root_path / filename
-            if not file_path.exists():
-                continue
-
+        import_blocks = context.lint_tree.find(ClaudeMdBlock) + context.lint_tree.find(
+            GeminiMdBlock
+        )
+        for block in import_blocks:
+            file_path = block.path
             content = read_text(file_path)
             if content is None:
                 continue

--- a/src/skillsaw/rules/builtin/marketplace.py
+++ b/src/skillsaw/rules/builtin/marketplace.py
@@ -8,7 +8,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext, RepositoryType
-from skillsaw.lint_target import PluginNode
+from skillsaw.lint_target import MarketplaceConfigNode, PluginNode
 from skillsaw.rules.builtin.utils import read_json
 
 
@@ -35,13 +35,17 @@ class MarketplaceJsonValidRule(Rule):
         if RepositoryType.MARKETPLACE not in context.repo_types:
             return violations
 
-        marketplace_file = context.root_path / ".claude-plugin" / "marketplace.json"
-
-        if not marketplace_file.exists():
+        config_nodes = context.lint_tree.find(MarketplaceConfigNode)
+        if not config_nodes:
             violations.append(
-                self.violation("Marketplace file not found", file_path=marketplace_file)
+                self.violation(
+                    "Marketplace file not found",
+                    file_path=context.root_path / ".claude-plugin" / "marketplace.json",
+                )
             )
             return violations
+
+        marketplace_file = config_nodes[0].path
 
         # Try to parse
         marketplace, error = read_json(marketplace_file)
@@ -132,7 +136,11 @@ class MarketplaceRegistrationRule(Rule):
         if not context.has_marketplace():
             return violations
 
-        marketplace_file = context.root_path / ".claude-plugin" / "marketplace.json"
+        config_nodes = context.lint_tree.find(MarketplaceConfigNode)
+        if not config_nodes:
+            return violations
+
+        marketplace_file = config_nodes[0].path
 
         for plugin_node in context.lint_tree.find(PluginNode):
             plugin_name = context.get_plugin_name(plugin_node.path)
@@ -154,9 +162,11 @@ class MarketplaceRegistrationRule(Rule):
         if not violations:
             return results
 
-        marketplace_file = context.root_path / ".claude-plugin" / "marketplace.json"
-        if not marketplace_file.exists():
+        config_nodes = context.lint_tree.find(MarketplaceConfigNode)
+        if not config_nodes:
             return results
+
+        marketplace_file = config_nodes[0].path
 
         original = marketplace_file.read_text(encoding="utf-8")
         try:

--- a/src/skillsaw/rules/builtin/marketplace.py
+++ b/src/skillsaw/rules/builtin/marketplace.py
@@ -8,6 +8,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import PluginNode
 from skillsaw.rules.builtin.utils import read_json
 
 
@@ -133,8 +134,8 @@ class MarketplaceRegistrationRule(Rule):
 
         marketplace_file = context.root_path / ".claude-plugin" / "marketplace.json"
 
-        for plugin_path in context.plugins:
-            plugin_name = context.get_plugin_name(plugin_path)
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_name = context.get_plugin_name(plugin_node.path)
 
             if not context.is_registered_in_marketplace(plugin_name):
                 violations.append(
@@ -177,10 +178,10 @@ class MarketplaceRegistrationRule(Rule):
             if any(p.get("name") == plugin_name for p in data["plugins"]):
                 continue
             rel_source = plugin_name
-            for plugin_path in context.plugins:
-                if context.get_plugin_name(plugin_path) == plugin_name:
+            for plugin_node in context.lint_tree.find(PluginNode):
+                if context.get_plugin_name(plugin_node.path) == plugin_name:
                     try:
-                        rel_source = str(plugin_path.relative_to(context.root_path))
+                        rel_source = str(plugin_node.path.relative_to(context.root_path))
                     except ValueError:
                         pass
                     break

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.lint_target import PluginNode
+from skillsaw.rules.builtin.content_analysis import McpBlock
 from skillsaw.rules.builtin.utils import read_json
 
 
@@ -31,44 +32,30 @@ class McpValidJsonRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_node in context.lint_tree.find(PluginNode):
-            plugin_path = plugin_node.path
-            # Check for .mcp.json at plugin root
-            mcp_json = plugin_path / ".mcp.json"
-            if mcp_json.exists():
-                violations.extend(self._validate_mcp_file(mcp_json))
+        for block in context.lint_tree.find(McpBlock):
+            if block.parse_error:
+                violations.append(
+                    self.violation(f"Invalid JSON: {block.parse_error}", file_path=block.path)
+                )
+                continue
 
-            # Check for mcpServers in plugin.json
-            plugin_json_path = plugin_path / ".claude-plugin" / "plugin.json"
+            data = block.raw_data
+            if data is None:
+                violations.append(
+                    self.violation("MCP configuration must be a JSON object", file_path=block.path)
+                )
+                continue
+
+            if "mcpServers" in data:
+                violations.extend(self._validate_mcp_structure(data, block.path))
+            else:
+                violations.extend(self._validate_mcp_structure({"mcpServers": data}, block.path))
+
+        # Also check mcpServers embedded in plugin.json (not a separate file node)
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_json_path = plugin_node.path / ".claude-plugin" / "plugin.json"
             if plugin_json_path.exists():
                 violations.extend(self._validate_plugin_json_mcp(plugin_json_path))
-
-        return violations
-
-    def _validate_mcp_file(self, mcp_json: Path) -> List[RuleViolation]:
-        """Validate standalone .mcp.json file.
-
-        Accepts two formats:
-        - Wrapped: {"mcpServers": {"name": {...}}}
-        - Flat: {"name": {"type": "...", ...}}  (server names as top-level keys)
-        """
-        violations = []
-
-        data, error = read_json(mcp_json)
-        if error:
-            violations.append(self.violation(f"Invalid JSON: {error}", file_path=mcp_json))
-            return violations
-
-        if not isinstance(data, dict):
-            violations.append(
-                self.violation("MCP configuration must be a JSON object", file_path=mcp_json)
-            )
-            return violations
-
-        if "mcpServers" in data:
-            violations.extend(self._validate_mcp_structure(data, mcp_json))
-        else:
-            violations.extend(self._validate_mcp_structure({"mcpServers": data}, mcp_json))
 
         return violations
 
@@ -78,13 +65,11 @@ class McpValidJsonRule(Rule):
 
         data, error = read_json(plugin_json)
         if error:
-            # If plugin.json is invalid, plugin-json-valid rule will catch it
             return violations
 
         if not isinstance(data, dict):
             return violations
 
-        # Only validate if mcpServers field exists
         if "mcpServers" not in data:
             return violations
 
@@ -119,7 +104,6 @@ class McpValidJsonRule(Rule):
             )
             return violations
 
-        # Validate each server configuration
         for server_name, server_config in mcp_servers.items():
             if not isinstance(server_config, dict):
                 violations.append(
@@ -139,10 +123,8 @@ class McpValidJsonRule(Rule):
                     )
                 )
 
-            # Get server type (defaults to stdio)
             server_type = server_config.get("type", "stdio")
 
-            # Validate type field
             if server_type not in self.VALID_MCP_TYPES:
                 violations.append(
                     self.violation(
@@ -151,7 +133,6 @@ class McpValidJsonRule(Rule):
                     )
                 )
             else:
-                # Check for required fields for the valid type
                 required_field = self.REQUIRED_FIELDS_BY_TYPE[server_type]
                 if required_field not in server_config:
                     violations.append(
@@ -161,7 +142,6 @@ class McpValidJsonRule(Rule):
                         )
                     )
 
-            # Validate optional fields
             if "args" in server_config and not isinstance(server_config["args"], list):
                 violations.append(
                     self.violation(
@@ -204,7 +184,6 @@ class McpValidJsonRule(Rule):
 
             if "startupTimeout" in server_config:
                 val = server_config["startupTimeout"]
-                # `bool` is a subclass of `int`, so we must explicitly exclude it.
                 is_valid_number = isinstance(val, (int, float)) and not isinstance(val, bool)
                 if not is_valid_number:
                     violations.append(
@@ -271,108 +250,57 @@ class McpProhibitedRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        # Get allowlist from config
         allowlist = set(self.config.get("allowlist", []))
 
-        for plugin_node in context.lint_tree.find(PluginNode):
-            plugin_path = plugin_node.path
-            # Check for .mcp.json at plugin root
-            mcp_json = plugin_path / ".mcp.json"
-            if mcp_json.exists():
-                violations.extend(self._check_mcp_file(mcp_json, allowlist))
-
-            # Check for mcpServers in plugin.json
-            plugin_json_path = plugin_path / ".claude-plugin" / "plugin.json"
-            if plugin_json_path.exists():
-                violations.extend(self._check_plugin_json(plugin_json_path, allowlist))
-
-        return violations
-
-    def _check_mcp_file(self, mcp_json: Path, allowlist: set) -> List[RuleViolation]:
-        """Check .mcp.json for non-allowlisted servers.
-
-        Accepts both wrapped (mcpServers key) and flat formats.
-        """
-        violations = []
-
-        data, error = read_json(mcp_json)
-        if error:
-            return violations
-
-        if not isinstance(data, dict):
-            return violations
-
-        servers = data.get("mcpServers", data)
-        if not isinstance(servers, dict):
-            return violations
-
-        prohibited = self._get_prohibited_servers(servers, allowlist)
-        if prohibited:
+        for block in context.lint_tree.find(McpBlock):
+            prohibited = block.server_names - allowlist if allowlist else block.server_names
+            if not prohibited:
+                continue
             if allowlist:
                 violations.append(
                     self.violation(
                         f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
-                        file_path=mcp_json,
+                        file_path=block.path,
                     )
                 )
             else:
                 violations.append(
                     self.violation(
                         "Plugin defines MCP servers in .mcp.json",
-                        file_path=mcp_json,
+                        file_path=block.path,
+                    )
+                )
+
+        # Also check mcpServers embedded in plugin.json
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_json_path = plugin_node.path / ".claude-plugin" / "plugin.json"
+            if not plugin_json_path.exists():
+                continue
+            data, error = read_json(plugin_json_path)
+            if error or not isinstance(data, dict):
+                continue
+            if "mcpServers" not in data:
+                continue
+            mcp_servers = data["mcpServers"]
+            if not isinstance(mcp_servers, dict):
+                continue
+            server_names = set(mcp_servers.keys())
+            prohibited = server_names - allowlist if allowlist else server_names
+            if not prohibited:
+                continue
+            if allowlist:
+                violations.append(
+                    self.violation(
+                        f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
+                        file_path=plugin_json_path,
+                    )
+                )
+            else:
+                violations.append(
+                    self.violation(
+                        "Plugin defines MCP servers in plugin.json",
+                        file_path=plugin_json_path,
                     )
                 )
 
         return violations
-
-    def _check_plugin_json(self, plugin_json: Path, allowlist: set) -> List[RuleViolation]:
-        """Check plugin.json for non-allowlisted servers"""
-        violations = []
-
-        data, error = read_json(plugin_json)
-        if error:
-            return violations
-
-        if not isinstance(data, dict):
-            return violations
-
-        if "mcpServers" in data:
-            mcp_servers = data["mcpServers"]
-            if not isinstance(mcp_servers, dict):
-                return violations
-
-            prohibited = self._get_prohibited_servers(mcp_servers, allowlist)
-            if prohibited:
-                if allowlist:
-                    violations.append(
-                        self.violation(
-                            f"Plugin defines non-allowlisted MCP servers: {', '.join(sorted(prohibited))}",
-                            file_path=plugin_json,
-                        )
-                    )
-                else:
-                    violations.append(
-                        self.violation(
-                            "Plugin defines MCP servers in plugin.json",
-                            file_path=plugin_json,
-                        )
-                    )
-
-        return violations
-
-    def _get_prohibited_servers(self, mcp_servers: dict, allowlist: set) -> set:
-        """
-        Get set of server names that are not in the allowlist
-
-        Args:
-            mcp_servers: Dict of MCP server configurations
-            allowlist: Set of allowed server names
-
-        Returns:
-            Set of prohibited server names
-        """
-        if not allowlist:
-            # If no allowlist, all servers are prohibited
-            return set(mcp_servers.keys())
-
-        return set(mcp_servers.keys()) - allowlist

--- a/src/skillsaw/rules/builtin/mcp.py
+++ b/src/skillsaw/rules/builtin/mcp.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import PluginNode
 from skillsaw.rules.builtin.utils import read_json
 
 
@@ -30,7 +31,8 @@ class McpValidJsonRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             # Check for .mcp.json at plugin root
             mcp_json = plugin_path / ".mcp.json"
             if mcp_json.exists():
@@ -272,7 +274,8 @@ class McpProhibitedRule(Rule):
         # Get allowlist from config
         allowlist = set(self.config.get("allowlist", []))
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             # Check for .mcp.json at plugin root
             mcp_json = plugin_path / ".mcp.json"
             if mcp_json.exists():

--- a/src/skillsaw/rules/builtin/openclaw.py
+++ b/src/skillsaw/rules/builtin/openclaw.py
@@ -2,29 +2,12 @@
 Rules for validating openclaw metadata in SKILL.md frontmatter
 """
 
-from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import SkillNode
-from skillsaw.rules.builtin.agentskills import _parse_skill_md
-from skillsaw.rules.builtin.utils import read_text, yaml_line_map, _extract_frontmatter_text
-
-
-def _build_frontmatter_line_map(skill_md: Path) -> Dict[str, int]:
-    """Map YAML key names to their line numbers in SKILL.md frontmatter.
-
-    Uses ruamel.yaml round-trip parsing for accurate line tracking.
-    """
-    content = read_text(skill_md)
-    if content is None:
-        return {}
-    fm_text, offset = _extract_frontmatter_text(content)
-    if fm_text is None:
-        return {}
-    return yaml_line_map(fm_text, line_offset=offset)
-
+from skillsaw.rules.builtin.content_analysis import SkillBlock
 
 VALID_OS_VALUES = {"darwin", "linux", "win32"}
 VALID_INSTALL_KINDS = {"brew", "node", "go", "uv", "download"}
@@ -56,14 +39,14 @@ class OpenclawMetadataRule(Rule):
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
-            skill_path = skill_node.path
-            skill_md = skill_path / "SKILL.md"
-            frontmatter, error = _parse_skill_md(skill_path)
-
-            if error or not frontmatter:
+            blocks = skill_node.find(SkillBlock)
+            if not blocks:
+                continue
+            block = blocks[0]
+            if block.frontmatter_error or block.frontmatter is None:
                 continue
 
-            metadata = frontmatter.get("metadata")
+            metadata = block.frontmatter.get("metadata")
             if not isinstance(metadata, dict):
                 continue
 
@@ -71,21 +54,21 @@ class OpenclawMetadataRule(Rule):
             if openclaw is None:
                 continue
 
-            line_map = _build_frontmatter_line_map(skill_md)
+            line_map = block.line_map()
 
             if not isinstance(openclaw, dict):
                 violations.append(
                     self.violation(
                         "'metadata.openclaw' must be a mapping",
-                        file_path=skill_md,
+                        file_path=block.path,
                         line=line_map.get("openclaw"),
                     )
                 )
                 continue
 
-            self._check_top_level(openclaw, skill_md, line_map, violations)
-            self._check_requires(openclaw, skill_md, line_map, violations)
-            self._check_install(openclaw, skill_md, line_map, violations)
+            self._check_top_level(openclaw, block.path, line_map, violations)
+            self._check_requires(openclaw, block.path, line_map, violations)
+            self._check_install(openclaw, block.path, line_map, violations)
 
         return violations
 

--- a/src/skillsaw/rules/builtin/openclaw.py
+++ b/src/skillsaw/rules/builtin/openclaw.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import SkillNode
 from skillsaw.rules.builtin.agentskills import _parse_skill_md
 from skillsaw.rules.builtin.utils import read_text, yaml_line_map, _extract_frontmatter_text
 
@@ -54,7 +55,8 @@ class OpenclawMetadataRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_path in context.skills:
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_path = skill_node.path
             skill_md = skill_path / "SKILL.md"
             frontmatter, error = _parse_skill_md(skill_path)
 

--- a/src/skillsaw/rules/builtin/plugin_structure.py
+++ b/src/skillsaw/rules/builtin/plugin_structure.py
@@ -9,6 +9,7 @@ from typing import List
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.rules.builtin.utils import read_json
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import PluginNode
 
 PLUGIN_REPO_TYPES = {RepositoryType.SINGLE_PLUGIN, RepositoryType.MARKETPLACE}
 
@@ -32,7 +33,8 @@ class PluginJsonRequiredRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
             if not plugin_json.exists():
                 # Check if plugin has strict: false in marketplace metadata
@@ -77,7 +79,8 @@ class PluginJsonValidRule(Rule):
         violations = []
         recommended_fields = self.config.get("recommended-fields", self.DEFAULT_RECOMMENDED_FIELDS)
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
 
             if not plugin_json.exists():
@@ -160,7 +163,8 @@ class PluginNamingRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             plugin_name = context.get_plugin_name(plugin_path)
 
             if not self._is_kebab_case(plugin_name):
@@ -210,7 +214,8 @@ class PluginReadmeRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
+        for plugin_node in context.lint_tree.find(PluginNode):
+            plugin_path = plugin_node.path
             readme = plugin_path / "README.md"
             if not readme.exists():
                 violations.append(

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -51,8 +51,9 @@ class SkillFrontmatterRule(Rule):
                 )
                 continue
 
-            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+            frontmatter_match = re.match(r"^---\r?\n(.*?)\r?\n---", content, re.DOTALL)
             if not frontmatter_match:
+                violations.append(self.violation("Invalid frontmatter format", file_path=skill_md))
                 continue
 
             frontmatter = frontmatter_match.group(1)
@@ -134,7 +135,7 @@ class SkillFrontmatterRule(Rule):
             missing_name = any("Missing 'name'" in m for m in messages)
             missing_desc = any("Missing 'description'" in m for m in messages)
             if (missing_name or missing_desc) and original.startswith("---"):
-                fm_match = re.match(r"^---\n(.*?)\n---", original, re.DOTALL)
+                fm_match = re.match(r"^---\r?\n(.*?)\r?\n---", original, re.DOTALL)
                 if fm_match:
                     fm_text = fm_match.group(1)
                     additions = []

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -37,7 +37,9 @@ class SkillFrontmatterRule(Rule):
             "Rules:\n"
             "- Must have 'name' and 'description' fields\n"
             "- 'name' should be the skill directory name\n"
-            "- 'description' should be a concise one-line summary derived from the body content\n"
+            "- 'description' should be imperative and tell the model when to invoke it, "
+            "e.g. 'Use when the user asks to deploy a service' — "
+            "derive it from the body content\n"
             "- If the YAML is malformed, fix the syntax\n"
             "- Preserve any other existing frontmatter fields"
         )

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -39,7 +39,7 @@ class SkillFrontmatterRule(Rule):
             "- 'name' should be the skill directory name\n"
             "- 'description' should be imperative and tell the model when to invoke it, "
             "e.g. 'Use when the user asks to deploy a service' — "
-            "derive it from the body content\n"
+            "derive it from the body content, keep it under 200 tokens\n"
             "- If the YAML is malformed, fix the syntax\n"
             "- Preserve any other existing frontmatter fields"
         )

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -10,6 +10,7 @@ from typing import List
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
 from skillsaw.lint_target import SkillNode
+from skillsaw.rules.builtin.content_analysis import SkillBlock
 from skillsaw.rules.builtin.utils import read_text
 
 
@@ -31,42 +32,33 @@ class SkillFrontmatterRule(Rule):
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
-            skill_md = skill_node.path / "SKILL.md"
-            if not skill_md.exists():
+            blocks = skill_node.find(SkillBlock)
+            if not blocks:
                 violations.append(self.violation("Missing SKILL.md", file_path=skill_node.path))
                 continue
 
-            content = read_text(skill_md)
-            if content is None:
-                violations.append(
-                    self.violation(f"Failed to read file: {skill_md}", file_path=skill_md)
-                )
+            block = blocks[0]
+            if block.frontmatter_error:
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
                 continue
 
-            if not content.startswith("---"):
+            if block.frontmatter is None:
                 violations.append(
                     self.violation(
-                        "Missing frontmatter (recommended for SKILL.md)", file_path=skill_md
+                        "Missing frontmatter (recommended for SKILL.md)", file_path=block.path
                     )
                 )
                 continue
 
-            frontmatter_match = re.match(r"^---\r?\n(.*?)\r?\n---", content, re.DOTALL)
-            if not frontmatter_match:
-                violations.append(self.violation("Invalid frontmatter format", file_path=skill_md))
-                continue
-
-            frontmatter = frontmatter_match.group(1)
-
-            if "name:" not in frontmatter:
+            if "name" not in block.frontmatter:
                 violations.append(
-                    self.violation("Missing 'name' in SKILL.md frontmatter", file_path=skill_md)
+                    self.violation("Missing 'name' in SKILL.md frontmatter", file_path=block.path)
                 )
 
-            if "description:" not in frontmatter:
+            if "description" not in block.frontmatter:
                 violations.append(
                     self.violation(
-                        "Missing 'description' in SKILL.md frontmatter", file_path=skill_md
+                        "Missing 'description' in SKILL.md frontmatter", file_path=block.path
                     )
                 )
 

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -9,6 +9,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import PluginNode, SkillNode
 from skillsaw.rules.builtin.utils import read_text
 
 
@@ -29,8 +30,8 @@ class SkillFrontmatterRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_path in context.plugins:
-            skills_dir = plugin_path / "skills"
+        for plugin_node in context.lint_tree.find(PluginNode):
+            skills_dir = plugin_node.path / "skills"
             if not skills_dir.exists():
                 continue
 
@@ -50,7 +51,6 @@ class SkillFrontmatterRule(Rule):
                     )
                     continue
 
-                # Check for frontmatter
                 if not content.startswith("---"):
                     violations.append(
                         self.violation(
@@ -59,14 +59,12 @@ class SkillFrontmatterRule(Rule):
                     )
                     continue
 
-                # Parse frontmatter
                 frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
                 if not frontmatter_match:
                     continue
 
                 frontmatter = frontmatter_match.group(1)
 
-                # Check for recommended fields
                 if "name:" not in frontmatter:
                     violations.append(
                         self.violation("Missing 'name' in SKILL.md frontmatter", file_path=skill_md)

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -28,6 +28,24 @@ class SkillFrontmatterRule(Rule):
     def default_severity(self) -> Severity:
         return Severity.WARNING
 
+    @property
+    def llm_fix_prompt(self):
+        return (
+            "You are fixing YAML frontmatter for a SKILL.md file.\n\n"
+            "The block you are editing is the raw YAML between the --- delimiters.\n"
+            "Do NOT include the --- delimiters in your output.\n\n"
+            "Rules:\n"
+            "- Must have 'name' and 'description' fields\n"
+            "- 'name' should be the skill directory name\n"
+            "- 'description' should be a concise one-line summary derived from the body content\n"
+            "- If the YAML is malformed, fix the syntax\n"
+            "- Preserve any other existing frontmatter fields"
+        )
+
+    @property
+    def llm_fix_frontmatter(self) -> bool:
+        return True
+
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
@@ -39,26 +57,36 @@ class SkillFrontmatterRule(Rule):
 
             block = blocks[0]
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                violations.append(
+                    self.violation(block.frontmatter_error, file_path=block.path, block=block)
+                )
                 continue
 
             if block.frontmatter is None:
                 violations.append(
                     self.violation(
-                        "Missing frontmatter (recommended for SKILL.md)", file_path=block.path
+                        "Missing frontmatter (recommended for SKILL.md)",
+                        file_path=block.path,
+                        block=block,
                     )
                 )
                 continue
 
             if "name" not in block.frontmatter:
                 violations.append(
-                    self.violation("Missing 'name' in SKILL.md frontmatter", file_path=block.path)
+                    self.violation(
+                        "Missing 'name' in SKILL.md frontmatter",
+                        file_path=block.path,
+                        block=block,
+                    )
                 )
 
             if "description" not in block.frontmatter:
                 violations.append(
                     self.violation(
-                        "Missing 'description' in SKILL.md frontmatter", file_path=block.path
+                        "Missing 'description' in SKILL.md frontmatter",
+                        file_path=block.path,
+                        block=block,
                     )
                 )
 

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -9,7 +9,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
-from skillsaw.lint_target import PluginNode, SkillNode
+from skillsaw.lint_target import SkillNode
 from skillsaw.rules.builtin.utils import read_text
 
 
@@ -30,52 +30,44 @@ class SkillFrontmatterRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for plugin_node in context.lint_tree.find(PluginNode):
-            skills_dir = plugin_node.path / "skills"
-            if not skills_dir.exists():
+        for skill_node in context.lint_tree.find(SkillNode):
+            skill_md = skill_node.path / "SKILL.md"
+            if not skill_md.exists():
+                violations.append(self.violation("Missing SKILL.md", file_path=skill_node.path))
                 continue
 
-            for skill_dir in skills_dir.iterdir():
-                if not skill_dir.is_dir():
-                    continue
+            content = read_text(skill_md)
+            if content is None:
+                violations.append(
+                    self.violation(f"Failed to read file: {skill_md}", file_path=skill_md)
+                )
+                continue
 
-                skill_md = skill_dir / "SKILL.md"
-                if not skill_md.exists():
-                    violations.append(self.violation("Missing SKILL.md", file_path=skill_dir))
-                    continue
-
-                content = read_text(skill_md)
-                if content is None:
-                    violations.append(
-                        self.violation(f"Failed to read file: {skill_md}", file_path=skill_md)
+            if not content.startswith("---"):
+                violations.append(
+                    self.violation(
+                        "Missing frontmatter (recommended for SKILL.md)", file_path=skill_md
                     )
-                    continue
+                )
+                continue
 
-                if not content.startswith("---"):
-                    violations.append(
-                        self.violation(
-                            "Missing frontmatter (recommended for SKILL.md)", file_path=skill_md
-                        )
+            frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+            if not frontmatter_match:
+                continue
+
+            frontmatter = frontmatter_match.group(1)
+
+            if "name:" not in frontmatter:
+                violations.append(
+                    self.violation("Missing 'name' in SKILL.md frontmatter", file_path=skill_md)
+                )
+
+            if "description:" not in frontmatter:
+                violations.append(
+                    self.violation(
+                        "Missing 'description' in SKILL.md frontmatter", file_path=skill_md
                     )
-                    continue
-
-                frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
-                if not frontmatter_match:
-                    continue
-
-                frontmatter = frontmatter_match.group(1)
-
-                if "name:" not in frontmatter:
-                    violations.append(
-                        self.violation("Missing 'name' in SKILL.md frontmatter", file_path=skill_md)
-                    )
-
-                if "description:" not in frontmatter:
-                    violations.append(
-                        self.violation(
-                            "Missing 'description' in SKILL.md frontmatter", file_path=skill_md
-                        )
-                    )
+                )
 
         return violations
 

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -228,6 +228,19 @@ class TestGatherContentFilesCoderabbit:
         assert cr_files[0].file_line(1) == 2  # instructions key on line 2
         assert cr_files[1].file_line(1) == 4  # instructions key on line 4
 
+    def test_line_offsets_block_scalar(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n"  # 1
+            "  instructions: |\n"  # 2
+            "    Block review text.\n"  # 3
+        )
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 1
+        # Body line 1 should map to file line 3 (one past the key line)
+        assert cr_files[0].file_line(1) == 3
+
     def test_no_instructions_yields_nothing(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
         context = RepositoryContext(temp_dir)

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -1,5 +1,7 @@
 """Tests for .coderabbit.yaml linting rules."""
 
+from pathlib import Path
+
 import yaml
 
 from skillsaw.config import LinterConfig
@@ -10,9 +12,9 @@ from skillsaw.rules.builtin.coderabbit import (
 )
 from skillsaw.rules.builtin.content_analysis import (
     _extract_instructions,
-    _extract_coderabbit_instructions_body,
     gather_all_content_files,
-    _get_body,
+    _get_body_from_cf,
+    ContentFile,
 )
 from skillsaw.rules.builtin.content_rules import (
     ContentWeakLanguageRule,
@@ -172,60 +174,73 @@ class TestContentRulesOnCoderabbit:
 
 
 # ---------------------------------------------------------------------------
-# _get_body for .coderabbit.yaml
+# Per-instruction ContentFile for .coderabbit.yaml
 # ---------------------------------------------------------------------------
 
 
 class TestGetBodyCoderabbit:
-    """Verify _get_body extracts instruction text from .coderabbit.yaml."""
+    """Verify _get_body_from_cf returns pre-populated body for coderabbit ContentFiles."""
 
-    def test_extracts_review_instructions(self, temp_dir):
-        cr = temp_dir / ".coderabbit.yaml"
-        cr.write_text("reviews:\n  instructions: 'Do stuff.'\n")
-        body = _get_body(cr)
-        assert body is not None
-        assert "Do stuff." in body
+    def test_returns_body_from_cf(self):
+        cf = ContentFile(path=Path(".coderabbit.yaml"), category="coderabbit", body="Do stuff.")
+        body = _get_body_from_cf(cf)
+        assert body == "Do stuff."
 
-    def test_extracts_multiple_instruction_fields(self, temp_dir):
-        cr = temp_dir / ".coderabbit.yaml"
-        cr.write_text(
+    def test_returns_none_for_no_body_missing_file(self, temp_dir):
+        cf = ContentFile(path=temp_dir / "nonexistent.yaml", category="coderabbit")
+        body = _get_body_from_cf(cf)
+        assert body is None
+
+
+# ---------------------------------------------------------------------------
+# gather_all_content_files yields per-instruction ContentFiles
+# ---------------------------------------------------------------------------
+
+
+class TestGatherContentFilesCoderabbit:
+    def test_yields_one_per_instruction(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
             "reviews:\n"
             "  instructions: 'Review stuff.'\n"
             "chat:\n"
             "  instructions: 'Chat stuff.'\n"
         )
-        body = _get_body(cr)
-        assert body is not None
-        assert "Review stuff." in body
-        assert "Chat stuff." in body
-
-    def test_returns_empty_for_no_instructions(self, temp_dir):
-        cr = temp_dir / ".coderabbit.yaml"
-        cr.write_text("language: en-US\n")
-        body = _get_body(cr)
-        assert body == ""
-
-    def test_returns_empty_for_invalid_yaml(self, temp_dir):
-        cr = temp_dir / ".coderabbit.yaml"
-        cr.write_text(":\n  bad: [unterminated\n")
-        body = _get_body(cr)
-        assert body == ""
-
-
-# ---------------------------------------------------------------------------
-# gather_all_content_files includes .coderabbit.yaml
-# ---------------------------------------------------------------------------
-
-
-class TestGatherContentFilesCoderabbit:
-    def test_includes_coderabbit_yaml(self, temp_dir):
-        (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: 'Do stuff.'\n")
         context = RepositoryContext(temp_dir)
         files = gather_all_content_files(context)
-        paths = [cf.path for cf in files]
-        assert temp_dir / ".coderabbit.yaml" in paths
-        categories = {cf.category for cf in files if cf.path == temp_dir / ".coderabbit.yaml"}
-        assert "coderabbit" in categories
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 2
+        bodies = [cf.body for cf in cr_files]
+        assert "Review stuff." in bodies
+        assert "Chat stuff." in bodies
+
+    def test_line_offsets_are_correct(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n"  # 1
+            "  instructions: 'Review stuff.'\n"  # 2
+            "chat:\n"  # 3
+            "  instructions: 'Chat stuff.'\n"  # 4
+        )
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 2
+        # line_offset = line - 1, so body line 1 + offset = YAML line
+        assert cr_files[0].line_offset == 1  # instructions key on line 2
+        assert cr_files[1].line_offset == 3  # instructions key on line 4
+
+    def test_no_instructions_yields_nothing(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 0
+
+    def test_invalid_yaml_yields_nothing(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(":\n  bad: [unterminated\n")
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 0
 
     def test_not_included_when_absent(self, temp_dir):
         context = RepositoryContext(temp_dir)

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -224,9 +224,9 @@ class TestGatherContentFilesCoderabbit:
         files = gather_all_content_files(context)
         cr_files = [cf for cf in files if cf.category == "coderabbit"]
         assert len(cr_files) == 2
-        # line_offset = line - 1, so body line 1 + offset = YAML line
-        assert cr_files[0].line_offset == 1  # instructions key on line 2
-        assert cr_files[1].line_offset == 3  # instructions key on line 4
+        # file_line(1) should map body line 1 to the YAML line of the instructions key
+        assert cr_files[0].file_line(1) == 2  # instructions key on line 2
+        assert cr_files[1].file_line(1) == 4  # instructions key on line 4
 
     def test_no_instructions_yields_nothing(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -444,3 +444,49 @@ class TestCoderabbitConfig:
     def test_yaml_valid_default_severity_error(self):
         config = LinterConfig.default()
         assert config.get_rule_config("coderabbit-yaml-valid").get("severity") == "error"
+
+
+class TestCoderabbitWriterRoundTrip:
+    """Verify write_body preserves YAML structure for coderabbit blocks."""
+
+    def test_write_body_updates_instruction(self, temp_dir):
+        yaml_content = (
+            "reviews:\n"
+            "  instructions: 'Original review instructions.'\n"
+            "chat:\n"
+            "  instructions: 'Original chat instructions.'\n"
+        )
+        cr_path = temp_dir / ".coderabbit.yaml"
+        cr_path.write_text(yaml_content)
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 2
+
+        review_block = [cf for cf in cr_files if cf.body == "Original review instructions."][0]
+        review_block.write_body("Updated review instructions.")
+
+        updated = cr_path.read_text(encoding="utf-8")
+        assert "Updated review instructions." in updated
+        assert "Original chat instructions." in updated
+
+    def test_write_body_preserves_yaml_keys(self, temp_dir):
+        yaml_content = (
+            "language: en-US\n"
+            "reviews:\n"
+            "  instructions: 'Do review stuff.'\n"
+            "  high_level_summary: true\n"
+        )
+        cr_path = temp_dir / ".coderabbit.yaml"
+        cr_path.write_text(yaml_content)
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 1
+
+        cr_files[0].write_body("Better review stuff.")
+
+        updated = cr_path.read_text(encoding="utf-8")
+        assert "Better review stuff." in updated
+        assert "language: en-US" in updated
+        assert "high_level_summary: true" in updated

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -787,19 +787,6 @@ class TestContentBlockReadWrite:
         block.write_body("new content")
         assert f.read_text(encoding="utf-8") == "new content"
 
-    def test_write_body_custom_writer(self, temp_dir):
-        written = {}
-
-        def custom_writer(body):
-            written["body"] = body
-
-        f = temp_dir / "test.md"
-        f.write_text("original")
-        block = ContentFile(path=f, category="instruction", _writer=custom_writer)
-        block.write_body("custom content")
-        assert written["body"] == "custom content"
-        assert f.read_text(encoding="utf-8") == "original"
-
     def test_file_line_with_offset(self):
         block = ContentFile(
             path=Path("/tmp/test.md"),

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -752,3 +752,70 @@ class TestGatherAllContentFiles:
         context = RepositoryContext(temp_dir)
         cfs = gather_all_content_files(context)
         assert any(cf.path.name == "CLAUDE.md" for cf in cfs)
+
+
+class TestContentBlockReadWrite:
+    def test_read_body_from_file(self, temp_dir):
+        f = temp_dir / "test.md"
+        f.write_text("# Heading\n\nBody text\n")
+        block = ContentFile(path=f, category="instruction")
+        body = block.read_body(strip_code_blocks=False)
+        assert body == "# Heading\n\nBody text\n"
+
+    def test_read_body_from_preloaded(self, temp_dir):
+        block = ContentFile(
+            path=temp_dir / "nonexistent.md",
+            category="instruction",
+            body="preloaded content",
+        )
+        body = block.read_body(strip_code_blocks=False)
+        assert body == "preloaded content"
+
+    def test_read_body_strips_code_blocks(self, temp_dir):
+        f = temp_dir / "test.md"
+        f.write_text("Before\n```python\nprint('hi')\n```\nAfter\n")
+        block = ContentFile(path=f, category="instruction")
+        body = block.read_body(strip_code_blocks=True)
+        assert "print" not in body
+        assert "Before" in body
+        assert "After" in body
+
+    def test_write_body_default(self, temp_dir):
+        f = temp_dir / "test.md"
+        f.write_text("original")
+        block = ContentFile(path=f, category="instruction")
+        block.write_body("new content")
+        assert f.read_text(encoding="utf-8") == "new content"
+
+    def test_write_body_custom_writer(self, temp_dir):
+        written = {}
+
+        def custom_writer(body):
+            written["body"] = body
+
+        f = temp_dir / "test.md"
+        f.write_text("original")
+        block = ContentFile(path=f, category="instruction", _writer=custom_writer)
+        block.write_body("custom content")
+        assert written["body"] == "custom content"
+        assert f.read_text(encoding="utf-8") == "original"
+
+    def test_file_line_with_offset(self):
+        block = ContentFile(
+            path=Path("/tmp/test.md"),
+            category="instruction",
+            line_offset=10,
+        )
+        assert block.file_line(5) == 15
+
+    def test_file_line_with_line_map(self):
+        block = ContentFile(
+            path=Path("/tmp/test.md"),
+            category="instruction",
+            _line_map=lambda body_line: body_line * 2,
+        )
+        assert block.file_line(5) == 10
+
+    def test_read_body_nonexistent_no_body(self, temp_dir):
+        block = ContentFile(path=temp_dir / "missing.md", category="instruction")
+        assert block.read_body() is None

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -19,6 +19,10 @@ from skillsaw.rules.builtin.content_analysis import (
 from skillsaw.context import RepositoryContext
 
 
+def _cf(path: Path, category: str = "instruction") -> ContentFile:
+    return ContentFile(path=path, category=category)
+
+
 @pytest.fixture
 def temp_dir():
     tmp = tempfile.mkdtemp()
@@ -132,7 +136,7 @@ class TestWeakLanguageDetector:
     def test_detects_hedging(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Try to use consistent naming.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert results[0].category == "hedging"
         assert "try to" in results[0].phrase.lower()
@@ -140,14 +144,14 @@ class TestWeakLanguageDetector:
     def test_detects_vagueness(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Handle errors gracefully.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert results[0].category == "vagueness"
 
     def test_detects_non_actionable(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Be aware of the rate limits.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert results[0].category == "non-actionable"
 
@@ -156,73 +160,73 @@ class TestWeakLanguageDetector:
             "Use 4-space indentation.\nRun tests before committing.\n"
         )
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) == 0
 
     def test_reports_correct_line_numbers(self, temp_dir):
         content = "Line one.\nLine two.\nTry to be careful here.\nLine four.\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert any(r.line == 3 for r in results)
 
     def test_multiple_matches_per_line(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Try to handle errors gracefully if possible.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 3
 
     def test_case_insensitive(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("TRY TO use PROPERLY.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 2
 
     def test_skips_fenced_code_blocks(self, temp_dir):
         content = "Real instruction.\n```\nTry to handle errors gracefully.\n```\nMore text.\n"
         (temp_dir / "code_block.md").write_text(content)
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "code_block.md")
+        results = detector.analyze(_cf(temp_dir / "code_block.md"))
         assert len(results) == 0
 
     def test_skips_indented_fenced_code_blocks(self, temp_dir):
         content = "Real instruction.\n- Example:\n  ```\n  Try to handle errors gracefully.\n  ```\nMore text.\n"
         (temp_dir / "indented.md").write_text(content)
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "indented.md")
+        results = detector.analyze(_cf(temp_dir / "indented.md"))
         assert len(results) == 0
 
     def test_consider_requires_action_verb(self, temp_dir):
         (temp_dir / "consider_fp.md").write_text("Consider this example:\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "consider_fp.md")
+        results = detector.analyze(_cf(temp_dir / "consider_fp.md"))
         assert len(results) == 0
 
     def test_consider_using_flagged(self, temp_dir):
         (temp_dir / "consider_tp.md").write_text("Consider using TypeScript.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "consider_tp.md")
+        results = detector.analyze(_cf(temp_dir / "consider_tp.md"))
         assert len(results) >= 1
         assert results[0].category == "hedging"
 
     def test_detects_you_might_want_to(self, temp_dir):
         (temp_dir / "might.md").write_text("You might want to add error handling.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "might.md")
+        results = detector.analyze(_cf(temp_dir / "might.md"))
         assert len(results) >= 1
         assert results[0].category == "hedging"
 
     def test_detects_perhaps(self, temp_dir):
         (temp_dir / "perhaps.md").write_text("Perhaps use a different approach.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "perhaps.md")
+        results = detector.analyze(_cf(temp_dir / "perhaps.md"))
         assert len(results) >= 1
         assert results[0].category == "hedging"
 
     def test_detects_you_should_probably(self, temp_dir):
         (temp_dir / "probably.md").write_text("You should probably refactor this.\n")
         detector = WeakLanguageDetector()
-        results = detector.analyze(temp_dir / "probably.md")
+        results = detector.analyze(_cf(temp_dir / "probably.md"))
         assert len(results) >= 1
         assert results[0].category == "hedging"
 
@@ -231,20 +235,20 @@ class TestTautologicalDetector:
     def test_detects_write_clean_code(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Always write clean code.\n")
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert "clean code" in results[0].phrase.lower()
 
     def test_detects_follow_best_practices(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Follow best practices.\n")
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
 
     def test_detects_be_helpful(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Be helpful to the user.\n")
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
 
     def test_specific_instructions_pass(self, temp_dir):
@@ -252,20 +256,20 @@ class TestTautologicalDetector:
             "Use 4-space indentation for Python files.\nReturn 404 for missing resources.\n"
         )
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) == 0
 
     def test_reports_reason(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Use common sense.\n")
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert results[0].reason
 
     def test_case_insensitive(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("WRITE CLEAN CODE.\n")
         detector = TautologicalDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md")
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
 
 
@@ -278,26 +282,26 @@ class TestCriticalPositionAnalyzer:
     def test_critical_in_middle_flagged(self, temp_dir):
         self._make_file(temp_dir, 50, 25)
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 1
         assert results[0].position_score == 0.5
 
     def test_critical_at_top_not_flagged(self, temp_dir):
         self._make_file(temp_dir, 50, 3)
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) == 0
 
     def test_critical_at_bottom_not_flagged(self, temp_dir):
         self._make_file(temp_dir, 50, 48)
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) == 0
 
     def test_short_file_skipped(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("IMPORTANT: do this.\nNEVER do that.\n")
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) == 0
 
     def test_multiple_keywords(self, temp_dir):
@@ -306,13 +310,13 @@ class TestCriticalPositionAnalyzer:
         lines[26] = "NEVER skip that step."
         (temp_dir / "CLAUDE.md").write_text("\n".join(lines) + "\n")
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert len(results) >= 2
 
     def test_reports_keyword(self, temp_dir):
         self._make_file(temp_dir, 50, 25)
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "CLAUDE.md")
+        results = analyzer.analyze(_cf(temp_dir / "CLAUDE.md"))
         assert results[0].keyword == "IMPORTANT"
 
     def test_lowercase_must_not_flagged(self, temp_dir):
@@ -320,7 +324,7 @@ class TestCriticalPositionAnalyzer:
         lines[24] = "This function must return a value."
         (temp_dir / "crit_lower.md").write_text("\n".join(lines) + "\n")
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "crit_lower.md")
+        results = analyzer.analyze(_cf(temp_dir / "crit_lower.md"))
         assert len(results) == 0
 
     def test_lowercase_required_not_flagged(self, temp_dir):
@@ -328,7 +332,7 @@ class TestCriticalPositionAnalyzer:
         lines[24] = "The required fields are: name, email."
         (temp_dir / "crit_req.md").write_text("\n".join(lines) + "\n")
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "crit_req.md")
+        results = analyzer.analyze(_cf(temp_dir / "crit_req.md"))
         assert len(results) == 0
 
     def test_allcaps_must_flagged(self, temp_dir):
@@ -336,7 +340,7 @@ class TestCriticalPositionAnalyzer:
         lines[24] = "You MUST always run tests."
         (temp_dir / "crit_caps.md").write_text("\n".join(lines) + "\n")
         analyzer = CriticalPositionAnalyzer()
-        results = analyzer.analyze(temp_dir / "crit_caps.md")
+        results = analyzer.analyze(_cf(temp_dir / "crit_caps.md"))
         assert len(results) >= 1
         assert results[0].keyword == "MUST"
 
@@ -346,28 +350,28 @@ class TestRedundancyDetector:
         (temp_dir / ".editorconfig").write_text("[*]\nindent_size = 4\n")
         (temp_dir / "CLAUDE.md").write_text("Use 4 spaces for indentation.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) >= 1
         assert ".editorconfig" in results[0].existing_config_file
 
     def test_no_editorconfig_no_match(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Use 4 spaces for indentation.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) == 0
 
     def test_detects_style_with_prettier(self, temp_dir):
         (temp_dir / ".prettierrc").write_text('{"singleQuote": true}')
         (temp_dir / "CLAUDE.md").write_text("Use single quotes for strings.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) >= 1
 
     def test_detects_tsconfig_strict(self, temp_dir):
         (temp_dir / "tsconfig.json").write_text('{"compilerOptions": {"strict": true}}')
         (temp_dir / "CLAUDE.md").write_text("Use strict TypeScript mode.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) >= 1
         assert "tsconfig.json" in results[0].existing_config_file
 
@@ -375,14 +379,14 @@ class TestRedundancyDetector:
         (temp_dir / ".editorconfig").write_text("[*]\nindent_size = 4\n")
         (temp_dir / "CLAUDE.md").write_text("Focus on user experience.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) == 0
 
     def test_detects_tabs_with_editorconfig(self, temp_dir):
         (temp_dir / ".editorconfig").write_text("[*]\nindent_style = tab\n")
         (temp_dir / "CLAUDE.md").write_text("Use tabs for indentation.\n")
         detector = RedundancyDetector()
-        results = detector.analyze(temp_dir / "CLAUDE.md", temp_dir)
+        results = detector.analyze(_cf(temp_dir / "CLAUDE.md"), temp_dir)
         assert len(results) >= 1
 
 
@@ -391,7 +395,7 @@ class TestInstructionBudgetAnalyzer:
         content = "- Use 4-space indentation\n- Run tests before commits\n- Check for errors\nSome description.\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        budget = analyzer.analyze_file(_cf(temp_dir / "CLAUDE.md"))
         assert budget.total_count == 3
         assert not budget.over_budget
 
@@ -399,21 +403,21 @@ class TestInstructionBudgetAnalyzer:
         lines = [f"- Use tool_{i}" for i in range(160)]
         (temp_dir / "CLAUDE.md").write_text("\n".join(lines) + "\n")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        budget = analyzer.analyze_file(_cf(temp_dir / "CLAUDE.md"))
         assert budget.over_budget
         assert budget.budget_remaining == 0
 
     def test_empty_file(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        budget = analyzer.analyze_file(_cf(temp_dir / "CLAUDE.md"))
         assert budget.total_count == 0
         assert not budget.over_budget
 
     def test_single_file_counted(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("- Use X\n- Run Y\n")
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        budget = analyzer.analyze_file(_cf(temp_dir / "CLAUDE.md"))
         assert budget.total_count == 2
         assert len(budget.files_counted) == 1
 
@@ -421,7 +425,7 @@ class TestInstructionBudgetAnalyzer:
         content = "# Instructions\n\nThis project is a web app.\nIt was built in 2024.\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         analyzer = InstructionBudgetAnalyzer()
-        budget = analyzer.analyze_file(temp_dir / "CLAUDE.md")
+        budget = analyzer.analyze_file(_cf(temp_dir / "CLAUDE.md"))
         assert budget.total_count == 0
 
 

--- a/tests/test_context_budget_rules.py
+++ b/tests/test_context_budget_rules.py
@@ -193,3 +193,61 @@ class TestContextBudgetRule:
 
         rule_under = ContextBudgetRule({"limits": {"claude-md": 999}})
         assert len(rule_under.check(context)) == 1
+
+    def test_skill_description_under_limit(self, temp_dir):
+        skill_dir = temp_dir / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: Short description\n---\n"
+        )
+        context = RepositoryContext(temp_dir)
+        rule = ContextBudgetRule()
+        desc_violations = [v for v in rule.check(context) if "description" in v.message.lower()]
+        assert len(desc_violations) == 0
+
+    def test_skill_description_over_warn(self, temp_dir):
+        skill_dir = temp_dir / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        long_desc = "x" * (201 * 4)  # ~201 tokens, exceeds default warn=200
+        (skill_dir / "SKILL.md").write_text(
+            f'---\nname: my-skill\ndescription: "{long_desc}"\n---\n'
+        )
+        context = RepositoryContext(temp_dir)
+        rule = ContextBudgetRule()
+        desc_violations = [v for v in rule.check(context) if "description" in v.message.lower()]
+        assert len(desc_violations) == 1
+        assert desc_violations[0].severity == Severity.WARNING
+
+    def test_skill_description_over_error(self, temp_dir):
+        skill_dir = temp_dir / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        long_desc = "x" * (501 * 4)  # ~501 tokens, exceeds default error=500
+        (skill_dir / "SKILL.md").write_text(
+            f'---\nname: my-skill\ndescription: "{long_desc}"\n---\n'
+        )
+        context = RepositoryContext(temp_dir)
+        rule = ContextBudgetRule()
+        desc_violations = [v for v in rule.check(context) if "description" in v.message.lower()]
+        assert len(desc_violations) == 1
+        assert desc_violations[0].severity == Severity.ERROR
+
+    def test_command_description_over_warn(self, temp_dir):
+        cmd_dir = temp_dir / ".claude" / "commands"
+        cmd_dir.mkdir(parents=True)
+        long_desc = "x" * (201 * 4)
+        (cmd_dir / "my-cmd.md").write_text(f'---\ndescription: "{long_desc}"\n---\n')
+        context = RepositoryContext(temp_dir)
+        rule = ContextBudgetRule()
+        desc_violations = [v for v in rule.check(context) if "description" in v.message.lower()]
+        assert len(desc_violations) == 1
+        assert "command-description" in desc_violations[0].message
+
+    def test_custom_description_limits(self, temp_dir):
+        skill_dir = temp_dir / ".claude" / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        desc = "x" * (51 * 4)  # ~51 tokens
+        (skill_dir / "SKILL.md").write_text(f'---\nname: my-skill\ndescription: "{desc}"\n---\n')
+        context = RepositoryContext(temp_dir)
+        rule = ContextBudgetRule({"limits": {"skill-description": 50}})
+        desc_violations = [v for v in rule.check(context) if "description" in v.message.lower()]
+        assert len(desc_violations) == 1

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -100,6 +100,7 @@ def test_find_parent_returns_nearest():
     plugin.children = [skill]
     marketplace.children = [plugin]
     root.children = [marketplace]
+    root.set_parents()
 
     parent = root.find_parent(leaf, PluginNode)
     assert parent is plugin
@@ -112,6 +113,7 @@ def test_find_parent_returns_none_when_no_match():
     root = LintTarget(path=Path("/root"))
     child = LintTarget(path=Path("/child"))
     root.children = [child]
+    root.set_parents()
 
     assert root.find_parent(child, PluginNode) is None
 
@@ -123,6 +125,7 @@ def test_find_parent_skips_non_ancestors():
     target = LintTarget(path=Path("/target"))
     p2.children = [target]
     root.children = [p1, p2]
+    root.set_parents()
 
     parent = root.find_parent(target, PluginNode)
     assert parent is p2

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -226,6 +226,64 @@ def test_content_blocks_returns_all_content(temp_dir):
     assert all(hasattr(b, "category") for b in blocks)
 
 
+def test_estimate_tokens_content_block(temp_dir):
+    """ContentBlock.estimate_tokens() returns len(body) // 4."""
+    from skillsaw.rules.builtin.content_analysis import FileContentBlock, InstructionBlock
+
+    f = temp_dir / "test.md"
+    f.write_text("a" * 400)
+    block = InstructionBlock(path=f)
+    assert block.estimate_tokens() == 100
+
+
+def test_estimate_tokens_container_sums_children(temp_dir):
+    """Container nodes sum their children's tokens."""
+    from skillsaw.rules.builtin.content_analysis import InstructionBlock
+
+    f1 = temp_dir / "a.md"
+    f1.write_text("x" * 200)
+    f2 = temp_dir / "b.md"
+    f2.write_text("y" * 400)
+
+    root = LintTarget(path=temp_dir)
+    root.children = [InstructionBlock(path=f1), InstructionBlock(path=f2)]
+    assert root.estimate_tokens() == 150  # 50 + 100
+
+
+def test_print_tree_shows_tokens(temp_dir):
+    """print_tree() output includes token counts."""
+    from skillsaw.rules.builtin.content_analysis import InstructionBlock
+
+    f = temp_dir / "CLAUDE.md"
+    f.write_text("x" * 80)
+
+    root = LintTarget(path=temp_dir)
+    root.children = [InstructionBlock(path=f)]
+    output = root.print_tree(root_path=temp_dir)
+    assert "tokens)" in output
+    assert "(20 tokens)" in output
+
+
+def test_print_dot_structure(temp_dir):
+    """print_dot() produces valid DOT with nodes and edges."""
+    from skillsaw.rules.builtin.content_analysis import InstructionBlock
+
+    f = temp_dir / "CLAUDE.md"
+    f.write_text("hello world")
+
+    root = LintTarget(path=temp_dir)
+    root.children = [InstructionBlock(path=f)]
+    dot = root.print_dot(root_path=temp_dir)
+
+    assert dot.startswith("digraph lint_tree {")
+    assert dot.strip().endswith("}")
+    assert "n0" in dot
+    assert "n1" in dot
+    assert "n0 -> n1" in dot
+    assert "tokens)" in dot
+    assert "fillcolor=" in dot
+
+
 def test_tree_all_rules_use_tree(temp_dir):
     """Verify no rule uses context.plugins or context.skills directly."""
     import ast

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -1,0 +1,253 @@
+"""
+Tests for the lint tree data structure and tree builder.
+"""
+
+from pathlib import Path
+
+from skillsaw.lint_target import (
+    LintTarget,
+    ApmConfigNode,
+    ApmNode,
+    CodeRabbitNode,
+    MarketplaceConfigNode,
+    MarketplaceNode,
+    PluginNode,
+    SkillNode,
+)
+from skillsaw.context import RepositoryContext
+
+# --- LintTarget.walk() ---
+
+
+def test_walk_single_node():
+    root = LintTarget(path=Path("/root"))
+    nodes = list(root.walk())
+    assert len(nodes) == 1
+    assert nodes[0] is root
+
+
+def test_walk_flat_children():
+    root = LintTarget(path=Path("/root"))
+    a = LintTarget(path=Path("/a"))
+    b = LintTarget(path=Path("/b"))
+    root.children = [a, b]
+
+    nodes = list(root.walk())
+    assert len(nodes) == 3
+    assert nodes[0] is root
+    assert nodes[1] is a
+    assert nodes[2] is b
+
+
+def test_walk_nested():
+    root = LintTarget(path=Path("/root"))
+    plugin = PluginNode(path=Path("/plugin"))
+    skill = SkillNode(path=Path("/skill"))
+    plugin.children = [skill]
+    root.children = [plugin]
+
+    nodes = list(root.walk())
+    assert len(nodes) == 3
+    assert nodes[0] is root
+    assert nodes[1] is plugin
+    assert nodes[2] is skill
+
+
+# --- LintTarget.find() ---
+
+
+def test_find_by_type():
+    root = LintTarget(path=Path("/root"))
+    p1 = PluginNode(path=Path("/p1"))
+    p2 = PluginNode(path=Path("/p2"))
+    s1 = SkillNode(path=Path("/s1"))
+    p1.children = [s1]
+    root.children = [p1, p2]
+
+    plugins = root.find(PluginNode)
+    assert len(plugins) == 2
+    assert all(isinstance(p, PluginNode) for p in plugins)
+
+    skills = root.find(SkillNode)
+    assert len(skills) == 1
+    assert skills[0] is s1
+
+
+def test_find_returns_empty_when_no_match():
+    root = LintTarget(path=Path("/root"))
+    root.children = [PluginNode(path=Path("/p"))]
+    assert root.find(SkillNode) == []
+
+
+def test_find_polymorphic():
+    """find(LintTarget) returns all nodes regardless of subtype."""
+    root = LintTarget(path=Path("/root"))
+    root.children = [PluginNode(path=Path("/p")), SkillNode(path=Path("/s"))]
+    assert len(root.find(LintTarget)) == 3
+
+
+# --- LintTarget.find_parent() ---
+
+
+def test_find_parent_returns_nearest():
+    root = LintTarget(path=Path("/root"))
+    marketplace = MarketplaceNode(path=Path("/plugins"))
+    plugin = PluginNode(path=Path("/plugin"))
+    skill = SkillNode(path=Path("/skill"))
+    leaf = LintTarget(path=Path("/leaf"))
+
+    skill.children = [leaf]
+    plugin.children = [skill]
+    marketplace.children = [plugin]
+    root.children = [marketplace]
+
+    parent = root.find_parent(leaf, PluginNode)
+    assert parent is plugin
+
+    parent = root.find_parent(skill, PluginNode)
+    assert parent is plugin
+
+
+def test_find_parent_returns_none_when_no_match():
+    root = LintTarget(path=Path("/root"))
+    child = LintTarget(path=Path("/child"))
+    root.children = [child]
+
+    assert root.find_parent(child, PluginNode) is None
+
+
+def test_find_parent_skips_non_ancestors():
+    root = LintTarget(path=Path("/root"))
+    p1 = PluginNode(path=Path("/p1"))
+    p2 = PluginNode(path=Path("/p2"))
+    target = LintTarget(path=Path("/target"))
+    p2.children = [target]
+    root.children = [p1, p2]
+
+    parent = root.find_parent(target, PluginNode)
+    assert parent is p2
+
+
+# --- Tree labels ---
+
+
+def test_tree_labels():
+    assert LintTarget(path=Path("/foo")).tree_label() == "foo"
+    assert MarketplaceConfigNode(path=Path("/m.json")).tree_label() == "marketplace.json"
+    assert MarketplaceNode(path=Path("/plugins")).tree_label() == "plugins/ [marketplace]"
+    assert PluginNode(path=Path("/my-plugin")).tree_label() == "my-plugin/ [plugin]"
+    assert SkillNode(path=Path("/my-skill")).tree_label() == "my-skill/ [skill]"
+    assert ApmConfigNode(path=Path("/apm.yml")).tree_label() == "apm.yml"
+    assert ApmNode(path=Path("/.apm")).tree_label() == ".apm/"
+    assert CodeRabbitNode(path=Path("/.coderabbit.yaml")).tree_label() == ".coderabbit.yaml"
+
+
+# --- print_tree ---
+
+
+def test_print_tree_nested():
+    root = LintTarget(path=Path("/repo"))
+    plugin = PluginNode(path=Path("/repo/my-plugin"))
+    skill = SkillNode(path=Path("/repo/my-plugin/my-skill"))
+    plugin.children = [skill]
+    root.children = [plugin]
+
+    output = root.print_tree(root_path=Path("/repo"))
+    assert "repo/" in output
+    assert "my-plugin/ [plugin]" in output
+    assert "my-skill/ [skill]" in output
+
+
+# --- Tree builder integration ---
+
+
+def test_tree_contains_typed_nodes(temp_dir):
+    """A marketplace repo should produce typed tree nodes."""
+    claude_plugin = temp_dir / ".claude-plugin"
+    claude_plugin.mkdir()
+    (claude_plugin / "marketplace.json").write_text('{"name": "test", "plugins": []}')
+
+    plugins_dir = temp_dir / "plugins"
+    plugins_dir.mkdir()
+    plugin = plugins_dir / "my-plugin"
+    plugin.mkdir()
+    (plugin / "plugin.json").write_text('{"name": "my-plugin"}')
+    commands = plugin / "commands"
+    commands.mkdir()
+    (commands / "hello.md").write_text("## Description\nHello\n## Usage\n/hello\n")
+    skill_dir = plugin / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: Test\n---\n")
+
+    context = RepositoryContext(temp_dir)
+    tree = context.lint_tree
+
+    assert len(tree.find(MarketplaceConfigNode)) == 1
+    assert len(tree.find(MarketplaceNode)) == 1
+    assert len(tree.find(PluginNode)) == 1
+    assert len(tree.find(SkillNode)) == 1
+
+
+def test_tree_contains_apm_nodes(temp_dir):
+    """An APM repo should produce ApmConfigNode and ApmNode."""
+    (temp_dir / "apm.yml").write_text("name: test\nversion: 1.0.0\ndescription: Test\n")
+    apm_dir = temp_dir / ".apm"
+    apm_dir.mkdir()
+    instructions = apm_dir / "instructions"
+    instructions.mkdir()
+    (instructions / "coding.instructions.md").write_text("# Coding\nBe good.\n")
+
+    context = RepositoryContext(temp_dir)
+    tree = context.lint_tree
+
+    assert len(tree.find(ApmConfigNode)) == 1
+    assert tree.find(ApmConfigNode)[0].path.name == "apm.yml"
+    assert len(tree.find(ApmNode)) == 1
+
+
+def test_tree_contains_coderabbit_node(temp_dir):
+    """A repo with .coderabbit.yaml should produce a CodeRabbitNode."""
+    (temp_dir / ".coderabbit.yaml").write_text("reviews:\n  instructions: Be thorough\n")
+
+    context = RepositoryContext(temp_dir)
+    tree = context.lint_tree
+
+    assert len(tree.find(CodeRabbitNode)) == 1
+
+
+def test_content_blocks_returns_all_content(temp_dir):
+    """content_blocks() should return all ContentBlock subclasses polymorphically."""
+    (temp_dir / "CLAUDE.md").write_text("# Instructions\nBe helpful.\n")
+
+    context = RepositoryContext(temp_dir)
+    blocks = context.lint_tree.content_blocks()
+
+    assert len(blocks) >= 1
+    assert all(hasattr(b, "category") for b in blocks)
+
+
+def test_tree_all_rules_use_tree(temp_dir):
+    """Verify no rule uses context.plugins or context.skills directly."""
+    import ast
+    from pathlib import Path
+
+    rules_dir = Path("src/skillsaw/rules/builtin")
+    for py_file in sorted(rules_dir.glob("*.py")):
+        if py_file.name in ("__init__.py", "utils.py", "content_analysis.py"):
+            continue
+        source = py_file.read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                for method in ast.walk(node):
+                    if isinstance(method, ast.FunctionDef) and method.name == "check":
+                        method_src = ast.get_source_segment(source, method)
+                        if method_src:
+                            assert "context.plugins" not in method_src, (
+                                f"{py_file.name}:{node.name}.check() "
+                                f"uses context.plugins instead of tree"
+                            )
+                            assert "context.skills" not in method_src, (
+                                f"{py_file.name}:{node.name}.check() "
+                                f"uses context.skills instead of tree"
+                            )

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -16,7 +16,14 @@ from skillsaw.llm.tools import (
     ReplaceSectionTool,
     DiffTool,
     LintTool,
+    BlockState,
+    ReadBlockTool,
+    WriteBlockTool,
+    ReplaceBlockSectionTool,
+    DiffBlockTool,
+    LintBlockTool,
 )
+from skillsaw.rules.builtin.content_analysis import ContentBlock
 from skillsaw.rule import AutofixConfidence, Severity
 
 
@@ -765,3 +772,128 @@ class TestLintToolExceptionHandling:
         assert "Error running lint" in result
         assert "test/broken" in result
         assert "something went wrong" in result
+
+
+class TestBlockState:
+    def test_init_reads_body(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("hello world", encoding="utf-8")
+        block = ContentBlock(path=f, category="instruction")
+        state = BlockState(block)
+        assert state.body == "hello world"
+        assert state.original == "hello world"
+
+    def test_body_mutation_independent(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("original", encoding="utf-8")
+        block = ContentBlock(path=f, category="instruction")
+        state = BlockState(block)
+        state.body = "modified"
+        assert state.original == "original"
+
+
+class TestReadBlockTool:
+    def test_returns_body(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("content here", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = ReadBlockTool(state)
+        assert tool.execute() == "content here"
+
+    def test_returns_mutated_body(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("original", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        state.body = "modified"
+        tool = ReadBlockTool(state)
+        assert tool.execute() == "modified"
+
+    def test_tool_metadata(self):
+        assert ReadBlockTool.__dict__["name"] == "read_block"
+
+
+class TestWriteBlockTool:
+    def test_overwrites_body(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("old", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = WriteBlockTool(state)
+        result = tool.execute(content="new content")
+        assert "Updated block" in result
+        assert state.body == "new content"
+        assert state.original == "old"
+
+
+class TestReplaceBlockSectionTool:
+    def test_replace_unique(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("Hello world", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = ReplaceBlockSectionTool(state)
+        result = tool.execute(old_text="Hello", new_text="Goodbye")
+        assert "Replaced 1 occurrence" in result
+        assert state.body == "Goodbye world"
+
+    def test_not_found(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("Hello", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = ReplaceBlockSectionTool(state)
+        result = tool.execute(old_text="missing", new_text="x")
+        assert "Error: old_text not found" in result
+
+    def test_multiple_matches(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("aaa bbb aaa", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = ReplaceBlockSectionTool(state)
+        result = tool.execute(old_text="aaa", new_text="ccc")
+        assert "found 2 times" in result
+
+
+class TestDiffBlockTool:
+    def test_shows_diff(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("line 1\nline 2\n", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        state.body = "line 1\nmodified\n"
+        tool = DiffBlockTool(state)
+        result = tool.execute()
+        assert "-line 2" in result
+        assert "+modified" in result
+
+    def test_no_changes(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("unchanged\n", encoding="utf-8")
+        state = BlockState(ContentBlock(path=f, category="instruction"))
+        tool = DiffBlockTool(state)
+        assert tool.execute() == "No changes."
+
+
+class TestLintBlockTool:
+    def test_no_violations(self, tmp_path):
+        from skillsaw.config import LinterConfig
+
+        f = tmp_path / "CLAUDE.md"
+        (tmp_path / ".git").mkdir()
+        f.write_text("# Instructions\n\nUse precise language.\n", encoding="utf-8")
+        block = ContentBlock(path=f, category="claude-md")
+        state = BlockState(block)
+        config = LinterConfig.default()
+        tool = LintBlockTool(state, config, root=tmp_path)
+        result = tool.execute()
+        assert result == "No violations found."
+
+    def test_writes_body_to_disk(self, tmp_path):
+        from skillsaw.config import LinterConfig
+
+        f = tmp_path / "CLAUDE.md"
+        (tmp_path / ".git").mkdir()
+        f.write_text("original", encoding="utf-8")
+        block = ContentBlock(path=f, category="claude-md")
+        state = BlockState(block)
+        state.body = "updated content"
+        config = LinterConfig.default()
+        tool = LintBlockTool(state, config, root=tmp_path)
+        tool.execute()
+        assert f.read_text(encoding="utf-8") == "updated content"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -23,7 +23,7 @@ from skillsaw.llm.tools import (
     DiffBlockTool,
     LintBlockTool,
 )
-from skillsaw.rules.builtin.content_analysis import ContentBlock
+from skillsaw.rules.builtin.content_analysis import FileContentBlock as ContentBlock
 from skillsaw.rule import AutofixConfidence, Severity
 
 

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -554,7 +554,7 @@ class TestLLMFixNonExistentFile:
         assert len(readme_violations) >= 1, "Expected plugin-readme violation"
 
         readme_content = "# test-plugin\n\nA test plugin.\n"
-        provider = _fake_file_fix_provider(readme_content, path="README.md")
+        provider = _fake_fix_provider(readme_content)
 
         result = linter.llm_fix(provider)
         assert result.violations_before > 0
@@ -576,7 +576,7 @@ class TestLLMFixNonExistentFile:
         linter = Linter(context, config)
 
         readme_content = "# test-plugin\n\nA test plugin.\n"
-        provider = _fake_file_fix_provider(readme_content, path="README.md")
+        provider = _fake_fix_provider(readme_content)
 
         result = linter.llm_fix(provider, dry_run=True)
         # The file should NOT exist on disk after dry-run

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -47,7 +47,50 @@ def _make_dot_claude_repo(tmp_path, claude_md_content):
 
 
 def _fake_fix_provider(fixed_content, path="CLAUDE.md"):
-    """Build a FakeProvider that reads, writes fixed content, lints, and stops."""
+    """Build a FakeProvider that reads, writes fixed content, lints, and stops.
+
+    Uses block tools (read_block, write_block, lint_block) since content
+    violations now carry a ContentBlock reference and go through the
+    block-based fix pipeline.
+    """
+    return FakeProvider(
+        [
+            CompletionResult(
+                content=None,
+                tool_calls=[ToolCall(id="1", name="read_block", arguments={})],
+                usage=TokenUsage(100, 20),
+            ),
+            CompletionResult(
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="2",
+                        name="write_block",
+                        arguments={"content": fixed_content},
+                    )
+                ],
+                usage=TokenUsage(100, 50),
+            ),
+            CompletionResult(
+                content=None,
+                tool_calls=[ToolCall(id="3", name="lint_block", arguments={})],
+                usage=TokenUsage(100, 20),
+            ),
+            CompletionResult(
+                content="Fixed.",
+                tool_calls=[],
+                usage=TokenUsage(100, 20),
+            ),
+        ]
+    )
+
+
+def _fake_file_fix_provider(fixed_content, path="CLAUDE.md"):
+    """Build a FakeProvider using file-level tools (read_file, write_file, lint).
+
+    For violations without a ContentBlock (e.g. missing-file structural
+    violations) that go through the file-based fix pipeline.
+    """
     return FakeProvider(
         [
             CompletionResult(
@@ -511,7 +554,7 @@ class TestLLMFixNonExistentFile:
         assert len(readme_violations) >= 1, "Expected plugin-readme violation"
 
         readme_content = "# test-plugin\n\nA test plugin.\n"
-        provider = _fake_fix_provider(readme_content, path="README.md")
+        provider = _fake_file_fix_provider(readme_content, path="README.md")
 
         result = linter.llm_fix(provider)
         assert result.violations_before > 0
@@ -533,7 +576,7 @@ class TestLLMFixNonExistentFile:
         linter = Linter(context, config)
 
         readme_content = "# test-plugin\n\nA test plugin.\n"
-        provider = _fake_fix_provider(readme_content, path="README.md")
+        provider = _fake_file_fix_provider(readme_content, path="README.md")
 
         result = linter.llm_fix(provider, dry_run=True)
         # The file should NOT exist on disk after dry-run

--- a/tests/test_prompt_dogfood.py
+++ b/tests/test_prompt_dogfood.py
@@ -1,0 +1,73 @@
+"""Dogfood test: run content-quality rules against our own LLM fix prompts."""
+
+from pathlib import Path
+
+import pytest
+
+from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import LintTarget
+from skillsaw.rules.builtin import BUILTIN_RULES
+from skillsaw.rules.builtin.content_analysis import ExtraBlock
+from skillsaw.rules.builtin.content_rules import (
+    ContentWeakLanguageRule,
+    ContentTautologicalRule,
+    ContentNegativeOnlyRule,
+    ContentEmbeddedSecretsRule,
+    ContentBannedReferencesRule,
+)
+
+CONTENT_RULES = [
+    ContentWeakLanguageRule,
+    ContentTautologicalRule,
+    ContentNegativeOnlyRule,
+    ContentEmbeddedSecretsRule,
+    ContentBannedReferencesRule,
+]
+
+SKIP_SELF = {
+    "content-weak-language": {"content-weak-language"},
+    "content-tautological": {"content-tautological"},
+    "content-contradiction": {"content-tautological"},
+}
+
+
+def _make_context(prompt_text: str) -> RepositoryContext:
+    """Build a minimal RepositoryContext with a single ExtraBlock containing the prompt."""
+    fake_root = Path("/fake")
+    block = ExtraBlock(path=fake_root / "prompt.md", body=prompt_text)
+    root = LintTarget(path=fake_root, children=[block])
+    root.set_parents()
+    ctx = RepositoryContext.__new__(RepositoryContext)
+    ctx._root_path = fake_root
+    ctx._lint_tree = root
+    return ctx
+
+
+def _rules_with_prompts():
+    for rule_cls in BUILTIN_RULES:
+        rule = rule_cls()
+        prompt = rule.llm_fix_prompt
+        if prompt:
+            yield rule.rule_id, prompt
+
+
+@pytest.mark.parametrize(
+    "rule_id,prompt",
+    list(_rules_with_prompts()),
+    ids=[rid for rid, _ in _rules_with_prompts()],
+)
+def test_prompt_passes_content_rules(rule_id, prompt):
+    context = _make_context(prompt)
+    skip = SKIP_SELF.get(rule_id, set())
+
+    all_violations = []
+    for content_rule_cls in CONTENT_RULES:
+        content_rule = content_rule_cls()
+        if content_rule.rule_id in skip:
+            continue
+        violations = content_rule.check(context)
+        all_violations.extend(violations)
+
+    if all_violations:
+        report = "\n".join(f"  [{v.rule_id}] {v.message}" for v in all_violations)
+        pytest.fail(f"Prompt for rule '{rule_id}' has content violations:\n{report}")


### PR DESCRIPTION
## Summary

- Introduce **lint tree** — a polymorphic tree data structure that represents everything lintable in a repository
- `LintTarget` base class with `walk()`, `find()`, `content_blocks()` for tree traversal
- `PluginNode` / `SkillNode` typed markers for structural rules to discover via `tree.find(PluginNode)`
- `ContentBlock` becomes ABC with `FileContentBlock`, `FrontmatterContentBlock`, `CodeRabbitContentBlock` subclasses
- Each subclass encapsulates its format logic (`read_body()`, `write_body()`, `gather()`)
- `build_lint_tree()` replaces fragmented discovery — single source of truth
- `context.lint_tree` lazy property with `rebuild_lint_tree()` for invalidation during fix loops
- Unified fix pipeline: all fixes go through block tools, no separate file-level fix path
- Group violations by block identity (`__eq__`/`__hash__`), not `id()` or file path
- Fix double-offset bug in detectors (9 sites) — detectors now store body-relative line numbers
- Fix multi-block relint filtering with `v.block == block` instead of file path matching
- Add `skillsaw tree` subcommand to visualize the lint tree
- Design doc at `docs/designs/lint-tree.md`

## Test plan

- [x] `make test` — 1044 passed, 14 skipped
- [x] `make format` / `make lint` — clean
- [x] `make update` — regenerated docs
- [x] Test against `openshift-eng/ai-helpers` — exit 0
- [x] `skillsaw tree` displays correct tree structure
- [ ] CI passes
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to display the repository lint tree and discovered content blocks.
  * LLM autofix gains block-scoped edit tools for targeted, re-linted fixes.

* **Improvements**
  * Introduced a content-block model for more accurate body reading, line mapping, and round-trip edits.
  * Formatter outputs (text/HTML/JSON/SARIF) now report file-mapped line numbers.

* **Tests**
  * Expanded tests covering lint-tree, content-block read/write, coderabbit round-trips, and LLM block tools.

* **Documentation**
  * New design doc and README updates describing the lint tree.

* **Chores**
  * Package/version metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->