### PR TITLE
Include rule ID in text formatter output

### DIFF
--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -36,7 +36,7 @@ def format_text(
         location = ""
         if rel:
             location = f" [{rel}:{v.file_line}]" if v.file_line else f" [{rel}]"
-        return f"{icon} {v.severity.value.upper()}{location}: {v.message}"
+        return f"{icon} {v.severity.value.upper()} ({v.rule_id}){location}: {v.message}"
 
     output = []
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -183,6 +183,16 @@ def test_text_shows_violations(valid_plugin):
     assert "kebab-case" in output
 
 
+def test_text_includes_rule_id(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_text(violations, context, [], "0.0.0", verbose=True)
+    assert "(plugin-json-required)" in output
+    assert "(command-naming)" in output
+    assert "(plugin-json-valid)" in output
+
+
 def test_text_verbose_shows_info(valid_plugin):
     context = RepositoryContext(valid_plugin)
     violations = _make_violations()


### PR DESCRIPTION
## Summary
- The text formatter was the only output format that didn't show which rule triggered a violation — JSON, SARIF, and HTML all included it.
- Violations now display as `✗ ERROR (rule-id) [file:line]: message` instead of `✗ ERROR [file:line]: message`.

## Test plan
- [x] Added `test_text_includes_rule_id` verifying all three severity levels show their rule ID
- [x] Full test suite passes (1351 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Violations now display the rule identifier alongside the severity level in the formatted output for improved clarity.

* **Tests**
  * Added test coverage to verify rule identifiers are properly included in formatted violation output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/179)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->