### PR TITLE
Remove stale hook references from .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,2 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/skillsaw/pre-commit.sh",
-            "if": "Bash(git commit*)"
-          }
-        ],
-        "_apm_source": "skillsaw"
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/skillsaw/pre-push.sh",
-            "if": "Bash(git push*--force*)"
-          }
-        ],
-        "_apm_source": "skillsaw"
-      }
-    ]
-  }
 }


### PR DESCRIPTION
## Summary
- Removes PreToolUse hook entries referencing `.claude/hooks/skillsaw/pre-commit.sh` and `pre-push.sh` which don't exist
- These stale references cause errors on every Claude Code tool invocation

## Test plan
- [x] Verify `.claude/settings.json` no longer references nonexistent hook scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)