### PR TITLE
Filter PR review action by pr-for-agent label

### DIFF
--- a/.github/workflows/skillsaw-pr-review.yml
+++ b/.github/workflows/skillsaw-pr-review.yml
@@ -43,9 +43,8 @@ jobs:
           COLLABS=$(gh api "repos/${{ github.repository }}/collaborators" --jq '[.[].login]')
           echo "Collaborators: $COLLABS"
 
-          # Open PRs from claude bot only
-          PRS=$(gh pr list --state open --json number,title,author \
-            | jq '[.[] | select(.author.login == "app/claude")]')
+          # Open PRs with pr-for-agent label
+          PRS=$(gh pr list --state open --label pr-for-agent --json number,title,author)
 
           if [ -z "$PRS" ] || [ "$PRS" = "[]" ]; then
             echo "No open PRs from claude"


### PR DESCRIPTION
## Summary
- Replace author-based filtering (`app/claude` only) with label-based filtering (`pr-for-agent`) in the PR review workflow
- Allows the agent to pick up and fix PRs from any author, not just claude bot
- Collaborator-only filtering on review comments is unchanged

## Test plan
- [ ] Add `pr-for-agent` label to a test PR and verify the action picks it up
- [ ] Verify PRs without the label are ignored
- [ ] Verify review comments are still filtered to collaborators only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR review automation to use label-based selection for improved workflow organization.

---

**Note:** This release contains no user-facing changes. The update is an internal infrastructure modification to streamline the PR review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->