### PR TITLE
feat: add rule descriptions and config options to generated config

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -110,10 +110,10 @@ rules:
     enabled: false
     severity: warning
     # allowed_dirs:
-    #     - assets
-    #     - evals
-    #     - references
-    #     - scripts
+    #   - assets
+    #   - evals
+    #   - references
+    #   - scripts
 
   # Require evals/evals.json for each skill (opt-in)
   agentskill-evals-required:
@@ -145,36 +145,36 @@ rules:
     enabled: auto
     severity: warning
     # limits:
-    #     agents-md:
-    #       warn: 6000
-    #       error: 12000
-    #     claude-md:
-    #       warn: 6000
-    #       error: 12000
-    #     gemini-md:
-    #       warn: 6000
-    #       error: 12000
-    #     instruction:
-    #       warn: 4000
-    #       error: 8000
-    #     skill:
-    #       warn: 3000
-    #       error: 6000
-    #     command:
-    #       warn: 2000
-    #       error: 4000
-    #     agent:
-    #       warn: 2000
-    #       error: 4000
-    #     rule:
-    #       warn: 2000
-    #       error: 4000
-    #     skill-description:
-    #       warn: 200
-    #       error: 500
-    #     command-description:
-    #       warn: 200
-    #       error: 500
+    #   agents-md:
+    #     warn: 6000
+    #     error: 12000
+    #   claude-md:
+    #     warn: 6000
+    #     error: 12000
+    #   gemini-md:
+    #     warn: 6000
+    #     error: 12000
+    #   instruction:
+    #     warn: 4000
+    #     error: 8000
+    #   skill:
+    #     warn: 3000
+    #     error: 6000
+    #   command:
+    #     warn: 2000
+    #     error: 4000
+    #   agent:
+    #     warn: 2000
+    #     error: 4000
+    #   rule:
+    #     warn: 2000
+    #     error: 4000
+    #   skill-description:
+    #     warn: 200
+    #     error: 500
+    #   command-description:
+    #     warn: 200
+    #     error: 500
 
   # Detect hedging, vague, and non-actionable language in instruction files
   content-weak-language:

--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.8.2"
+version: "0.8.3"
 
 rules:
 
@@ -83,6 +83,7 @@ rules:
   mcp-prohibited:
     enabled: false
     severity: error
+    # allowlist: []
 
   # .claude/rules/ files must be markdown with valid optional paths frontmatter
   rules-valid:
@@ -108,6 +109,11 @@ rules:
   agentskill-structure:
     enabled: false
     severity: warning
+    # allowed_dirs:
+    #     - assets
+    #     - evals
+    #     - references
+    #     - scripts
 
   # Require evals/evals.json for each skill (opt-in)
   agentskill-evals-required:
@@ -138,6 +144,37 @@ rules:
   context-budget:
     enabled: auto
     severity: warning
+    # limits:
+    #     agents-md:
+    #       warn: 6000
+    #       error: 12000
+    #     claude-md:
+    #       warn: 6000
+    #       error: 12000
+    #     gemini-md:
+    #       warn: 6000
+    #       error: 12000
+    #     instruction:
+    #       warn: 4000
+    #       error: 8000
+    #     skill:
+    #       warn: 3000
+    #       error: 6000
+    #     command:
+    #       warn: 2000
+    #       error: 4000
+    #     agent:
+    #       warn: 2000
+    #       error: 4000
+    #     rule:
+    #       warn: 2000
+    #       error: 4000
+    #     skill-description:
+    #       warn: 200
+    #       error: 500
+    #     command-description:
+    #       warn: 200
+    #       error: 500
 
   # Detect hedging, vague, and non-actionable language in instruction files
   content-weak-language:
@@ -174,6 +211,7 @@ rules:
   content-section-length:
     enabled: auto
     severity: info
+    # max-tokens: 500
 
   # Detect likely contradictions within instruction files using keyword-pair heuristics
   content-contradiction:
