### PR TITLE
Report line numbers for frontmatter YAML parse errors

### DIFF
--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -53,7 +53,7 @@ class AgentFrontmatterRule(Rule):
         for block in context.lint_tree.find(AgentBlock):
             if block.frontmatter_error:
                 violations.append(
-                    self.violation(block.frontmatter_error, file_path=block.path, block=block)
+                    self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line, block=block)
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -53,7 +53,12 @@ class AgentFrontmatterRule(Rule):
         for block in context.lint_tree.find(AgentBlock):
             if block.frontmatter_error:
                 violations.append(
-                    self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line, block=block)
+                    self.violation(
+                        block.frontmatter_error,
+                        file_path=block.path,
+                        line=block.frontmatter_error_line,
+                        block=block,
+                    )
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -108,7 +108,7 @@ class AgentSkillValidRule(Rule):
 
             block = blocks[0]
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line))
                 continue
 
             frontmatter = block.frontmatter

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -165,20 +165,30 @@ class AgentSkillValidRule(Rule):
 
             if "license" in frontmatter and not isinstance(frontmatter["license"], str):
                 violations.append(
-                    self.violation("'license' must be a string", file_path=block.path)
+                    self.violation(
+                        "'license' must be a string",
+                        file_path=block.path,
+                        line=block.key_line("license"),
+                    )
                 )
 
             if "compatibility" in frontmatter:
                 compat = frontmatter["compatibility"]
+                compat_line = block.key_line("compatibility")
                 if not isinstance(compat, str):
                     violations.append(
-                        self.violation("'compatibility' must be a string", file_path=block.path)
+                        self.violation(
+                            "'compatibility' must be a string",
+                            file_path=block.path,
+                            line=compat_line,
+                        )
                     )
                 elif not compat.strip():
                     violations.append(
                         self.violation(
                             "'compatibility' must not be empty if provided",
                             file_path=block.path,
+                            line=compat_line,
                         )
                     )
                 elif len(compat) > COMPATIBILITY_MAX_LENGTH:
@@ -186,14 +196,20 @@ class AgentSkillValidRule(Rule):
                         self.violation(
                             f"'compatibility' exceeds {COMPATIBILITY_MAX_LENGTH} characters ({len(compat)})",
                             file_path=block.path,
+                            line=compat_line,
                         )
                     )
 
             if "metadata" in frontmatter:
                 meta = frontmatter["metadata"]
+                meta_line = block.key_line("metadata")
                 if not isinstance(meta, dict):
                     violations.append(
-                        self.violation("'metadata' must be a mapping", file_path=block.path)
+                        self.violation(
+                            "'metadata' must be a mapping",
+                            file_path=block.path,
+                            line=meta_line,
+                        )
                     )
                 else:
                     for k, v in meta.items():
@@ -202,17 +218,20 @@ class AgentSkillValidRule(Rule):
                                 self.violation(
                                     f"'metadata' key {k!r} must be a string",
                                     file_path=block.path,
+                                    line=meta_line,
                                 )
                             )
 
             if "allowed-tools" in frontmatter:
                 at = frontmatter["allowed-tools"]
+                at_line = block.key_line("allowed-tools")
                 if isinstance(at, list):
                     if not all(isinstance(item, str) for item in at):
                         violations.append(
                             self.violation(
                                 "'allowed-tools' list items must all be strings",
                                 file_path=block.path,
+                                line=at_line,
                             )
                         )
                 elif not isinstance(at, str):
@@ -220,6 +239,7 @@ class AgentSkillValidRule(Rule):
                         self.violation(
                             "'allowed-tools' must be a string or list of strings",
                             file_path=block.path,
+                            line=at_line,
                         )
                     )
 

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -108,7 +108,13 @@ class AgentSkillValidRule(Rule):
 
             block = blocks[0]
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line))
+                violations.append(
+                    self.violation(
+                        block.frontmatter_error,
+                        file_path=block.path,
+                        line=block.frontmatter_error_line,
+                    )
+                )
                 continue
 
             frontmatter = block.frontmatter

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -111,7 +111,7 @@ class CommandFrontmatterRule(Rule):
 
         for block in context.lint_tree.find(CommandBlock):
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path))
+                violations.append(self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line))
                 continue
 
             if block.frontmatter is None:

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -111,7 +111,13 @@ class CommandFrontmatterRule(Rule):
 
         for block in context.lint_tree.find(CommandBlock):
             if block.frontmatter_error:
