### PR TITLE
Rename per-rule `excludes` to `exclude`

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,14 +371,14 @@ exclude:
 
 ### Per-Rule Excludes
 
-Exclude specific files from a single rule using the `excludes` key in the
+Exclude specific files from a single rule using the `exclude` key in the
 rule's config:
 
 ```yaml
 rules:
   content-weak-language:
     enabled: true
-    excludes:
+    exclude:
       - "docs/legacy/**"
       - "CHANGELOG.md"
 ```

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -158,14 +158,14 @@ class Linter:
         if file_path is None:
             return False
         rule_config = self.config.get_rule_config(rule_id)
-        excludes = rule_config.get("excludes")
-        if not excludes:
+        exclude = rule_config.get("exclude")
+        if not exclude:
             return False
         try:
             rel = str(file_path.resolve().relative_to(self.context.root_path))
         except ValueError:
             return False
-        return any(fnmatch.fnmatch(rel, pat) for pat in excludes)
+        return any(fnmatch.fnmatch(rel, pat) for pat in exclude)
 
     def _get_suppression_map(self, file_path: Path) -> Optional[SuppressionMap]:
         """Get or build a suppression map for a file, with caching."""

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -145,7 +145,7 @@ def test_per_rule_excludes_skips_matching_file(temp_dir):
     config.rules["content-weak-language"] = {
         "enabled": True,
         "severity": "warning",
-        "excludes": ["skills/legacy/**"],
+        "exclude": ["skills/legacy/**"],
     }
 
     linter = Linter(context, config)
@@ -170,7 +170,7 @@ def test_per_rule_excludes_still_fires_for_non_matching(temp_dir):
     config.rules["content-weak-language"] = {
         "enabled": True,
         "severity": "warning",
-        "excludes": ["skills/legacy/**"],
+        "exclude": ["skills/legacy/**"],
     }
 
     linter = Linter(context, config)


### PR DESCRIPTION
## Summary
- Renames the per-rule `excludes` config key to `exclude` to match the top-level key
- 3 files changed: `linter.py` (config lookup), `test_linter.py` (test configs), `README.md` (docs/example)

## Test plan
- [x] `make test` — all 1181 tests pass
- [x] `make lint` — clean
- [x] `make update` — regenerated
- [x] Tested against `openshift-eng/ai-helpers` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated per-rule file exclusion documentation to clarify the correct configuration key name.

* **Bug Fixes**
  * Fixed per-rule exclusion functionality to properly read exclusion patterns from the updated configuration key.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/158)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->