@@ -204,6 +242,8 @@ rules:
   content-banned-references:
     enabled: auto
     severity: warning
+    # banned: []
+    # skip-builtins: false
 
   # Detect inconsistent terminology across instruction files (e.g., mixing 'directory' and 'folder')
   content-inconsistent-terminology:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.8.2"
+version = "0.8.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -317,13 +317,16 @@ class LinterConfig:
         return d
 
     def save(self, config_path: Path):
-        """Save configuration to file with rule descriptions as comments"""
+        """Save configuration to file with rule descriptions and config options as comments"""
         from .rules.builtin import BUILTIN_RULES
 
         descriptions = {}
+        schemas = {}
         for rule_class in BUILTIN_RULES:
             rule = rule_class()
             descriptions[rule.rule_id] = rule.description
+            if rule.config_schema:
+                schemas[rule.rule_id] = rule.config_schema
 
         with open(config_path, "w") as f:
             f.write("# skillsaw configuration\n")
@@ -342,6 +345,20 @@ class LinterConfig:
                         f.write(f"    {key}:{yaml_val}\n")
                     else:
                         f.write(f"    {key}: {yaml_val}\n")
+                # Write commented-out config_schema options not already in config
+                schema = schemas.get(rule_id, {})
+                for param_name, param_info in schema.items():
+                    if param_name not in rule_config:
+                        default = param_info.get("default")
+                        yaml_val = self._yaml_value(default)
+                        if yaml_val.startswith("\n"):
+                            # Multi-line value: comment out each line
+                            lines = yaml_val.lstrip("\n").split("\n")
+                            f.write(f"    # {param_name}:\n")
+                            for line in lines:
+                                f.write(f"    # {line}\n")
+                        else:
+                            f.write(f"    # {param_name}: {yaml_val}\n")
 
             f.write("\n# Load custom rules from these files\n")
             f.write(f"custom-rules: {self._yaml_value(self.custom_rules)}\n")

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -350,7 +350,7 @@ class LinterConfig:
                 for param_name, param_info in schema.items():
                     if param_name not in rule_config:
                         default = param_info.get("default")
-                        yaml_val = self._yaml_value(default)
+                        yaml_val = self._yaml_value(default, indent=2)
                         if yaml_val.startswith("\n"):
                             # Multi-line value: comment out each line
                             lines = yaml_val.lstrip("\n").split("\n")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -813,7 +813,10 @@ def test_save_no_schema_comments_for_rules_without_schema(tmp_path):
     # but NOT a commented-out config_schema parameter
     for j in range(plugin_naming_idx + 1, len(lines)):
         line = lines[j].strip()
-        if not line or line.startswith("# ") or not line.startswith("#"):
+        if not line or not line.startswith("#"):
+            break
+        # A comment without ":" is a description comment, not a config key
+        if line.startswith("# ") and ":" not in line:
             break
         # Should not reach a commented-out param like "# some-key: value"
         assert False, f"Unexpected commented-out config option for plugin-naming: {line}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -734,3 +734,119 @@ def test_severity_override_on_auto_rule_still_fires_when_matching(marketplace_re
         config.is_rule_enabled("marketplace-registration", context, {RepositoryType.MARKETPLACE})
         is True
     )
