### PR TITLE
Deprecate lint --fix, consolidate on skillsaw fix, add LLM setup docs

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.9.0"
+version: "0.9.1"
 
 rules:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
 ## Features
 
 - 🧠 **Content Intelligence** — [Research-backed](docs/designs/content-rules-research.md) rules that catch [weak language](#content-intelligence), [tautological instructions](https://arxiv.org/abs/2407.01906), [attention dead zones](https://arxiv.org/abs/2307.03172), embedded secrets, contradictions, and more
-- 🔧 **LLM Autofix** — Fix violations with any LLM via `skillsaw lint --fix --llm` — parallel processing, scoped re-lint, per-file rollback
+- 🔧 **LLM Autofix** — Fix violations with any LLM via `skillsaw fix --llm` — parallel processing, scoped re-lint, per-file rollback
 - 🔍 **Context-Aware** — Auto-detects repo type and instruction formats (CLAUDE.md, AGENTS.md, Cursor, Copilot, Gemini, Kiro)
 - 📐 **40+ Rules** — Validates structure, metadata, commands, cross-file consistency, context budget, and content quality
 - 🏗️ **Scaffolding** — `skillsaw add` generates plugins, skills, commands, agents, and hooks
@@ -57,9 +57,9 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
   - [Content Paths](#content-paths)
 - [Builtin Rules](#builtin-rules)
 - [Autofixing](#autofixing)
-  - [Deterministic Fixes (`--fix`)](#deterministic-fixes---fix)
-  - [LLM-Powered Fixes (`--fix --llm`)](#llm-powered-fixes---fix---llm)
-  - [Standalone Fix Command (`skillsaw fix`)](#standalone-fix-command-skillsaw-fix)
+  - [Deterministic Fixes](#deterministic-fixes)
+  - [LLM-Powered Fixes](#llm-powered-fixes)
+  - [LLM Setup](#llm-setup)
 - [Custom Rules](#custom-rules)
 - [Scaffolding](#scaffolding)
   - [Initialize a Marketplace](#initialize-a-marketplace)
@@ -86,13 +86,13 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
 uvx skillsaw
 
 # Fix structural issues automatically
-skillsaw lint --fix
+skillsaw fix
 
 # Fix content quality issues with an LLM
-skillsaw lint --fix --llm
+skillsaw fix --llm
 
 # Preview LLM fixes without writing
-skillsaw lint --fix --llm --dry-run
+skillsaw fix --llm --dry-run
 
 # Verbose output (includes info-level findings)
 skillsaw -v
@@ -568,7 +568,7 @@ Warns when instruction and configuration files exceed recommended token limits. 
 
 ### Content Intelligence
 
-Rules that go beyond structural validation to analyze the *quality* of instruction files. Built on attention research ([lost-in-the-middle](https://arxiv.org/abs/2307.03172), [instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) and prompt engineering best practices. All support LLM-powered fixes via `--fix --llm`. See [docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) for the full research basis behind each rule.
+Rules that go beyond structural validation to analyze the *quality* of instruction files. Built on attention research ([lost-in-the-middle](https://arxiv.org/abs/2307.03172), [instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) and prompt engineering best practices. All support LLM-powered fixes via `skillsaw fix --llm`. See [docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) for the full research basis behind each rule.
 
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
@@ -638,30 +638,29 @@ Validates repositories using the [APM](https://github.com/microsoft/apm) directo
 
 skillsaw supports two levels of autofixing — deterministic fixes for structural issues and LLM-powered fixes for content quality. Rules declare which fix type they support (see the **Autofix** column in the rules tables above).
 
-### Deterministic Fixes (`--fix`)
+### Deterministic Fixes
 
 Safe, pattern-based fixes that run instantly without any external dependencies:
 
 ```bash
-skillsaw lint --fix              # Apply safe structural fixes
+skillsaw fix                     # Apply safe structural fixes
 ```
 
 Examples: adding missing frontmatter, renaming files to kebab-case, registering unregistered plugins in marketplace.json, fixing skill names to match directory names. These are marked **SAFE** confidence and applied automatically.
 
-### LLM-Powered Fixes (`--fix --llm`)
+### LLM-Powered Fixes
 
 All content intelligence rules support LLM-powered fixes. The LLM reads your instruction files, rewrites violations, and re-lints in a loop until the file is clean — or rolls back if it made things worse.
 
 ```bash
-# Fix content violations with an LLM (any LiteLLM-compatible model)
-skillsaw lint --fix --llm
-
-# Preview what would change without writing to disk
-skillsaw lint --fix --llm --dry-run
-
-# Use a specific model (OpenAI, Anthropic, Vertex AI, local, etc.)
-skillsaw lint --fix --llm --model vertex_ai/claude-sonnet-4-6
-skillsaw lint --fix --llm --model openrouter/minimax/minimax-m1
+skillsaw fix --llm                          # Fix with default model
+skillsaw fix --llm --model vertex_ai/claude-sonnet-4-6
+skillsaw fix --llm --model openrouter/minimax/minimax-m1
+skillsaw fix --llm --all                    # Include info-level violations
+skillsaw fix --llm --workers 8              # Parallel workers (default: 4)
+skillsaw fix --llm --max-iterations 10      # Max iterations per file
+skillsaw fix --llm --dry-run                # Preview changes without writing
+skillsaw fix --llm -y                       # Auto-apply without confirmation
 ```
 
 **How it works:**
@@ -676,20 +675,35 @@ The LLM never has access to arbitrary shell commands — it can only read, edit,
 
 Check `skillsaw list-rules` to see which rules support `auto`, `llm`, or both fix types.
 
-### Standalone Fix Command (`skillsaw fix`)
+> **Note:** `skillsaw lint --fix` is deprecated and will be removed in 1.0. Use `skillsaw fix` instead.
 
-For more control over LLM fixes, use the standalone `fix` subcommand:
+### LLM Setup
+
+skillsaw uses [LiteLLM](https://docs.litellm.ai/docs/providers) under the hood, so any LiteLLM-compatible model works. Install the extras for your provider:
 
 ```bash
-skillsaw fix --llm                          # Fix with default model
-skillsaw fix --llm --model vertex_ai/claude-sonnet-4-6
-skillsaw fix --llm --all                    # Include info-level violations
-skillsaw fix --llm --workers 8              # Parallel workers (default: 4)
-skillsaw fix --llm --max-iterations 10      # Max iterations per file
-skillsaw fix --llm --dry-run                # Preview changes
+# pip
+pip install 'skillsaw[llm]'       # Any LiteLLM-compatible model
+pip install 'skillsaw[vertexai]'  # Vertex AI (includes google-cloud-aiplatform)
+pip install 'skillsaw[bedrock]'   # AWS Bedrock (includes boto3)
+
+# uvx (no install required)
+uvx --with 'skillsaw[llm]' skillsaw fix --llm
+uvx --with 'skillsaw[vertexai]' skillsaw fix --llm --model vertex_ai/claude-sonnet-4-6
 ```
 
-This provides a richer terminal UI with progress bars, per-file ETA, and detailed tool call logging. Use `skillsaw fix --llm` for interactive development; use `skillsaw lint --fix --llm` for CI or scripted workflows.
+Set the environment variables for your provider:
+
+| Provider | Environment Variables |
+|----------|----------------------|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Vertex AI | `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION` (+ `gcloud auth application-default login`) |
+| AWS Bedrock | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` |
+
+You can also set `SKILLSAW_MODEL` to override the default model via environment variable, or `llm.model` in your `.skillsaw.yaml` config.
+
+See the [LiteLLM provider documentation](https://docs.litellm.ai/docs/providers) for the full list of supported providers and their required environment variables.
 
 ## Custom Rules
 

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Warns when instruction and configuration files exceed recommended token limits. 
 
 ### Content Intelligence
 
-Rules that go beyond structural validation to analyze the *quality* of instruction files. Built on attention research ([lost-in-the-middle](https://arxiv.org/abs/2307.03172), [instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) and prompt engineering best practices. All support LLM-powered fixes via `skillsaw fix --llm`. See [docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) for the full research basis behind each rule.
+Rules that go beyond structural validation to analyze the *quality* of instruction files. Built on attention research ([lost-in-the-middle](https://arxiv.org/abs/2307.03172), [instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) and prompt engineering best practices. Most support LLM-powered fixes via `skillsaw fix --llm`. See [docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) for the full research basis behind each rule.
 
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
@@ -650,7 +650,7 @@ Examples: adding missing frontmatter, renaming files to kebab-case, registering 
 
 ### LLM-Powered Fixes
 
-All content intelligence rules support LLM-powered fixes. The LLM reads your instruction files, rewrites violations, and re-lints in a loop until the file is clean — or rolls back if it made things worse.
+Most content intelligence rules support LLM-powered fixes (see the **Autofix** column above). The LLM reads your instruction files, rewrites violations, and re-lints in a loop until the file is clean — or rolls back if it made things worse.
 
 ```bash
 skillsaw fix --llm                          # Fix with default model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.9.0"
+version = "0.9.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -107,7 +107,7 @@ RULE_GROUPS = [
         "instruction files. Built on attention research "
         "([lost-in-the-middle](https://arxiv.org/abs/2307.03172), "
         "[instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) "
-        "and prompt engineering best practices. All support LLM-powered fixes via "
+        "and prompt engineering best practices. Most support LLM-powered fixes via "
         "`skillsaw fix --llm`. See "
         "[docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) "
         "for the full research basis behind each rule.",

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -108,7 +108,7 @@ RULE_GROUPS = [
         "([lost-in-the-middle](https://arxiv.org/abs/2307.03172), "
         "[instruction-following limits](https://openreview.net/forum?id=R6q67CDBCH)) "
         "and prompt engineering best practices. All support LLM-powered fixes via "
-        "`--fix --llm`. See "
+        "`skillsaw fix --llm`. See "
         "[docs/designs/content-rules-research.md](docs/designs/content-rules-research.md) "
         "for the full research basis behind each rule.",
     ),

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -402,17 +402,12 @@ def _run_lint(args):
         import warnings
 
         fix_cmd = "skillsaw fix --llm" if args.use_llm else "skillsaw fix"
-        warnings.warn(
+        msg = (
             f"`skillsaw lint --fix` is deprecated and will be removed in 1.0. "
-            f"Use `{fix_cmd}` instead.",
-            DeprecationWarning,
-            stacklevel=1,
+            f"Use `{fix_cmd}` instead."
         )
-        print(
-            f"Warning: `skillsaw lint --fix` is deprecated and will be removed in 1.0. "
-            f"Use `{fix_cmd}` instead.",
-            file=sys.stderr,
-        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=1)
+        print(f"Warning: {msg}", file=sys.stderr)
         violations, fixes = linter.fix()
         applied = linter.apply_fixes(fixes)
         if applied and args.fmt == "text":

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -399,6 +399,20 @@ def _run_lint(args):
     linter = Linter(context, config)
 
     if args.fix:
+        import warnings
+
+        fix_cmd = "skillsaw fix --llm" if args.use_llm else "skillsaw fix"
+        warnings.warn(
+            f"`skillsaw lint --fix` is deprecated and will be removed in 1.0. "
+            f"Use `{fix_cmd}` instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        print(
+            f"Warning: `skillsaw lint --fix` is deprecated and will be removed in 1.0. "
+            f"Use `{fix_cmd}` instead.",
+            file=sys.stderr,
+        )
         violations, fixes = linter.fix()
         applied = linter.apply_fixes(fixes)
         if applied and args.fmt == "text":


### PR DESCRIPTION
## Summary

- `skillsaw lint --fix` (both deterministic and LLM) now emits a deprecation warning pointing to `skillsaw fix` — will be removed in 1.0
- README rewritten to document only the `fix` subcommand (no more `lint --fix` examples)
- New **LLM Setup** section with install extras (`[llm]`, `[vertexai]`, `[bedrock]`), `uvx` equivalents, provider env var table, and link to [LiteLLM provider docs](https://docs.litellm.ai/docs/providers)
- Updated `generate-docs.py` Content Intelligence group description

## Test plan

- [x] `make test` — 1094 passed, 14 skipped
- [x] `make lint` — clean
- [x] `make update` — docs regenerated
- [x] `skillsaw lint --fix` shows deprecation warning on stderr
- [x] `skillsaw fix --help` shows `--model` and all options
- [x] Tested against `openshift-eng/ai-helpers` — exit 0
- [x] No stale `lint --fix` references in README (only the deprecation note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated LLM setup section for provider installation and model override guidance.

* **Documentation**
  * Standardized CLI guidance to promote `skillsaw fix` with a separate `--llm` flag for LLM-powered fixes.
  * Reorganized Autofixing docs, updated example flags and Quick Start examples, and clarified LLM usage.
  * Added deprecation note that `skillsaw lint --fix` will be removed in 1.0 and updated messaging.

* **Chores**
  * Project version bumped to 0.9.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/160)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->