### PR TITLE
Address review feedback on #163: guard tests, add line-number assertions

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -94,6 +94,8 @@ rules:
   agentskill-valid:
     enabled: auto
     severity: error
+    # required-fields: []
+    # required-metadata: []
 
   # Skill name must be lowercase with hyphens and match directory name
   agentskill-name:

--- a/README.md
+++ b/README.md
@@ -471,6 +471,13 @@ These rules validate skills against the [agentskills.io specification](https://a
 | `agentskill-evals` | Validate evals/evals.json format when present | error (auto) | - |
 | `agentskill-evals-required` | Require evals/evals.json for each skill (opt-in) | error (disabled) | - |
 
+**`agentskill-valid` parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `required-fields` | Additional frontmatter fields to require (name and description are always required) | `[]` |
+| `required-metadata` | Keys that must be present inside the metadata mapping | `[]` |
+
 **`agentskill-structure` parameters:**
 
 | Parameter | Description | Default |

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -38,6 +38,21 @@ class AgentSkillValidRule(Rule):
         RepositoryType.DOT_CLAUDE,
     }
 
+    BUILTIN_REQUIRED = {"name", "description"}
+
+    config_schema = {
+        "required-fields": {
+            "type": "list",
+            "default": [],
+            "description": "Additional frontmatter fields to require (name and description are always required)",
+        },
+        "required-metadata": {
+            "type": "list",
+            "default": [],
+            "description": "Keys that must be present inside the metadata mapping",
+        },
+    }
+
     @property
     def rule_id(self) -> str:
         return "agentskill-valid"
@@ -242,6 +257,40 @@ class AgentSkillValidRule(Rule):
                             line=at_line,
                         )
                     )
+
+            extra_required = self.config.get("required-fields", [])
+            for field_name in extra_required:
+                if field_name in self.BUILTIN_REQUIRED:
+                    continue
+                if field_name not in frontmatter:
+                    violations.append(
+                        self.violation(
+                            f"Missing required field '{field_name}'",
+                            file_path=block.path,
+                        )
+                    )
+
+            required_meta = self.config.get("required-metadata", [])
+            if required_meta:
+                meta = frontmatter.get("metadata")
+                if meta is None:
+                    violations.append(
+                        self.violation(
+                            "Missing required 'metadata' (needed for required-metadata check)",
+                            file_path=block.path,
+                        )
+                    )
+                elif isinstance(meta, dict):
+                    meta_line = block.key_line("metadata")
+                    for key in required_meta:
+                        if key not in meta:
+                            violations.append(
+                                self.violation(
+                                    f"Missing required metadata key '{key}'",
+                                    file_path=block.path,
+                                    line=meta_line,
+                                )
+                            )
 
         return violations
 

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -262,28 +262,33 @@ class AgentSkillValidRule(Rule):
             for field_name in extra_required:
                 if field_name in self.BUILTIN_REQUIRED:
                     continue
-                if field_name not in frontmatter:
+                if not frontmatter.get(field_name):
+                    line = block.key_line(field_name) if field_name in frontmatter else None
                     violations.append(
                         self.violation(
                             f"Missing required field '{field_name}'",
                             file_path=block.path,
+                            line=line,
                         )
                     )
 
             required_meta = self.config.get("required-metadata", [])
             if required_meta:
                 meta = frontmatter.get("metadata")
+                meta_line = block.key_line("metadata")
                 if meta is None:
-                    violations.append(
-                        self.violation(
-                            "Missing required 'metadata' (needed for required-metadata check)",
-                            file_path=block.path,
+                    if "metadata" not in extra_required:
+                        violations.append(
+                            self.violation(
+                                "Missing required 'metadata' (needed for required-metadata check)",
+                                file_path=block.path,
+                                line=meta_line,
+                            )
                         )
-                    )
                 elif isinstance(meta, dict):
-                    meta_line = block.key_line("metadata")
                     for key in required_meta:
-                        if key not in meta:
+                        val = meta.get(key)
+                        if val is None or (isinstance(val, str) and not val.strip()):
                             violations.append(
                                 self.violation(
                                     f"Missing required metadata key '{key}'",

--- a/tests/fixtures/config/required-fields/.skillsaw.yaml
+++ b/tests/fixtures/config/required-fields/.skillsaw.yaml
@@ -1,0 +1,10 @@
+version: "99.0.0"
+rules:
+  agentskill-valid:
+    enabled: true
+    required-fields:
+      - license
+      - metadata
+    required-metadata:
+      - author
+      - org

--- a/tests/fixtures/config/required-fields/complete-skill/SKILL.md
+++ b/tests/fixtures/config/required-fields/complete-skill/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: complete-skill
+description: A skill with all required fields and metadata
+license: MIT
+metadata:
+  author: test-user
+  org: acme-corp
+  version: "1.0"
+---
+
+# Complete Skill
+
+This skill has all required fields and metadata keys present.
+
+## When to Use This Skill
+
+Use for testing that a fully populated skill passes validation.
+
+## Implementation Steps
+
+### Step 1: Do the thing
+
+Run the command.

--- a/tests/fixtures/config/required-fields/missing-fields-skill/SKILL.md
+++ b/tests/fixtures/config/required-fields/missing-fields-skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: missing-fields-skill
+description: A skill that is missing license and metadata
+---
+
+# Missing Fields Skill
+
+This skill is missing the configured required fields (license, metadata).
+
+## When to Use This Skill
+
+Use for testing that missing required fields are reported.
+
+## Implementation Steps
+
+### Step 1: Do the thing
+
+Run the command.

--- a/tests/fixtures/config/required-fields/missing-metadata-key/SKILL.md
+++ b/tests/fixtures/config/required-fields/missing-metadata-key/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: missing-metadata-key
+description: A skill with metadata but missing required keys
+license: Apache-2.0
+metadata:
+  author: test-user
+---
+
+# Missing Metadata Key
+
+This skill has metadata but is missing the required 'org' key.
+
+## When to Use This Skill
+
+Use for testing that missing metadata keys are reported.
+
+## Implementation Steps
+
+### Step 1: Do the thing
+
+Run the command.

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -997,3 +997,60 @@ def test_required_metadata_skipped_when_metadata_not_dict(temp_dir):
     violations = rule.check(context)
     assert any("mapping" in v.message for v in violations)
     assert not any("metadata key" in v.message for v in violations)
+
+
+def test_required_fields_null_value_triggers_error(temp_dir):
+    skill = temp_dir / "null-license"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: null-license\ndescription: A skill\nlicense:\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": ["license"]})
+    violations = rule.check(context)
+    assert any("Missing required field 'license'" in v.message for v in violations)
+    v = next(v for v in violations if "Missing required field 'license'" in v.message)
+    assert v.line is not None
+
+
+def test_required_metadata_null_value_triggers_error(temp_dir):
+    skill = temp_dir / "null-author"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: null-author\ndescription: A skill\nmetadata:\n  author:\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author"]})
+    violations = rule.check(context)
+    assert any("Missing required metadata key 'author'" in v.message for v in violations)
+
+
+def test_required_metadata_empty_string_triggers_error(temp_dir):
+    skill = temp_dir / "empty-author"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: empty-author\ndescription: A skill\nmetadata:\n  author: '  '\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author"]})
+    violations = rule.check(context)
+    assert any("Missing required metadata key 'author'" in v.message for v in violations)
+
+
+def test_required_metadata_no_duplicate_when_metadata_in_required_fields(temp_dir):
+    """When metadata is in required-fields and also missing, don't emit a second violation from required-metadata."""
+    skill = temp_dir / "no-dup"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: no-dup\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(
+        config={"required-fields": ["metadata"], "required-metadata": ["author"]}
+    )
+    violations = rule.check(context)
+    meta_violations = [v for v in violations if "metadata" in v.message.lower()]
+    assert len(meta_violations) == 1
+    assert "Missing required field 'metadata'" in meta_violations[0].message

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -828,3 +828,172 @@ def test_allowed_tools_invalid_type_fails(temp_dir):
     context = RepositoryContext(skill)
     violations = AgentSkillValidRule().check(context)
     assert any("allowed-tools" in v.message for v in violations)
+
+
+# --- required-fields config ---
+
+
+def test_required_fields_missing_triggers_error(temp_dir):
+    skill = temp_dir / "no-license"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: no-license\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": ["license"]})
+    violations = rule.check(context)
+    assert any("Missing required field 'license'" in v.message for v in violations)
+
+
+def test_required_fields_present_passes(temp_dir):
+    skill = temp_dir / "has-license"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: has-license\ndescription: A skill\nlicense: MIT\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": ["license"]})
+    violations = rule.check(context)
+    assert not any("Missing required field" in v.message for v in violations)
+
+
+def test_required_fields_builtin_not_duplicated(temp_dir):
+    """Listing 'name' in required-fields should not produce duplicate violations."""
+    skill = temp_dir / "builtin-dup"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: builtin-dup\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": ["name", "description"]})
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_required_fields_multiple_missing(temp_dir):
+    skill = temp_dir / "bare"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: bare\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": ["license", "compatibility"]})
+    violations = rule.check(context)
+    missing = [v for v in violations if "Missing required field" in v.message]
+    assert len(missing) == 2
+    messages = {v.message for v in missing}
+    assert "Missing required field 'license'" in messages
+    assert "Missing required field 'compatibility'" in messages
+
+
+def test_required_fields_empty_config_no_extra_checks(temp_dir):
+    skill = temp_dir / "default"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: default\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-fields": []})
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+# --- required-metadata config ---
+
+
+def test_required_metadata_missing_metadata_triggers_error(temp_dir):
+    skill = temp_dir / "no-meta"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: no-meta\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author"]})
+    violations = rule.check(context)
+    assert any("Missing required 'metadata'" in v.message for v in violations)
+
+
+def test_required_metadata_missing_key_triggers_error(temp_dir):
+    skill = temp_dir / "meta-no-author"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: meta-no-author\ndescription: A skill\nmetadata:\n  version: '1.0'\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author"]})
+    violations = rule.check(context)
+    assert any("Missing required metadata key 'author'" in v.message for v in violations)
+    v = [v for v in violations if "metadata key" in v.message][0]
+    assert v.line is not None
+
+
+def test_required_metadata_present_passes(temp_dir):
+    skill = temp_dir / "meta-ok"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: meta-ok\ndescription: A skill\nmetadata:\n  author: test\n  org: acme\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author", "org"]})
+    violations = rule.check(context)
+    assert not any(
+        "metadata" in v.message.lower() and "missing" in v.message.lower() for v in violations
+    )
+
+
+def test_required_metadata_multiple_missing(temp_dir):
+    skill = temp_dir / "meta-sparse"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: meta-sparse\ndescription: A skill\nmetadata:\n  version: '1.0'\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author", "org"]})
+    violations = rule.check(context)
+    meta_violations = [v for v in violations if "metadata key" in v.message]
+    assert len(meta_violations) == 2
+
+
+def test_required_metadata_empty_config_no_extra_checks(temp_dir):
+    skill = temp_dir / "meta-default"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: meta-default\ndescription: A skill\n---\n")
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": []})
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_required_fields_and_metadata_combined(temp_dir):
+    """Both options work together."""
+    skill = temp_dir / "combined"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: combined\ndescription: A skill\nlicense: MIT\n"
+        "metadata:\n  author: test\n  org: acme\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(
+        config={
+            "required-fields": ["license", "metadata"],
+            "required-metadata": ["author", "org"],
+        }
+    )
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_required_metadata_skipped_when_metadata_not_dict(temp_dir):
+    """required-metadata check is skipped when metadata is not a mapping (already caught by type check)."""
+    skill = temp_dir / "meta-bad-type"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: meta-bad-type\ndescription: A skill\nmetadata: not-a-map\n---\n"
+    )
+
+    context = RepositoryContext(skill)
+    rule = AgentSkillValidRule(config={"required-metadata": ["author"]})
+    violations = rule.check(context)
+    assert any("mapping" in v.message for v in violations)
+    assert not any("metadata key" in v.message for v in violations)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -678,6 +678,7 @@ class TestRequiredFieldsConfig:
     def test_complete_skill_passes(self, tmp_path):
         repo = copy_fixture("config/required-fields", tmp_path)
         r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
         vs = [
             v
             for v in violations(r)
@@ -688,6 +689,7 @@ class TestRequiredFieldsConfig:
     def test_missing_required_fields_reported(self, tmp_path):
         repo = copy_fixture("config/required-fields", tmp_path)
         r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
         vs = [
             v
             for v in violations(r)
@@ -696,10 +698,13 @@ class TestRequiredFieldsConfig:
         messages = [v["message"] for v in vs]
         assert any("Missing required field 'license'" in m for m in messages)
         assert any("metadata" in m.lower() for m in messages)
+        license_v = next(v for v in vs if "Missing required field 'license'" in v["message"])
+        assert license_v.get("line") is None
 
     def test_missing_metadata_key_reported(self, tmp_path):
         repo = copy_fixture("config/required-fields", tmp_path)
         r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
         vs = [
             v
             for v in violations(r)
@@ -708,12 +713,15 @@ class TestRequiredFieldsConfig:
         messages = [v["message"] for v in vs]
         assert any("Missing required metadata key 'org'" in m for m in messages)
         assert not any("Missing required metadata key 'author'" in m for m in messages)
+        org_v = next(v for v in vs if "Missing required metadata key 'org'" in v["message"])
+        assert org_v.get("line") is not None
 
     def test_no_extra_violations_without_config(self, tmp_path):
         """Without required-fields config, no extra violations are raised."""
         repo = copy_fixture("config/required-fields", tmp_path)
         (repo / ".skillsaw.yaml").unlink()
         r = run_lint(repo)
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
         vs = [
             v
             for v in violations(r)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -666,3 +666,58 @@ class TestOptInRules:
         ids = rule_ids(r)
         for rule in OPT_IN_RULES:
             assert rule not in ids, f"Opt-in rule '{rule}' fired without being enabled"
+
+
+# ── Required Fields / Required Metadata ────────────────────────
+
+
+@pytest.mark.integration
+class TestRequiredFieldsConfig:
+    """Verify that required-fields and required-metadata config options work end-to-end."""
+
+    def test_complete_skill_passes(self, tmp_path):
+        repo = copy_fixture("config/required-fields", tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [
+            v
+            for v in violations(r)
+            if "complete-skill" in v["file_path"] and v["rule_id"] == "agentskill-valid"
+        ]
+        assert len(vs) == 0, f"Complete skill should have no agentskill-valid violations: {vs}"
+
+    def test_missing_required_fields_reported(self, tmp_path):
+        repo = copy_fixture("config/required-fields", tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [
+            v
+            for v in violations(r)
+            if "missing-fields-skill" in v["file_path"] and v["rule_id"] == "agentskill-valid"
+        ]
+        messages = [v["message"] for v in vs]
+        assert any("Missing required field 'license'" in m for m in messages)
+        assert any("metadata" in m.lower() for m in messages)
+
+    def test_missing_metadata_key_reported(self, tmp_path):
+        repo = copy_fixture("config/required-fields", tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [
+            v
+            for v in violations(r)
+            if "missing-metadata-key" in v["file_path"] and v["rule_id"] == "agentskill-valid"
+        ]
+        messages = [v["message"] for v in vs]
+        assert any("Missing required metadata key 'org'" in m for m in messages)
+        assert not any("Missing required metadata key 'author'" in m for m in messages)
+
+    def test_no_extra_violations_without_config(self, tmp_path):
+        """Without required-fields config, no extra violations are raised."""
+        repo = copy_fixture("config/required-fields", tmp_path)
+        (repo / ".skillsaw.yaml").unlink()
+        r = run_lint(repo)
+        vs = [
+            v
+            for v in violations(r)
+            if "Missing required field" in v["message"]
+            or "Missing required metadata key" in v["message"]
+        ]
+        assert len(vs) == 0, f"Should have no required-field violations without config: {vs}"


### PR DESCRIPTION
## Summary

Addresses the outstanding CodeRabbit review feedback from #163:

- Add `assert r["out"] is not None` guards to all four `TestRequiredFieldsConfig` tests so they fail fast if the linter crashes instead of silently passing with empty violations
- Add line-number semantic assertions: missing required fields report no line (`None`), missing metadata keys report a line anchor (not `None`)

Closes #163 (supersedes it with review fixes applied)

## Test plan

- [x] All 1257 tests pass, 14 skipped
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable validation options for the agentskill-valid rule: specify extra required frontmatter fields and required metadata keys.

* **Documentation**
  * README updated with parameter table and docs for the new agentskill-valid options.
  * Example configuration updated to show the new options (commented out).

* **Tests**
  * Unit and integration tests added to cover required-fields and required-metadata behaviors and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/168)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->