+
+
+# --- Generated config documentation tests ---
+
+
+def test_save_includes_description_comments(tmp_path):
+    """Test that save() writes description comments for each rule"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+
+    # Check a few known rule descriptions appear as comments
+    assert "# Plugin must have .claude-plugin/plugin.json" in content
+    assert "# SKILL.md files should have frontmatter with name and description" in content
+    assert "# Detect potential API keys, tokens, and passwords in instruction files" in content
+
+
+def test_save_includes_config_schema_as_comments(tmp_path):
+    """Test that save() writes config_schema options as commented-out lines"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+
+    # content-banned-references has config_schema with 'banned' and 'skip-builtins'
+    # These should appear as commented-out options since they are not in the default config
+    assert "    # banned: []\n" in content
+    assert "    # skip-builtins: false\n" in content
+
+    # mcp-prohibited has 'allowlist' in config_schema
+    assert "    # allowlist: []\n" in content
+
+
+def test_save_does_not_duplicate_existing_config_keys(tmp_path):
+    """Config keys already in the rule config should not also appear as comments"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+
+    # content-critical-position already has min-lines: 50 in its default config.
+    # It should NOT also appear as a commented-out option.
+    assert "    min-lines: 50\n" in content
+    assert "    # min-lines:" not in content
+
+    # plugin-json-valid already has recommended-fields in its default config
+    assert "    # recommended-fields:" not in content
+
+
+def test_save_no_schema_comments_for_rules_without_schema(tmp_path):
+    """Rules without config_schema should only get a description comment"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+    lines = content.split("\n")
+
+    # Find the plugin-naming rule block (has no config_schema)
+    plugin_naming_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "plugin-naming:":
+            plugin_naming_idx = i
+            break
+
+    assert plugin_naming_idx is not None, "plugin-naming rule not found in output"
+
+    # The line before should be a description comment
+    assert lines[plugin_naming_idx - 1].strip().startswith("# Plugin names should")
+
+    # The lines after should be the config keys (enabled, severity) and then
+    # either a blank line, another description comment, or the next rule --
+    # but NOT a commented-out config_schema parameter
+    for j in range(plugin_naming_idx + 1, len(lines)):
+        line = lines[j].strip()
+        if not line or line.startswith("# ") or not line.startswith("#"):
+            break
+        # Should not reach a commented-out param like "# some-key: value"
+        assert False, f"Unexpected commented-out config option for plugin-naming: {line}"
+
+
+def test_save_with_config_schema_is_valid_yaml(tmp_path):
+    """The generated config with schema comments must still be valid YAML"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+    parsed = yaml.safe_load(content)
+    assert parsed is not None
+    assert "rules" in parsed
+
+    # Commented-out lines should not affect YAML parsing
+    assert "content-banned-references" in parsed["rules"]
+    assert "mcp-prohibited" in parsed["rules"]
+
+
+def test_save_multiline_schema_defaults_commented(tmp_path):
+    """Config schema options with complex defaults should have each line commented"""
+    config = LinterConfig.for_init()
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+
+    content = config_path.read_text()
+
+    # context-budget has a 'limits' config_schema with a complex dict default.
+    # Each line of the multi-line value should be commented out.
+    assert "    # limits:\n" in content
+
+    # The file should still be valid YAML (multi-line comments don't break parsing)
+    parsed = yaml.safe_load(content)
+    assert parsed is not None


### PR DESCRIPTION
## Summary
- Generated `.skillsaw.yaml` now includes commented-out configuration options for rules that declare `config_schema`, showing parameter names and their defaults
- Rules with parameters already in the active config do not get duplicate commented-out entries
- Multi-line defaults (e.g. nested dicts for `context-budget` limits) are properly commented out line-by-line

Makes the generated config self-documenting so users can discover and customize rule parameters without consulting external docs.

## Test plan
- [x] Tests for description comments in generated config
- [x] Tests for config_schema parameters as commented-out options
- [x] Tests for rules without config_schema (no spurious comments)
- [x] Tests that existing config keys are not duplicated as comments
- [x] Tests that multi-line defaults are properly commented
- [x] Tests that output is valid YAML
- [x] `make test` passes (1100 passed)
- [x] `make lint` passes
- [x] Tested against `openshift-eng/ai-helpers` (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated config/template now includes commented example settings for rules (allowlists, allowed directories, token-limit thresholds, content-length limits, banned patterns, and skip-builtins) to make discovery and customization easier.

* **Chores**
  * Bumped project/package version to 0.8.3.

* **Tests**
  * Added unit tests validating saved config formatting, inclusion/omission of commented schema options, and YAML validity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/150)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->