-                violations.append(self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line))
+                violations.append(
+                    self.violation(
+                        block.frontmatter_error,
+                        file_path=block.path,
+                        line=block.frontmatter_error_line,
+                    )
+                )
                 continue
 
             if block.frontmatter is None:

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -544,8 +544,8 @@ def _parse_file_frontmatter(
 class ParsedFrontmatterBlock(FileContentBlock):
     """File content block with lazy-parsed YAML frontmatter."""
 
-    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]] = field(
-        default=None, init=False, repr=False
+    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]] = (
+        field(default=None, init=False, repr=False)
     )
 
     def _ensure_parsed(self) -> None:

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -251,7 +251,7 @@ class FrontmatterContentBlock(ContentBlock):
             content = read_text(self.path)
             if content is None:
                 return None
-            _, body = parse_frontmatter(content)
+            _, body, _ = parse_frontmatter(content)
         if strip_code_blocks:
             body = _strip_fenced_code_blocks(body)
         return body
@@ -259,7 +259,7 @@ class FrontmatterContentBlock(ContentBlock):
     def write_body(self, new_body: str) -> None:
         content = read_text(self.path)
         if content:
-            front, _ = parse_frontmatter(content)
+            front, _, _ = parse_frontmatter(content)
             if front:
                 self.path.write_text(front + "\n---\n" + new_body, encoding="utf-8")
                 return
@@ -270,7 +270,7 @@ class FrontmatterContentBlock(ContentBlock):
         content = read_text(self.path)
         if not content:
             return 0
-        front, _ = parse_frontmatter(content)
+        front, _, _ = parse_frontmatter(content)
         if not front:
             return 0
         return front.count("\n") + 2  # frontmatter + closing ---
@@ -524,27 +524,27 @@ class CursorRuleBlock(FrontmatterContentBlock):
 
 def _parse_file_frontmatter(
     path: Path,
-) -> Tuple[Optional[Dict[str, Any]], Optional[str], str]:
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]:
     """Parse YAML frontmatter from a markdown file.
 
-    Returns (frontmatter_dict, error_string, body_after_frontmatter).
+    Returns (frontmatter_dict, error_string, error_line, body_after_frontmatter).
     """
     content = read_text(path)
     if content is None:
-        return None, f"Failed to read file: {path}", ""
+        return None, f"Failed to read file: {path}", None, ""
     if not content.startswith("---"):
-        return None, None, content
-    fm, body = parse_frontmatter(content)
+        return None, None, None, content
+    fm, body, error_line = parse_frontmatter(content)
     if fm is None:
-        return None, "Invalid frontmatter (malformed YAML or missing closing ---)", body
-    return fm, None, body
+        return None, "Invalid frontmatter (malformed YAML or missing closing ---)", error_line, body
+    return fm, None, None, body
 
 
 @dataclass(eq=False)
 class ParsedFrontmatterBlock(FileContentBlock):
     """File content block with lazy-parsed YAML frontmatter."""
 
-    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], str]] = field(
+    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]] = field(
         default=None, init=False, repr=False
     )
 
@@ -563,9 +563,14 @@ class ParsedFrontmatterBlock(FileContentBlock):
         return self._fm_parsed[1]
 
     @property
-    def body_text(self) -> str:
+    def frontmatter_error_line(self) -> Optional[int]:
         self._ensure_parsed()
         return self._fm_parsed[2]
+
+    @property
+    def body_text(self) -> str:
+        self._ensure_parsed()
+        return self._fm_parsed[3]
 
     def key_line(self, key: str) -> Optional[int]:
         return _frontmatter_key_line(self.path, key)

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -60,7 +60,7 @@ class SkillFrontmatterRule(Rule):
             block = blocks[0]
             if block.frontmatter_error:
                 violations.append(
-                    self.violation(block.frontmatter_error, file_path=block.path, block=block)
+                    self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line, block=block)
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -60,7 +60,12 @@ class SkillFrontmatterRule(Rule):
             block = blocks[0]
             if block.frontmatter_error:
                 violations.append(
-                    self.violation(block.frontmatter_error, file_path=block.path, line=block.frontmatter_error_line, block=block)
+                    self.violation(
+                        block.frontmatter_error,
+                        file_path=block.path,
+                        line=block.frontmatter_error_line,
+                        block=block,
+                    )
                 )
                 continue
 

--- a/src/skillsaw/rules/builtin/utils.py
+++ b/src/skillsaw/rules/builtin/utils.py
@@ -178,23 +178,27 @@ def frontmatter_key_line(file_path: Path, key: str) -> Optional[int]:
 _FRONTMATTER_RE = re.compile(r"^---[ \t]*\n(.*?\n)---[ \t]*\n?", re.DOTALL)
 
 
