### PR TITLE
feat: add broken-reference, unlinked-reference, and placeholder-text rules

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.8.2"
+version: "0.8.3"
 
 rules:
 
@@ -209,6 +209,21 @@ rules:
   content-inconsistent-terminology:
     enabled: auto
     severity: info
+
+  # Detect markdown links where the target file does not exist
+  content-broken-internal-reference:
+    enabled: auto
+    severity: warning
+
+  # Detect bare path-like strings not wrapped in markdown link syntax
+  content-unlinked-internal-reference:
+    enabled: auto
+    severity: info
+
+  # Detect TODO markers, bracket placeholders, and unfilled template text
+  content-placeholder-text:
+    enabled: auto
+    severity: warning
 
   # .coderabbit.yaml must be valid YAML
   coderabbit-yaml-valid:

--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.8.3"
+version: "0.9.0"
 
 rules:
 
@@ -259,6 +259,9 @@ rules:
   content-unlinked-internal-reference:
     enabled: auto
     severity: info
+    # patterns:
+    #   - ./**/*.*
+    #   - references/**/*.md
 
   # Detect TODO markers, bracket placeholders, and unfilled template text
   content-placeholder-text:

--- a/README.md
+++ b/README.md
@@ -517,6 +517,9 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 | `content-embedded-secrets` | Detect potential API keys, tokens, and passwords in instruction files | error (auto) | llm |
 | `content-banned-references` | Detect banned or deprecated model names, APIs, and custom patterns | warning (auto) | llm |
 | `content-inconsistent-terminology` | Detect inconsistent terminology across instruction files (e.g., mixing 'directory' and 'folder') | info (auto) | llm |
+| `content-broken-internal-reference` | Detect markdown links where the target file does not exist | warning (auto) | - |
+| `content-unlinked-internal-reference` | Detect bare path-like strings not wrapped in markdown link syntax | info (auto) | - |
+| `content-placeholder-text` | Detect TODO markers, bracket placeholders, and unfilled template text | warning (auto) | - |
 
 **`content-critical-position` parameters:**
 
@@ -536,6 +539,12 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 |-----------|-------------|---------|
 | `banned` | Additional banned patterns as list of {pattern, message} dicts | `[]` |
 | `skip-builtins` | Disable built-in deprecated model/API checks | `false` |
+
+**`content-unlinked-internal-reference` parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `patterns` | Glob patterns for path-like strings to flag when unlinked | `["./**/*.*", "references/**/*.md"]` |
 
 ### CodeRabbit
 

--- a/README.md
+++ b/README.md
@@ -578,8 +578,8 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 | `content-embedded-secrets` | Detect potential API keys, tokens, and passwords in instruction files | error (auto) | llm |
 | `content-banned-references` | Detect banned or deprecated model names, APIs, and custom patterns | warning (auto) | llm |
 | `content-inconsistent-terminology` | Detect inconsistent terminology across instruction files (e.g., mixing 'directory' and 'folder') | info (auto) | llm |
-| `content-broken-internal-reference` | Detect markdown links where the target file does not exist | warning (auto) | - |
-| `content-unlinked-internal-reference` | Detect bare path-like strings not wrapped in markdown link syntax | info (auto) | - |
+| `content-broken-internal-reference` | Detect markdown links where the target file does not exist | warning (auto) | auto |
+| `content-unlinked-internal-reference` | Detect bare path-like strings not wrapped in markdown link syntax | info (auto) | auto |
 | `content-placeholder-text` | Detect TODO markers, bracket placeholders, and unfilled template text | warning (auto) | - |
 
 **`content-critical-position` parameters:**

