### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Report a false positive, false negative, crash, or other bug
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of issue
+      options:
+        - False positive (flagged something that should be allowed)
+        - False negative (missed something that should be flagged)
+        - Crash / traceback
+        - Incorrect line number or message
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: rule
+    attributes:
+      label: Rule ID
+      description: >
+        Which rule is involved? (e.g. `missing-description`, `trigger-too-broad`).
+        Leave blank if not rule-specific.
+      placeholder: e.g. missing-description
+
+  - type: input
+    id: version
+    attributes:
+      label: skillsaw version
+      description: Output of `skillsaw --version`
+      placeholder: e.g. 0.9.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducer
+      description: >
+        Minimal skill file or repo layout that triggers the bug.
+        Wrap file contents in a fenced code block.
+      placeholder: |
+        ```yaml
+        # agentskills.yaml
+        skills:
+          - name: my-skill
+            ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: >
+        What actually happened. Include the full skillsaw output
+        (with `--verbose` if possible).
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: >
+        Paste your `.skillsaw.yaml` / `.claudelint.yaml` if you have one,
+        or note if you're using default settings.
+      render: yaml
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help (OS, Python version, CI environment, etc.)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,9 +20,9 @@ body:
     attributes:
       label: Rule ID
       description: >
-        Which rule is involved? (e.g. `missing-description`, `trigger-too-broad`).
+        Which rule is involved? (e.g. `content-weak-language`, `agentskill-description`).
         Leave blank if not rule-specific.
-      placeholder: e.g. missing-description
+      placeholder: e.g. content-weak-language
 
   - type: input
     id: version
@@ -64,7 +64,8 @@ body:
       label: Actual behavior
       description: >
         What actually happened. Include the full skillsaw output
-        (with `--verbose` if possible).
+        (with `--verbose` if possible). Please redact secrets, tokens,
+        and private paths before posting.
     validations:
       required: true
 
@@ -74,7 +75,8 @@ body:
       label: Configuration
       description: >
         Paste your `.skillsaw.yaml` / `.claudelint.yaml` if you have one,
-        or note if you're using default settings.
+        or note if you're using default settings. Redact any secrets
+        or sensitive values first.
       render: yaml
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest a new rule, option, or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of feature
+      options:
+        - New lint rule
+        - New option for an existing rule
+        - CLI / output improvement
+        - Integration (GitHub Action, CI, editor)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like skillsaw to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: >
+        Why is this useful? Link to a real skill or marketplace where
+        this would have caught an issue or improved the experience.
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples
+      description: >
+        Show what should pass and what should fail under the proposed
+        behavior, if applicable.


### PR DESCRIPTION
## Summary
- Adds structured issue templates for bug reports (false positives, crashes, etc.) and feature requests
- Bug report template asks for issue kind, rule ID, version, reproducer, expected/actual behavior, and config
- Feature request template asks for feature kind, description, motivation, and examples
- Blank issues remain enabled via config.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a structured bug report template with required fields for kind, version, reproduction steps, expected and actual behavior, and contextual details
  * Added a structured feature request template with kind, description, motivation, and examples
  * Enabled support for creating blank issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/161)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->