### PR TITLE
Add per-rule exclude support

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.8.2"
+version: "0.8.3"
 
 rules:
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,22 @@ exclude:
   - "node_modules/**"
 ```
 
+#### Per-Rule Excludes
+
+Exclude specific files from a single rule using the `exclude` key in the
+rule's config:
+
+```yaml
+rules:
+  content-weak-language:
+    enabled: true
+    exclude:
+      - "docs/legacy/**"
+      - "CHANGELOG.md"
+```
+
+Per-rule excludes use the same glob semantics as the top-level `exclude`.
+
 ### Content Paths
 
 By default, content intelligence rules only analyze recognized instruction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.8.2"
+version = "0.8.3"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -91,6 +91,13 @@ class LinterConfig:
                     f"'rules.{rule_id}' must be a mapping or null, "
                     f"got {type(rule_config).__name__}"
                 )
+            else:
+                raw_rule_exclude = rule_config.get("exclude")
+                if raw_rule_exclude is not None and not isinstance(raw_rule_exclude, list):
+                    raise ValueError(
+                        f"'rules.{rule_id}.exclude' must be a list, "
+                        f"got {type(raw_rule_exclude).__name__}"
+                    )
 
         if raw_custom_rules is None:
             custom_rules = []
@@ -220,6 +227,16 @@ class LinterConfig:
         config = cls.default()
         config.version = __version__
         return config
+
+    def get_rule_excludes(self, rule_id: str) -> List[str]:
+        """Return the per-rule exclude glob patterns for *rule_id*."""
+        overrides = self.rules.get(rule_id)
+        if not overrides:
+            return []
+        exclude = overrides.get("exclude")
+        if not exclude:
+            return []
+        return list(exclude)
 
     def get_rule_config(self, rule_id: str) -> Dict[str, Any]:
         """

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -118,13 +118,17 @@ class RepositoryContext:
 
     def is_path_excluded(self, path: Path) -> bool:
         """Check if a path matches any exclude pattern."""
-        if not self.exclude_patterns:
+        return self.is_path_excluded_by(path, self.exclude_patterns)
+
+    def is_path_excluded_by(self, path: Path, patterns: list) -> bool:
+        """Check if *path* matches any of the given glob *patterns*."""
+        if not patterns:
             return False
         try:
             rel = str(path.resolve().relative_to(self.root_path))
         except ValueError:
             return False
-        return any(fnmatch.fnmatch(rel, pat) for pat in self.exclude_patterns)
+        return any(fnmatch.fnmatch(rel, pat) for pat in patterns)
 
     def apply_excludes(self) -> None:
         """Filter plugins, skills, and instruction_files by exclude_patterns.

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -151,6 +151,15 @@ class Linter:
             return False
         return self.context.is_path_excluded(violation.file_path)
 
+    def _is_rule_excluded(self, violation: RuleViolation) -> bool:
+        """Check if a violation's file matches its rule's per-rule exclude patterns."""
+        if violation.file_path is None:
+            return False
+        patterns = self.config.get_rule_excludes(violation.rule_id)
+        if not patterns:
+            return False
+        return self.context.is_path_excluded_by(violation.file_path, patterns)
+
     def run(self) -> List[RuleViolation]:
         """
         Run all enabled rules
@@ -172,7 +181,7 @@ class Linter:
             except Exception as e:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
 
-        return [v for v in violations if not self._is_excluded(v)]
+        return [v for v in violations if not self._is_excluded(v) and not self._is_rule_excluded(v)]
 
     def fix(self) -> tuple[List[RuleViolation], List[AutofixResult]]:
         """
@@ -191,7 +200,11 @@ class Linter:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
                 continue
 
-            visible = [v for v in rule_violations if not self._is_excluded(v)]
+            visible = [
+                v
+                for v in rule_violations
+                if not self._is_excluded(v) and not self._is_rule_excluded(v)
+            ]
 
             if visible and rule.supports_autofix:
                 try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -734,3 +734,82 @@ def test_severity_override_on_auto_rule_still_fires_when_matching(marketplace_re
         config.is_rule_enabled("marketplace-registration", context, {RepositoryType.MARKETPLACE})
         is True
     )
+
+
+# --- Per-rule exclude tests ---
+
+
+def test_per_rule_exclude_parsed(tmp_path):
+    """Per-rule exclude list is accepted and retrievable"""
+    config_file = tmp_path / ".skillsaw.yaml"
+    config_file.write_text(
+        "rules:\n"
+        "  content-weak-language:\n"
+        "    enabled: true\n"
+        "    exclude:\n"
+        "      - 'docs/legacy/**'\n"
+        "      - 'CHANGELOG.md'\n"
+    )
+    config = LinterConfig.from_file(config_file)
+    assert config.get_rule_excludes("content-weak-language") == [
+        "docs/legacy/**",
+        "CHANGELOG.md",
+    ]
+
+
+def test_per_rule_exclude_null(tmp_path):
+    """Per-rule exclude: null should behave like no excludes"""
+    config_file = tmp_path / ".skillsaw.yaml"
+    config_file.write_text("rules:\n" "  content-weak-language:\n" "    exclude:\n")
+    config = LinterConfig.from_file(config_file)
+    assert config.get_rule_excludes("content-weak-language") == []
+
+
+def test_per_rule_exclude_wrong_type_raises(tmp_path):
+    """Per-rule exclude as a string should raise ValueError"""
+    config_file = tmp_path / ".skillsaw.yaml"
+    config_file.write_text("rules:\n" "  content-weak-language:\n" '    exclude: "*.md"\n')
+
+    import pytest
+
+    with pytest.raises(ValueError, match="'rules.content-weak-language.exclude' must be a list"):
+        LinterConfig.from_file(config_file)
+
+
+def test_per_rule_exclude_missing_returns_empty():
+    """get_rule_excludes returns [] when no exclude key is present"""
+    config = LinterConfig(rules={"content-weak-language": {"enabled": True}})
+    assert config.get_rule_excludes("content-weak-language") == []
+
+
+def test_per_rule_exclude_unknown_rule_returns_empty():
+    """get_rule_excludes returns [] for a rule that isn't configured"""
+    config = LinterConfig(rules={})
+    assert config.get_rule_excludes("nonexistent-rule") == []
+
+
+def test_per_rule_exclude_filters_violations(tmp_path):
+    """Per-rule exclude should suppress violations for matched paths only"""
+    from skillsaw.linter import Linter
+
+    (tmp_path / "CLAUDE.md").write_text("# Instructions\n\nYou should try to do something.\n")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "legacy.md").write_text("# Legacy\n\nYou should try to do something.\n")
+    config = LinterConfig(
+        version="999.0.0",
+        rules={
+            "content-weak-language": {
+                "enabled": True,
+                "exclude": ["docs/**"],
+            },
+        },
+        content_paths=["docs/**"],
+    )
+    context = RepositoryContext(tmp_path)
+    linter = Linter(context, config)
+    violations = linter.run()
+    weak_violations = [v for v in violations if v.rule_id == "content-weak-language"]
+    paths = [str(v.file_path) for v in weak_violations]
+    assert not any(
+        "docs" in p for p in paths
+    ), f"Per-rule exclude should suppress docs violations, got: {paths}"


### PR DESCRIPTION
## Summary
- Adds per-rule `exclude` key to `.skillsaw.yaml` config, using the same name as the top-level `exclude` for consistency
- Validates `exclude` as a list in per-rule config, with clear error messages for wrong types
- Filters violations per-rule in both `Linter.run()` and `Linter.fix()`
- Refactors `RepositoryContext.is_path_excluded` into a reusable `is_path_excluded_by` helper

## Test plan
- [x] `make test` — all 1100 tests pass
- [x] `make lint` — clean
- [x] `make update` — all generated files regenerated
- [x] Tested against `openshift-eng/ai-helpers` — exit 0
- [x] New tests: config parsing, null/wrong-type validation, linter filtering with per-rule excludes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-rule exclude functionality, allowing users to skip specific files and paths for individual rules using the `exclude` key within rule configurations.

* **Documentation**
  * Expanded README with a new Per-Rule Excludes subsection, providing practical YAML examples for implementing granular rule-level file and directory exclusions.

* **Chores**
  * Updated package version to 0.8.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/157)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->