--- a/docs/designs/content-rules-research.md
+++ b/docs/designs/content-rules-research.md
@@ -25,6 +25,9 @@ This document explains **why each rule exists**, and what research supports it.
 - [content-embedded-secrets](#content-embedded-secrets)
 - [content-banned-references](#content-banned-references)
 - [content-inconsistent-terminology](#content-inconsistent-terminology)
+- [content-broken-internal-reference](#content-broken-internal-reference)
+- [content-unlinked-internal-reference](#content-unlinked-internal-reference)
+- [content-placeholder-text](#content-placeholder-text)
 - [Instruction Budget vs. Context Budget](#instruction-budget-vs-context-budget)
 - [Key Papers (Cross-Cutting)](#key-papers-cross-cutting)
 
@@ -445,6 +448,105 @@ two different terms refer to the same concept from broader context.
 
 ---
 
+## content-broken-internal-reference
+
+**Detects markdown links pointing to files that do not exist** (e.g.,
+`[setup guide](docs/setup.md)` when `docs/setup.md` has been deleted or
+renamed).
+
+Broken internal links are a standard software engineering defect — dead
+references that mislead both human readers and AI agents. When an LLM
+encounters a broken link in an instruction file, it cannot follow the reference
+to gather the intended context. Worse, the LLM may hallucinate the contents of
+the missing file based on the link text, producing confidently wrong output
+grounded in a nonexistent source.
+
+This is the same class of defect that link checkers catch in documentation
+sites and wikis. The difference is that instruction files for AI agents are
+*executable context* — a broken link doesn't just frustrate a reader, it
+removes a dependency from the agent's decision-making chain.
+
+The rule constrains resolved paths to the repository root to avoid
+environment-dependent results from `../` traversal, and skips files inside
+template directories where placeholder links are expected.
+
+**References:**
+
+- [W3C: Link Checking](https://www.w3.org/QA/Tools/) — Broken links are a
+  recognized web quality defect; the same principle applies to interlinked
+  instruction files
+- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
+  — "Don't force readers to backtrack because a link doesn't work"
+- [Anthropic: Effective Context
+  Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+  — Context that references missing information degrades agent performance
+
+---
+
+## content-unlinked-internal-reference
+
+**Detects bare path-like strings that are not wrapped in markdown link syntax**
+(e.g., `src/config.yaml` mentioned in prose but not linked as
+`[src/config.yaml](src/config.yaml)`).
+
+Bare path references are a maintenance hazard. When a path is mentioned in
+prose without link syntax, there is no tooling (including
+`content-broken-internal-reference`) that can verify the referenced file still
+exists. The path silently rots as the repository evolves.
+
+Wrapping paths in link syntax provides two benefits: (1) link checkers and
+linters can detect when the target is renamed or deleted, and (2) in rendered
+markdown environments (GitHub, IDEs), the reference becomes navigable. Both
+benefits improve the reliability of instruction files as executable context.
+
+The rule is configurable via `patterns` — a list of glob patterns that control
+which path-like strings are flagged. This avoids false positives on paths that
+are illustrative examples rather than real file references.
+
+**References:**
+
+- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
+  — "Use meaningful link text" — paths mentioned without links are
+  un-navigable and un-verifiable
+- [Microsoft Writing Style Guide: Links](https://learn.microsoft.com/en-us/style-guide/urls-web-addresses)
+  — Bare URLs and paths should be formatted as actionable links
+
+---
+
+## content-placeholder-text
+
+**Detects TODO markers, bracket placeholders, and unfilled template text** in
+instruction files (e.g., `TODO`, `FIXME`, `[Insert API key here]`, `*TBD*`).
+
+Placeholder text in committed instruction files is unfinished work that the
+agent treats as real context. An LLM cannot distinguish between a deliberate
+instruction and an unfilled template — it processes `[Insert your API endpoint
+here]` as a literal instruction, potentially generating code that references a
+nonexistent endpoint or asking the user to fill in information that should
+already be present.
+
+This is standard software engineering hygiene applied to a new file type.
+`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-
+comments`, SonarQube's "Track uses of 'TODO' tags") for decades because they
+indicate incomplete implementation. The same principle applies to instruction
+files: if the content isn't ready, it shouldn't be in the agent's context.
+
+**References:**
+
+- [ESLint: no-warning-comments](https://eslint.org/docs/latest/rules/no-warning-comments)
+  — Tracks TODO/FIXME as code quality signals; the same pattern applies to
+  instruction files
+- [SonarSource: Track uses of "TODO"
+  tags](https://rules.sonarsource.com/python/RSPEC-1135/) — "TODO tags are
+  commonly used to mark places where some more code is required, but which the
+  developer wants to implement later"
+- [Anthropic: Effective Context
+  Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+  — "Keep your context informative, yet tight" — placeholder text is
+  uninformative noise that consumes context budget
+
+---
+
 ## Instruction Budget vs. Context Budget
 
 skillsaw has two separate budget rules that measure different things:
@@ -522,5 +624,5 @@ These papers justify multiple rules simultaneously:
 | [Suppressing Pink Elephants](https://arxiv.org/abs/2402.07896) | arXiv 2024 | negative-only |
 | Chroma, [Context Rot](https://research.trychroma.com/context-rot) | 2025 | critical-position, instruction-budget, section-length |
 | [When Prompts Go Wrong](https://arxiv.org/abs/2507.20439) | arXiv 2025 | contradiction |
-| [Anthropic: Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | 2025 | tautological, redundant-with-tooling, instruction-budget |
+| [Anthropic: Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | 2025 | tautological, redundant-with-tooling, instruction-budget, broken-internal-reference, placeholder-text |
 | Wang et al., [LLMs Meet Library Evolution](https://yebof.github.io/assets/pdf/wang2025icse.pdf) | ICSE 2025 | banned-references |

--- a/docs/designs/content-rules-research.md
+++ b/docs/designs/content-rules-research.md
@@ -526,8 +526,8 @@ nonexistent endpoint or asking the user to fill in information that should
 already be present.
 
 This is standard software engineering hygiene applied to a new file type.
-`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-
-comments`, SonarQube's "Track uses of 'TODO' tags") for decades because they
+`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-comments`,
+SonarQube's "Track uses of 'TODO' tags") for decades because they
 indicate incomplete implementation. The same principle applies to instruction
 files: if the content isn't ready, it shouldn't be in the agent's context.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.8.2"
+version = "0.8.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.8.3"
+version = "0.9.0"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -99,6 +99,9 @@ RULE_GROUPS = [
             "content-embedded-secrets",
             "content-banned-references",
             "content-inconsistent-terminology",
+            "content-broken-internal-reference",
+            "content-unlinked-internal-reference",
+            "content-placeholder-text",
         ],
         "Rules that go beyond structural validation to analyze the *quality* of "
         "instruction files. Built on attention research "

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -204,6 +204,9 @@ class LinterConfig:
                 "content-embedded-secrets": {"enabled": "auto", "severity": "error"},
                 "content-banned-references": {"enabled": "auto", "severity": "warning"},
                 "content-inconsistent-terminology": {"enabled": "auto", "severity": "info"},
+                "content-broken-internal-reference": {"enabled": "auto", "severity": "warning"},
+                "content-unlinked-internal-reference": {"enabled": "auto", "severity": "info"},
+                "content-placeholder-text": {"enabled": "auto", "severity": "warning"},
                 # CodeRabbit config
                 "coderabbit-yaml-valid": {"enabled": "auto", "severity": "error"},
                 # APM (Agent Package Manager) rules

--- a/src/skillsaw/marketplace/init.py
+++ b/src/skillsaw/marketplace/init.py
@@ -152,7 +152,11 @@ def _create_structure(
 
     _write(root / ".github" / "workflows" / "lint.yml", read_template("lint.yml", t))
 
-    LinterConfig.default().save(root / ".skillsaw.yaml")
+    scaffold_config = LinterConfig.default()
+    # Scaffolded templates intentionally use TODO/FIXME placeholders;
+    # disable the rule so the fresh scaffold lints clean.
+    scaffold_config.rules["content-placeholder-text"] = {"enabled": False, "severity": "warning"}
+    scaffold_config.save(root / ".skillsaw.yaml")
 
     _write(root / ".gitignore", read_template("gitignore", t))
 

--- a/src/skillsaw/rules/builtin/__init__.py
+++ b/src/skillsaw/rules/builtin/__init__.py
@@ -79,6 +79,9 @@ from .content_rules import (
     ContentEmbeddedSecretsRule,
     ContentBannedReferencesRule,
     ContentInconsistentTerminologyRule,
+    ContentBrokenInternalReferenceRule,
+    ContentUnlinkedInternalReferenceRule,
+    ContentPlaceholderTextRule,
 )
 
 from .coderabbit import (
@@ -145,6 +148,9 @@ BUILTIN_RULES = [
     ContentEmbeddedSecretsRule,
     ContentBannedReferencesRule,
     ContentInconsistentTerminologyRule,
+    ContentBrokenInternalReferenceRule,
+    ContentUnlinkedInternalReferenceRule,
+    ContentPlaceholderTextRule,
     # CodeRabbit
     CoderabbitYamlValidRule,
     # APM (Agent Package Manager)
@@ -196,6 +202,9 @@ __all__ = [
     "ContentEmbeddedSecretsRule",
     "ContentBannedReferencesRule",
     "ContentInconsistentTerminologyRule",
+    "ContentBrokenInternalReferenceRule",
+    "ContentUnlinkedInternalReferenceRule",
+    "ContentPlaceholderTextRule",
     "CoderabbitYamlValidRule",
     "ApmYamlValidRule",
     "ApmStructureValidRule",

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -7,7 +7,7 @@ instruction file formats equally.
 
 import re
 from collections import defaultdict
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Dict, List, Set, Tuple
 from urllib.parse import urlparse
 
@@ -1102,6 +1102,7 @@ class ContentBrokenInternalReferenceRule(Rule):
         return False
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        root = context.root_path.resolve()
         violations = []
         for cf in gather_all_content_blocks(context):
             if self._is_in_template_dir(cf.path):
@@ -1121,6 +1122,18 @@ class ContentBrokenInternalReferenceRule(Rule):
                         continue
                     # Resolve relative to the file containing the link
                     resolved = (cf.path.parent / target_path).resolve()
+                    # Ensure the resolved path is within the repo root
+                    try:
+                        resolved.relative_to(root)
+                    except ValueError:
+                        violations.append(
+                            self.violation(
+                                f"Broken internal link: [{match.group(1)}]({target}) — target is outside repository",
+                                block=cf,
+                                line=line_num,
+                            )
+                        )
+                        continue
                     if not resolved.exists():
                         violations.append(
                             self.violation(
@@ -1137,6 +1150,11 @@ class ContentUnlinkedInternalReferenceRule(Rule):
 
     formats = None
     since = "0.8.3"
+    repo_types = {
+        RepositoryType.AGENTSKILLS,
+        RepositoryType.SINGLE_PLUGIN,
+        RepositoryType.MARKETPLACE,
+    }
 
     config_schema = {
         "patterns": {
@@ -1160,6 +1178,9 @@ class ContentUnlinkedInternalReferenceRule(Rule):
     # Detect if a match is inside a markdown link [text](path)
     _LINK_SYNTAX_RE = re.compile(r"\[[^\]]*\]\([^)]*\)")
 
+    # Detect URLs so we can skip path-like fragments inside them
+    _URL_RE = re.compile(r"https?://[^\s)]+")
+
     @property
     def rule_id(self) -> str:
         return "content-unlinked-internal-reference"
@@ -1178,7 +1199,15 @@ class ContentUnlinkedInternalReferenceRule(Rule):
                 return True
         return False
 
+    def _is_inside_url(self, line: str, match_start: int, match_end: int) -> bool:
+        """Check if a match position falls inside a URL."""
+        for url_match in self._URL_RE.finditer(line):
+            if url_match.start() <= match_start and match_end <= url_match.end():
+                return True
+        return False
+
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        patterns = self.config.get("patterns", self.config_schema["patterns"]["default"])
         violations = []
         for cf in gather_all_content_blocks(context):
             body = cf.read_body(strip_code_blocks=True)
@@ -1191,6 +1220,11 @@ class ContentUnlinkedInternalReferenceRule(Rule):
                 for match in self._PATH_LIKE_RE.finditer(line):
                     path_str = match.group(0)
                     if self._is_inside_link(line, match.start(), match.end()):
+                        continue
+                    if self._is_inside_url(line, match.start(), match.end()):
+                        continue
+                    # Check if path matches any configured glob pattern
+                    if not any(PurePath(path_str).match(p) for p in patterns):
                         continue
                     violations.append(
                         self.violation(
@@ -1207,6 +1241,11 @@ class ContentPlaceholderTextRule(Rule):
 
     formats = None
     since = "0.8.3"
+    repo_types = {
+        RepositoryType.AGENTSKILLS,
+        RepositoryType.SINGLE_PLUGIN,
+        RepositoryType.MARKETPLACE,
+    }
 
     _PLACEHOLDER_PATTERNS = [
         (re.compile(r"\bTODO\b"), "TODO marker"),
@@ -1215,7 +1254,13 @@ class ContentPlaceholderTextRule(Rule):
         (re.compile(r"\[link\s+here\]", re.IGNORECASE), "Placeholder link"),
         (re.compile(r"\[Insert\s+[^\]]+\]", re.IGNORECASE), "Insert placeholder"),
         (re.compile(r"\[If\s+[^\]]+\]", re.IGNORECASE), "Conditional placeholder"),
-        (re.compile(r"\*[^*]*will be added[^*]*\*", re.IGNORECASE), "Unfilled template text"),
+        (
+            re.compile(
+                r"\*(?:TBD|to be added|details to be added|content to be added|will be added as you use)[^*]*\*",
+                re.IGNORECASE,
+            ),
+            "Unfilled template text",
+        ),
     ]
 
     @property

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -10,7 +10,7 @@ import os
 import re
 from collections import defaultdict
 from pathlib import Path, PurePath
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from skillsaw.rule import AutofixConfidence, AutofixResult, Rule, RuleViolation, Severity
@@ -1171,7 +1171,7 @@ class ContentBrokenInternalReferenceRule(Rule):
                     continue
         return paths
 
-    def _find_similar(self, root: Path, link_dir: Path, target_path: str) -> str | None:
+    def _find_similar(self, root: Path, link_dir: Path, target_path: str) -> Optional[str]:
         """Find a similar file path in the repo using fuzzy matching."""
         repo_paths = self._collect_repo_paths(root)
         target_name = Path(target_path).name

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -5,13 +5,15 @@ These rules use shared analyzers from content_analysis.py and apply to ALL
 instruction file formats equally.
 """
 
+import difflib
+import os
 import re
 from collections import defaultdict
 from pathlib import Path, PurePath
 from typing import Dict, List, Set, Tuple
 from urllib.parse import urlparse
 
-from skillsaw.rule import Rule, RuleViolation, Severity
+from skillsaw.rule import AutofixConfidence, AutofixResult, Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
@@ -1147,14 +1149,88 @@ class ContentBrokenInternalReferenceRule(Rule):
                         )
                         continue
                     if not resolved.exists():
-                        violations.append(
-                            self.violation(
-                                f"Broken internal link: [{match.group(1)}]({target}) — target does not exist",
-                                block=cf,
-                                line=line_num,
-                            )
-                        )
+                        suggestion = self._find_similar(root, cf.path.parent, target_path)
+                        msg = f"Broken internal link: [{match.group(1)}]({target}) — target does not exist"
+                        if suggestion:
+                            msg += f" (did you mean '{suggestion}'?)"
+                        violations.append(self.violation(msg, block=cf, line=line_num))
         return violations
+
+    def _collect_repo_paths(self, root: Path) -> List[str]:
+        """Collect all file paths in the repo, relative to root."""
+        paths = []
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if d not in {".git", "node_modules", "__pycache__", ".venv"}
+            ]
+            for f in filenames:
+                full = Path(dirpath) / f
+                try:
+                    paths.append(str(full.relative_to(root)))
+                except ValueError:
+                    continue
+        return paths
+
+    def _find_similar(self, root: Path, link_dir: Path, target_path: str) -> str | None:
+        """Find a similar file path in the repo using fuzzy matching."""
+        repo_paths = self._collect_repo_paths(root)
+        target_name = Path(target_path).name
+        candidates = [p for p in repo_paths if Path(p).name == target_name]
+        if len(candidates) == 1:
+            try:
+                return str(Path(candidates[0]).relative_to(link_dir.relative_to(root)))
+            except ValueError:
+                rel = os.path.relpath(root / candidates[0], link_dir)
+                return rel
+        if not candidates:
+            candidate_names = [Path(p).name for p in repo_paths]
+            close = difflib.get_close_matches(target_name, candidate_names, n=1, cutoff=0.6)
+            if close:
+                candidates = [p for p in repo_paths if Path(p).name == close[0]]
+        if candidates:
+            try:
+                rel = os.path.relpath(root / candidates[0], link_dir)
+                return rel
+            except ValueError:
+                return candidates[0]
+        return None
+
+    def fix(
+        self, context: RepositoryContext, violations: List[RuleViolation], **kwargs: object
+    ) -> List[AutofixResult]:
+        root = context.root_path.resolve()
+        fixes_by_file: Dict[Path, List[tuple]] = defaultdict(list)
+        for v in violations:
+            if not v.file_path or "did you mean" not in v.message:
+                continue
+            suggestion = v.message.split("did you mean '")[1].rstrip("'?)")
+            old_target = v.message.split("](")[1].split(")")[0]
+            fixes_by_file[v.file_path].append((old_target, suggestion, v))
+
+        results: List[AutofixResult] = []
+        for fpath, replacements in fixes_by_file.items():
+            try:
+                content = fpath.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            fixed = content
+            violations_fixed = []
+            for old_target, suggestion, v in replacements:
+                fixed = fixed.replace(f"]({old_target})", f"]({suggestion})")
+                violations_fixed.append(v)
+            if fixed != content:
+                results.append(
+                    AutofixResult(
+                        rule_id=self.rule_id,
+                        file_path=fpath,
+                        confidence=AutofixConfidence.SUGGEST,
+                        original_content=content,
+                        fixed_content=fixed,
+                        description=f"Fix {len(violations_fixed)} broken link(s) with likely matches",
+                        violations_fixed=violations_fixed,
+                    )
+                )
+        return results
 
 
 class ContentUnlinkedInternalReferenceRule(Rule):
@@ -1215,6 +1291,7 @@ class ContentUnlinkedInternalReferenceRule(Rule):
         return False
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        root = context.root_path.resolve()
         patterns = self.config.get("patterns", self.config_schema["patterns"]["default"])
         violations = []
         for cf in gather_all_content_blocks(context):
@@ -1222,7 +1299,6 @@ class ContentUnlinkedInternalReferenceRule(Rule):
             if not body:
                 continue
             for line_num, line in enumerate(body.splitlines(), 1):
-                # Skip empty lines (from stripped code blocks)
                 if not line.strip():
                     continue
                 for match in self._PATH_LIKE_RE.finditer(line):
@@ -1231,17 +1307,55 @@ class ContentUnlinkedInternalReferenceRule(Rule):
                         continue
                     if self._is_inside_url(line, match.start(), match.end()):
                         continue
-                    # Check if path matches any configured glob pattern
                     if not any(PurePath(path_str).match(p) for p in patterns):
                         continue
-                    violations.append(
-                        self.violation(
-                            f"Unlinked path reference: '{path_str}' — consider wrapping in link syntax [text]({path_str})",
-                            block=cf,
-                            line=line_num,
-                        )
-                    )
+                    resolved = (cf.path.parent / path_str).resolve()
+                    file_exists = False
+                    try:
+                        resolved.relative_to(root)
+                        file_exists = resolved.exists()
+                    except ValueError:
+                        pass
+                    msg = f"Unlinked path reference: '{path_str}' — consider wrapping in link syntax [{path_str}]({path_str})"
+                    if file_exists:
+                        msg += " (file exists, autofixable)"
+                    violations.append(self.violation(msg, block=cf, line=line_num))
         return violations
+
+    def fix(
+        self, context: RepositoryContext, violations: List[RuleViolation], **kwargs: object
+    ) -> List[AutofixResult]:
+        fixes_by_file: Dict[Path, List[tuple]] = defaultdict(list)
+        for v in violations:
+            if not v.file_path or "autofixable" not in v.message:
+                continue
+            path_str = v.message.split("'")[1]
+            fixes_by_file[v.file_path].append((path_str, v))
+
+        results: List[AutofixResult] = []
+        for fpath, replacements in fixes_by_file.items():
+            try:
+                content = fpath.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            fixed = content
+            violations_fixed = []
+            for path_str, v in replacements:
+                fixed = fixed.replace(path_str, f"[{path_str}]({path_str})", 1)
+                violations_fixed.append(v)
+            if fixed != content:
+                results.append(
+                    AutofixResult(
+                        rule_id=self.rule_id,
+                        file_path=fpath,
+                        confidence=AutofixConfidence.SAFE,
+                        original_content=content,
+                        fixed_content=fixed,
+                        description=f"Wrap {len(violations_fixed)} bare path(s) in markdown link syntax",
+                        violations_fixed=violations_fixed,
+                    )
+                )
+        return results
 
 
 class ContentPlaceholderTextRule(Rule):

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -9,9 +9,10 @@ import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
+from urllib.parse import urlparse
 
 from skillsaw.rule import Rule, RuleViolation, Severity
-from skillsaw.context import RepositoryContext
+from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_blocks,
@@ -23,6 +24,7 @@ from skillsaw.rules.builtin.content_analysis import (
     InstructionBudgetAnalyzer,
     _HEADING_RE,
     _TAUTOLOGICAL_PHRASES,
+    _strip_fenced_code_blocks,
 )
 
 
@@ -1064,4 +1066,186 @@ class ContentInconsistentTerminologyRule(Rule):
                 for fpath in sorted(minority_files):
                     violations.append(self.violation(msg, file_path=fpath))
 
+        return violations
+
+
+class ContentBrokenInternalReferenceRule(Rule):
+    """Detect markdown links pointing to nonexistent files"""
+
+    formats = None
+    since = "0.8.3"
+    repo_types = {
+        RepositoryType.AGENTSKILLS,
+        RepositoryType.SINGLE_PLUGIN,
+        RepositoryType.MARKETPLACE,
+    }
+
+    _LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+    _TEMPLATE_DIR_NAMES = {"template", "templates", "_template"}
+
+    @property
+    def rule_id(self) -> str:
+        return "content-broken-internal-reference"
+
+    @property
+    def description(self) -> str:
+        return "Detect markdown links where the target file does not exist"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def _is_in_template_dir(self, file_path: Path) -> bool:
+        """Check if the file is inside a template directory."""
+        for part in file_path.parts:
+            if part in self._TEMPLATE_DIR_NAMES:
+                return True
+        return False
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        for cf in gather_all_content_blocks(context):
+            if self._is_in_template_dir(cf.path):
+                continue
+            body = cf.read_body(strip_code_blocks=True)
+            if not body:
+                continue
+            for line_num, line in enumerate(body.splitlines(), 1):
+                for match in self._LINK_RE.finditer(line):
+                    target = match.group(2).strip()
+                    # Skip URLs, anchors, and mailto
+                    if target.startswith(("http://", "https://", "#", "mailto:")):
+                        continue
+                    # Strip anchor from path (e.g., "file.md#section")
+                    target_path = target.split("#")[0]
+                    if not target_path:
+                        continue
+                    # Resolve relative to the file containing the link
+                    resolved = (cf.path.parent / target_path).resolve()
+                    if not resolved.exists():
+                        violations.append(
+                            self.violation(
+                                f"Broken internal link: [{match.group(1)}]({target}) — target does not exist",
+                                block=cf,
+                                line=line_num,
+                            )
+                        )
+        return violations
+
+
+class ContentUnlinkedInternalReferenceRule(Rule):
+    """Detect bare path-like strings that are not wrapped in markdown link syntax"""
+
+    formats = None
+    since = "0.8.3"
+
+    config_schema = {
+        "patterns": {
+            "type": "list",
+            "default": ["./**/*.*", "references/**/*.md"],
+            "description": "Glob patterns for path-like strings to flag when unlinked",
+        },
+    }
+
+    # Match path-like strings: contain / and a file extension, or start with ./
+    _PATH_LIKE_RE = re.compile(
+        r"(?<!\()"  # not preceded by ( (would be inside link syntax)
+        r"(?:"
+        r"\./[\w./_-]+"  # starts with ./
+        r"|"
+        r"[\w._-]+(?:/[\w._-]+)+\.[\w]{1,10}"  # contains / and has extension
+        r")"
+        r"(?!\))"  # not followed by ) (would be inside link syntax)
+    )
+
+    # Detect if a match is inside a markdown link [text](path)
+    _LINK_SYNTAX_RE = re.compile(r"\[[^\]]*\]\([^)]*\)")
+
+    @property
+    def rule_id(self) -> str:
+        return "content-unlinked-internal-reference"
+
+    @property
+    def description(self) -> str:
+        return "Detect bare path-like strings not wrapped in markdown link syntax"
+
+    def default_severity(self) -> Severity:
+        return Severity.INFO
+
+    def _is_inside_link(self, line: str, match_start: int, match_end: int) -> bool:
+        """Check if a match position falls inside markdown link syntax."""
+        for link_match in self._LINK_SYNTAX_RE.finditer(line):
+            if link_match.start() <= match_start and match_end <= link_match.end():
+                return True
+        return False
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body(strip_code_blocks=True)
+            if not body:
+                continue
+            for line_num, line in enumerate(body.splitlines(), 1):
+                # Skip empty lines (from stripped code blocks)
+                if not line.strip():
+                    continue
+                for match in self._PATH_LIKE_RE.finditer(line):
+                    path_str = match.group(0)
+                    if self._is_inside_link(line, match.start(), match.end()):
+                        continue
+                    violations.append(
+                        self.violation(
+                            f"Unlinked path reference: '{path_str}' — consider wrapping in link syntax [text]({path_str})",
+                            block=cf,
+                            line=line_num,
+                        )
+                    )
+        return violations
+
+
+class ContentPlaceholderTextRule(Rule):
+    """Detect TODO markers, bracket placeholders, and unfilled template text"""
+
+    formats = None
+    since = "0.8.3"
+
+    _PLACEHOLDER_PATTERNS = [
+        (re.compile(r"\bTODO\b"), "TODO marker"),
+        (re.compile(r"\bFIXME\b"), "FIXME marker"),
+        (re.compile(r"\bXXX\b"), "XXX marker"),
+        (re.compile(r"\[link\s+here\]", re.IGNORECASE), "Placeholder link"),
+        (re.compile(r"\[Insert\s+[^\]]+\]", re.IGNORECASE), "Insert placeholder"),
+        (re.compile(r"\[If\s+[^\]]+\]", re.IGNORECASE), "Conditional placeholder"),
+        (re.compile(r"\*[^*]*will be added[^*]*\*", re.IGNORECASE), "Unfilled template text"),
+    ]
+
+    @property
+    def rule_id(self) -> str:
+        return "content-placeholder-text"
+
+    @property
+    def description(self) -> str:
+        return "Detect TODO markers, bracket placeholders, and unfilled template text"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        for cf in gather_all_content_blocks(context):
+            body = cf.read_body(strip_code_blocks=True)
+            if not body:
+                continue
+            for line_num, line in enumerate(body.splitlines(), 1):
+                if not line.strip():
+                    continue
+                for pattern, desc in self._PLACEHOLDER_PATTERNS:
+                    match = pattern.search(line)
+                    if match:
+                        violations.append(
+                            self.violation(
+                                f"Placeholder text ({desc}): '{match.group()}'",
+                                block=cf,
+                                line=line_num,
+                            )
+                        )
         return violations

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -1073,12 +1073,8 @@ class ContentBrokenInternalReferenceRule(Rule):
     """Detect markdown links pointing to nonexistent files"""
 
     formats = None
-    since = "0.8.3"
-    repo_types = {
-        RepositoryType.AGENTSKILLS,
-        RepositoryType.SINGLE_PLUGIN,
-        RepositoryType.MARKETPLACE,
-    }
+    since = "0.9.0"
+    repo_types = None
 
     _LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
     _TEMPLATE_DIR_NAMES = {"template", "templates", "_template"}
@@ -1113,6 +1109,9 @@ class ContentBrokenInternalReferenceRule(Rule):
             for line_num, line in enumerate(body.splitlines(), 1):
                 for match in self._LINK_RE.finditer(line):
                     target = match.group(2).strip()
+                    # Strip optional title text: [text](path "title")
+                    if " " in target:
+                        target = target.split(" ")[0]
                     # Skip URLs, anchors, and mailto
                     if target.startswith(("http://", "https://", "#", "mailto:")):
                         continue
@@ -1149,12 +1148,8 @@ class ContentUnlinkedInternalReferenceRule(Rule):
     """Detect bare path-like strings that are not wrapped in markdown link syntax"""
 
     formats = None
-    since = "0.8.3"
-    repo_types = {
-        RepositoryType.AGENTSKILLS,
-        RepositoryType.SINGLE_PLUGIN,
-        RepositoryType.MARKETPLACE,
-    }
+    since = "0.9.0"
+    repo_types = None
 
     config_schema = {
         "patterns": {
@@ -1240,12 +1235,8 @@ class ContentPlaceholderTextRule(Rule):
     """Detect TODO markers, bracket placeholders, and unfilled template text"""
 
     formats = None
-    since = "0.8.3"
-    repo_types = {
-        RepositoryType.AGENTSKILLS,
-        RepositoryType.SINGLE_PLUGIN,
-        RepositoryType.MARKETPLACE,
-    }
+    since = "0.9.0"
+    repo_types = None
 
     _PLACEHOLDER_PATTERNS = [
         (re.compile(r"\bTODO\b"), "TODO marker"),
@@ -1256,7 +1247,7 @@ class ContentPlaceholderTextRule(Rule):
         (re.compile(r"\[If\s+[^\]]+\]", re.IGNORECASE), "Conditional placeholder"),
         (
             re.compile(
-                r"\*(?:TBD|to be added|details to be added|content to be added|will be added as you use)[^*]*\*",
+                r"\*(?:TBD|to be added|details to be added|content to be added)\*",
                 re.IGNORECASE,
             ),
             "Unfilled template text",

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -685,6 +685,13 @@ class TestContentBrokenInternalReferenceRule:
         violations = ContentBrokenInternalReferenceRule().check(context)
         assert len(violations) == 3
 
+    def test_path_traversal_outside_repo(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("See [escape](../../etc/passwd) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "outside repository" in violations[0].message
+
     def test_no_files_no_violations(self, temp_dir):
         context = RepositoryContext(temp_dir)
         violations = ContentBrokenInternalReferenceRule().check(context)
@@ -734,9 +741,7 @@ class TestContentUnlinkedInternalReferenceRule:
         )
         context = RepositoryContext(temp_dir)
         violations = ContentUnlinkedInternalReferenceRule().check(context)
-        # Should not flag the URL itself as an unlinked path
-        for v in violations:
-            assert "https://" not in v.message
+        assert len(violations) == 0
 
     def test_reports_line_number(self, temp_dir):
         content = "Line 1\nLine 2\nSee docs/guide.md for info.\nLine 4\n"
@@ -803,11 +808,25 @@ class TestContentPlaceholderTextRule:
         assert "Conditional placeholder" in violations[0].message
 
     def test_detects_will_be_added(self, temp_dir):
-        (temp_dir / "CLAUDE.md").write_text("More details *will be added later*.\n")
+        (temp_dir / "CLAUDE.md").write_text("More details *to be added*.\n")
         context = RepositoryContext(temp_dir)
         violations = ContentPlaceholderTextRule().check(context)
         assert len(violations) == 1
         assert "Unfilled template" in violations[0].message
+
+    def test_detects_tbd(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("Configuration *TBD*.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "Unfilled template" in violations[0].message
+
+    def test_will_be_added_in_changelog_not_flagged(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("Feature X *will be added in v2.0*.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        # The tightened regex should not flag general "will be added" text
+        assert len(violations) == 0
 
     def test_clean_content_no_violations(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text(

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -692,6 +692,16 @@ class TestContentBrokenInternalReferenceRule:
         assert len(violations) == 1
         assert "outside repository" in violations[0].message
 
+    def test_link_with_title_text(self, temp_dir):
+        """Links with optional title text should resolve correctly."""
+        (temp_dir / "guide.md").write_text("# Guide\n")
+        (temp_dir / "CLAUDE.md").write_text(
+            'See [the guide](guide.md "Intro guide") for details.\n'
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
     def test_no_files_no_violations(self, temp_dir):
         context = RepositoryContext(temp_dir)
         violations = ContentBrokenInternalReferenceRule().check(context)
@@ -741,6 +751,33 @@ class TestContentUnlinkedInternalReferenceRule:
         )
         context = RepositoryContext(temp_dir)
         violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 0, f"URL path fragment should not be flagged, got: {violations}"
+
+    def test_custom_patterns_config(self, temp_dir):
+        """Test that custom patterns config filters which paths are flagged."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "See docs/guide.md for info.\nAlso check src/config/settings.yaml.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        # With default patterns, both should be flagged
+        rule_default = ContentUnlinkedInternalReferenceRule()
+        violations = rule_default.check(context)
+        assert len(violations) == 2
+
+        # With restricted patterns, only .yaml paths should match
+        rule_custom = ContentUnlinkedInternalReferenceRule()
+        rule_custom.config = {"patterns": ["*.yaml"]}
+        violations = rule_custom.check(context)
+        assert len(violations) == 1
+        assert "settings.yaml" in violations[0].message
+
+    def test_empty_patterns_config_no_violations(self, temp_dir):
+        """Test that empty patterns list results in no violations."""
+        (temp_dir / "CLAUDE.md").write_text("See docs/guide.md for info.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentUnlinkedInternalReferenceRule()
+        rule.config = {"patterns": []}
+        violations = rule.check(context)
         assert len(violations) == 0
 
     def test_reports_line_number(self, temp_dir):
@@ -826,6 +863,13 @@ class TestContentPlaceholderTextRule:
         context = RepositoryContext(temp_dir)
         violations = ContentPlaceholderTextRule().check(context)
         # The tightened regex should not flag general "will be added" text
+        assert len(violations) == 0
+
+    def test_will_be_added_as_you_use_not_flagged(self, temp_dir):
+        """'will be added as you use' is normal prose, not placeholder text."""
+        (temp_dir / "CLAUDE.md").write_text("Memories *will be added as you use* the tool.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
         assert len(violations) == 0
 
     def test_clean_content_no_violations(self, temp_dir):

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -22,6 +22,9 @@ from skillsaw.rules.builtin.content_rules import (
     ContentEmbeddedSecretsRule,
     ContentBannedReferencesRule,
     ContentInconsistentTerminologyRule,
+    ContentBrokenInternalReferenceRule,
+    ContentUnlinkedInternalReferenceRule,
+    ContentPlaceholderTextRule,
 )
 
 # Stripe test keys built from parts to avoid triggering GitHub push protection
@@ -612,4 +615,224 @@ class TestContentInconsistentTerminologyRule:
         )
         context = RepositoryContext(temp_dir)
         violations = ContentInconsistentTerminologyRule().check(context)
+        assert len(violations) == 0
+
+
+class TestContentBrokenInternalReferenceRule:
+    def test_rule_metadata(self):
+        rule = ContentBrokenInternalReferenceRule()
+        assert rule.rule_id == "content-broken-internal-reference"
+        assert rule.default_severity() == Severity.WARNING
+
+    def test_existing_file_no_violation(self, temp_dir):
+        (temp_dir / "guide.md").write_text("# Guide\nContent here.\n")
+        (temp_dir / "CLAUDE.md").write_text("See [the guide](guide.md) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_missing_file_violation(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("See [the guide](missing-guide.md) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "missing-guide.md" in violations[0].message
+        assert violations[0].line == 1
+
+    def test_url_links_skipped(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "See [docs](https://example.com/docs) and [other](http://example.com).\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_anchor_links_skipped(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("See [section](#overview) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_template_dir_skipped(self, temp_dir):
+        tmpl_dir = temp_dir / "templates"
+        tmpl_dir.mkdir()
+        (tmpl_dir / "CLAUDE.md").write_text("See [placeholder](nonexistent.md) for details.\n")
+        # Need a SKILL.md to make it an agentskills repo so the rule applies
+        (temp_dir / "SKILL.md").write_text("---\nname: test\n---\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_reports_line_number(self, temp_dir):
+        content = "Line 1\nLine 2\nSee [broken](no-such-file.md).\nLine 4\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].line == 3
+
+    def test_link_with_anchor_existing_file(self, temp_dir):
+        (temp_dir / "guide.md").write_text("# Guide\n## Section\n")
+        (temp_dir / "CLAUDE.md").write_text("See [section](guide.md#section).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_multiple_broken_links(self, temp_dir):
+        content = "See [a](missing-a.md) and [b](missing-b.md).\n" "Also [c](missing-c.md).\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 3
+
+    def test_no_files_no_violations(self, temp_dir):
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+
+class TestContentUnlinkedInternalReferenceRule:
+    def test_rule_metadata(self):
+        rule = ContentUnlinkedInternalReferenceRule()
+        assert rule.rule_id == "content-unlinked-internal-reference"
+        assert rule.default_severity() == Severity.INFO
+
+    def test_bare_path_violation(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "Check the file at src/config/settings.yaml for defaults.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "src/config/settings.yaml" in violations[0].message
+
+    def test_path_in_link_syntax_no_violation(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "Check the [settings](src/config/settings.yaml) for defaults.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_dot_slash_path(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("Run ./scripts/build.sh to build.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "./scripts/build.sh" in violations[0].message
+
+    def test_code_blocks_skipped(self, temp_dir):
+        content = "# Rules\n```\nsrc/config/settings.yaml\n```\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+    def test_url_not_flagged(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "Visit https://example.com/path/to/file.html for more.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        # Should not flag the URL itself as an unlinked path
+        for v in violations:
+            assert "https://" not in v.message
+
+    def test_reports_line_number(self, temp_dir):
+        content = "Line 1\nLine 2\nSee docs/guide.md for info.\nLine 4\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) >= 1
+        assert violations[0].line == 3
+
+    def test_no_files_no_violations(self, temp_dir):
+        context = RepositoryContext(temp_dir)
+        violations = ContentUnlinkedInternalReferenceRule().check(context)
+        assert len(violations) == 0
+
+
+class TestContentPlaceholderTextRule:
+    def test_rule_metadata(self):
+        rule = ContentPlaceholderTextRule()
+        assert rule.rule_id == "content-placeholder-text"
+        assert rule.default_severity() == Severity.WARNING
+
+    def test_detects_todo(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("TODO: add error handling.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "TODO" in violations[0].message
+
+    def test_detects_fixme(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("FIXME: broken logic here.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "FIXME" in violations[0].message
+
+    def test_detects_xxx(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("XXX: needs review.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "XXX" in violations[0].message
+
+    def test_detects_link_here(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("See [link here] for more info.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "Placeholder link" in violations[0].message
+
+    def test_detects_insert_placeholder(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("Add your [Insert API key] to the config.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "Insert placeholder" in violations[0].message
+
+    def test_detects_if_placeholder(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "[If using Docker, add Docker setup instructions here]\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "Conditional placeholder" in violations[0].message
+
+    def test_detects_will_be_added(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("More details *will be added later*.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert "Unfilled template" in violations[0].message
+
+    def test_clean_content_no_violations(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            "# Rules\nUse 4-space indentation.\nReturn 404 for missing resources.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 0
+
+    def test_reports_line_number(self, temp_dir):
+        content = "Line 1\nLine 2\nTODO: fix this\nLine 4\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 1
+        assert violations[0].line == 3
+
+    def test_code_blocks_skipped(self, temp_dir):
+        content = "# Rules\n```\nTODO: fix this\nFIXME: broken\n```\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
+        assert len(violations) == 0
+
+    def test_no_files_no_violations(self, temp_dir):
+        context = RepositoryContext(temp_dir)
+        violations = ContentPlaceholderTextRule().check(context)
         assert len(violations) == 0

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 
 from skillsaw.context import RepositoryContext
-from skillsaw.rule import Severity
+from skillsaw.rule import AutofixConfidence, Severity
 from skillsaw.rules.builtin.content_rules import (
     ContentWeakLanguageRule,
     ContentTautologicalRule,
@@ -934,3 +934,87 @@ class TestContentPlaceholderTextRule:
         context = RepositoryContext(temp_dir)
         violations = ContentPlaceholderTextRule().check(context)
         assert len(violations) == 0
+
+
+class TestContentUnlinkedInternalReferenceAutofix:
+    def test_autofix_wraps_existing_path(self, temp_dir):
+        """Bare paths to existing files should be autofixed with SAFE confidence."""
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "guide.md").write_text("# Guide\n")
+        (temp_dir / "CLAUDE.md").write_text("See docs/guide.md for info.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentUnlinkedInternalReferenceRule()
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "autofixable" in violations[0].message
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert fixes[0].confidence == AutofixConfidence.SAFE
+        assert "[docs/guide.md](docs/guide.md)" in fixes[0].fixed_content
+
+    def test_no_autofix_for_nonexistent_path(self, temp_dir):
+        """Bare paths to nonexistent files should not be autofixed."""
+        (temp_dir / "CLAUDE.md").write_text("See docs/guide.md for info.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentUnlinkedInternalReferenceRule()
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "autofixable" not in violations[0].message
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 0
+
+    def test_supports_autofix_property(self):
+        rule = ContentUnlinkedInternalReferenceRule()
+        assert rule.supports_autofix
+
+
+class TestContentBrokenInternalReferenceAutofix:
+    def test_suggests_similar_filename(self, temp_dir):
+        """Broken link should suggest a similar existing file."""
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "setup.md").write_text("# Setup\n")
+        (temp_dir / "CLAUDE.md").write_text("See [guide](docs/setpu.md) for setup.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentBrokenInternalReferenceRule()
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "did you mean" in violations[0].message
+
+    def test_suggests_moved_file(self, temp_dir):
+        """Broken link should suggest exact name match in different directory."""
+        (temp_dir / "reference").mkdir()
+        (temp_dir / "reference" / "guide.md").write_text("# Guide\n")
+        (temp_dir / "CLAUDE.md").write_text("See [guide](docs/guide.md) for help.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentBrokenInternalReferenceRule()
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "did you mean" in violations[0].message
+
+    def test_fix_applies_suggestion(self, temp_dir):
+        """Fix should replace broken link target with the suggestion."""
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "setup.md").write_text("# Setup\n")
+        (temp_dir / "CLAUDE.md").write_text("See [guide](docs/setpu.md) for setup.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentBrokenInternalReferenceRule()
+        violations = rule.check(context)
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert fixes[0].confidence == AutofixConfidence.SUGGEST
+        assert "docs/setpu.md" not in fixes[0].fixed_content
+
+    def test_supports_autofix_property(self):
+        rule = ContentBrokenInternalReferenceRule()
+        assert rule.supports_autofix
+
+    def test_no_suggestion_when_no_similar_file(self, temp_dir):
+        """No suggestion when no similar file exists."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "See [guide](totally/unique/nonexistent.xyz) for info.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        rule = ContentBrokenInternalReferenceRule()
+        violations = rule.check(context)
+        assert len(violations) == 1
+        assert "did you mean" not in violations[0].message


### PR DESCRIPTION
## Summary
- Add `content-broken-internal-reference` rule — detects markdown links pointing to nonexistent files (WARNING)
- Add `content-unlinked-internal-reference` rule — detects bare path-like strings not wrapped in links, configurable via `patterns` (INFO)
- Add `content-placeholder-text` rule — detects TODO markers, bracket placeholders, and unfilled templates (WARNING)

Based on ecosystem survey findings across 45 repositories (~2,100 skills).

## Test plan
- [ ] Tests for broken internal reference detection (existing files, missing files, URLs, template dirs)
- [ ] Tests for unlinked internal reference detection (bare paths, linked paths, custom patterns)
- [ ] Tests for placeholder text detection (TODO, FIXME, bracket placeholders)
- [ ] `make test` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three content-quality checks: broken-internal-reference, unlinked-internal-reference (with configurable patterns), and placeholder-text; each has default severity and auto-enable settings.

* **Documentation**
  * Updated docs and generated docs tooling to describe the new rules, their default severities, autofix support, and unlinked-reference pattern defaults.

* **Tests**
  * Added comprehensive tests covering detection, exclusions, line reporting, configuration, and edge cases.

* **Chores**
  * Package and example config version bumped to 0.9.0; project scaffold now adjusts rule defaults (placeholder disabled by default).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->