-def parse_frontmatter(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
+def parse_frontmatter(content: str) -> Tuple[Optional[Dict[str, Any]], str, Optional[int]]:
     """Parse YAML frontmatter from markdown content.
 
-    Returns (frontmatter_dict, body_after_frontmatter).
-    If no valid frontmatter is found, returns (None, original_content).
+    Returns (frontmatter_dict, body_after_frontmatter, error_line).
+    ``error_line`` is set (1-indexed, relative to file) only on YAML parse errors.
+    If no valid frontmatter is found, returns (None, original_content, error_line).
     """
     m = _FRONTMATTER_RE.match(content)
     if not m:
-        return None, content
+        return None, content, None
     try:
         data = yaml.safe_load(m.group(1))
-    except yaml.YAMLError:
-        return None, content
+    except yaml.YAMLError as e:
+        error_line = None
+        if hasattr(e, "problem_mark") and e.problem_mark is not None:
+            error_line = e.problem_mark.line + 2  # +1 for 0-indexed, +1 for opening ---
+        return None, content, error_line
     if not isinstance(data, dict):
-        return None, content
+        return None, content, None
     body = content[m.end() :]
-    return data, body
+    return data, body, None
 
 
 def extract_section(content: str, heading: str, level: int = 2) -> str:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -22,6 +22,7 @@ from skillsaw.rules.builtin.marketplace import (
     MarketplaceJsonValidRule,
     MarketplaceRegistrationRule,
 )
+from skillsaw.rules.builtin.skills import SkillFrontmatterRule
 
 
 def test_plugin_json_required_passes(valid_plugin):
@@ -556,3 +557,26 @@ def test_valid_severity_override():
     """Test that a valid severity string overrides the default"""
     rule = PluginJsonRequiredRule({"severity": "warning"})
     assert rule.severity == Severity.WARNING
+
+
+def test_skill_frontmatter_malformed_yaml_reports_line(temp_dir):
+    """Malformed YAML frontmatter should report the error line number."""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text(
+        '{"name": "test-plugin", "description": "test", "version": "1.0"}'
+    )
+    skills_dir = plugin_dir / "skills" / "bad-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text(
+        "---\nname: bad\ndescription: test\nbad: [unclosed\n---\n# Body\n"
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = SkillFrontmatterRule()
+    violations = rule.check(context)
+    fm_violations = [v for v in violations if "Invalid frontmatter" in v.message]
+    assert len(fm_violations) == 1
+    assert fm_violations[0].line is not None
+    assert fm_violations[0].line == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from skillsaw.rules.builtin.utils import (
     read_json,
     frontmatter_key_line,
     heading_line,
+    parse_frontmatter,
     yaml_key_line,
     yaml_key_lines,
     yaml_line_map,
@@ -354,3 +355,27 @@ def test_yaml_key_line_flow_mapping():
     text = "metadata: {version: '1.0', author: test}\nname: foo\n"
     assert yaml_key_line(text, "name", top_level=True) == 2
     assert yaml_key_line(text, "metadata", top_level=True) == 1
+
+
+def test_parse_frontmatter_valid():
+    content = "---\nname: test\ndescription: hello\n---\n# Body\n"
+    fm, body, error_line = parse_frontmatter(content)
+    assert fm == {"name": "test", "description": "hello"}
+    assert "# Body" in body
+    assert error_line is None
+
+
+def test_parse_frontmatter_malformed_yaml_reports_error_line():
+    content = "---\nname: test\nversion: 1.0\nbad_yaml: [unclosed\n---\n"
+    fm, body, error_line = parse_frontmatter(content)
+    assert fm is None
+    assert error_line is not None
+    assert error_line == 5  # --- closing line where parser fails
+
+
+def test_parse_frontmatter_no_frontmatter():
+    content = "# Just a heading\nSome text\n"
+    fm, body, error_line = parse_frontmatter(content)
+    assert fm is None
+    assert error_line is None
+    assert body == content


### PR DESCRIPTION
## Summary
- Extract the error line from `yaml.YAMLError.problem_mark` and propagate it through `parse_frontmatter` → `_parse_file_frontmatter` → `ParsedFrontmatterBlock.frontmatter_error_line`
- All rules that report frontmatter errors (skills, agents, agentskills, commands) now pass the line number
- Before: `SKILL.md: Invalid frontmatter...` — After: `SKILL.md:8: Invalid frontmatter...`

## Silly goose notes
1. Originally pushed directly to main. Reverted in 0a14e57 and re-submitted properly as a PR.
2. Originally submitted without tests. Also a silly goose move.

## Test plan
- [x] All existing tests pass
- [x] New `test_parse_frontmatter_*` tests verify error line extraction at the utility level
- [x] New `test_skill_frontmatter_malformed_yaml_reports_line` verifies end-to-end from rule to violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frontmatter validation now reports exact line numbers for errors across agents, skills, and commands, improving error localization.
  * Parser now captures and reports the frontmatter error line for malformed YAML, and handles absent/invalid frontmatter more consistently.

* **Tests**
  * Added unit tests confirming frontmatter parsing behaviors (valid, malformed, absent) and that malformed frontmatter yields a reported line number.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/142)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->