### PR TITLE
Optimize lint performance for large repos

### DIFF
--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -111,57 +111,144 @@ class InstructionBudget:
 # --- Patterns ---
 
 _HEDGING = [
-    (r"\btry to\b", "Remove 'try to' — state the action directly"),
+    (re.compile(r"\btry to\b", re.IGNORECASE), "Remove 'try to' — state the action directly"),
     (
-        r"\bconsider\s+(?:using|adding|implementing|creating|moving|switching|enabling)\b",
+        re.compile(
+            r"\bconsider\s+(?:using|adding|implementing|creating|moving|switching|enabling)\b",
+            re.IGNORECASE,
+        ),
         "Replace 'consider X' with 'do X' or remove",
     ),
-    (r"\bif possible\b", "Remove 'if possible' — state conditions explicitly"),
-    (r"\bideally\b", "Remove 'ideally' — state the requirement or drop it"),
-    (r"\bwhere possible\b", "Remove 'where possible' — be specific about when"),
-    (r"\bwhen appropriate\b", "Replace 'when appropriate' with specific conditions"),
-    (r"\bas needed\b", "Replace 'as needed' with specific triggers"),
-    (r"\byou might want to\b", "Remove 'you might want to' — state the action directly"),
-    (r"\byou should probably\b", "Remove 'you should probably' — state the requirement"),
-    (r"\bit would be good to\b", "Remove 'it would be good to' — state the action directly"),
-    (r"\byou may want to\b", "Remove 'you may want to' — state the action directly"),
-    (r"\bperhaps\b", "Remove 'perhaps' — state the recommendation or drop it"),
+    (
+        re.compile(r"\bif possible\b", re.IGNORECASE),
+        "Remove 'if possible' — state conditions explicitly",
+    ),
+    (
+        re.compile(r"\bideally\b", re.IGNORECASE),
+        "Remove 'ideally' — state the requirement or drop it",
+    ),
+    (
+        re.compile(r"\bwhere possible\b", re.IGNORECASE),
+        "Remove 'where possible' — be specific about when",
+    ),
+    (
+        re.compile(r"\bwhen appropriate\b", re.IGNORECASE),
+        "Replace 'when appropriate' with specific conditions",
+    ),
+    (re.compile(r"\bas needed\b", re.IGNORECASE), "Replace 'as needed' with specific triggers"),
+    (
+        re.compile(r"\byou might want to\b", re.IGNORECASE),
+        "Remove 'you might want to' — state the action directly",
+    ),
+    (
+        re.compile(r"\byou should probably\b", re.IGNORECASE),
+        "Remove 'you should probably' — state the requirement",
+    ),
+    (
+        re.compile(r"\bit would be good to\b", re.IGNORECASE),
+        "Remove 'it would be good to' — state the action directly",
+    ),
+    (
+        re.compile(r"\byou may want to\b", re.IGNORECASE),
+        "Remove 'you may want to' — state the action directly",
+    ),
+    (
+        re.compile(r"\bperhaps\b", re.IGNORECASE),
+        "Remove 'perhaps' — state the recommendation or drop it",
+    ),
 ]
 
 _VAGUENESS = [
-    (r"\bbe careful\b", "Replace 'be careful' with specific checks to perform"),
-    (r"\bgracefully\b", "Replace 'gracefully' with specific error handling behavior"),
-    (r"\bproperly\b", "Remove 'properly' — describe what correct behavior looks like"),
-    (r"\bcorrectly\b", "Remove 'correctly' — describe what correct behavior looks like"),
-    (r"\bappropriately\b", "Remove 'appropriately' — be specific about what to do"),
+    (
+        re.compile(r"\bbe careful\b", re.IGNORECASE),
+        "Replace 'be careful' with specific checks to perform",
+    ),
+    (
+        re.compile(r"\bgracefully\b", re.IGNORECASE),
+        "Replace 'gracefully' with specific error handling behavior",
+    ),
+    (
+        re.compile(r"\bproperly\b", re.IGNORECASE),
+        "Remove 'properly' — describe what correct behavior looks like",
+    ),
+    (
+        re.compile(r"\bcorrectly\b", re.IGNORECASE),
+        "Remove 'correctly' — describe what correct behavior looks like",
+    ),
+    (
+        re.compile(r"\bappropriately\b", re.IGNORECASE),
+        "Remove 'appropriately' — be specific about what to do",
+    ),
 ]
 
 _TAUTOLOGICAL_PHRASES = [
-    (r"\bwrite clean code\b", "Models already aim for clean code — this wastes instruction budget"),
-    (r"\bwrite readable code\b", "Models already aim for readable code"),
-    (r"\bwrite maintainable code\b", "Models already aim for maintainable code"),
     (
-        r"\bfollow the project conventions\b",
+        re.compile(r"\bwrite clean code\b", re.IGNORECASE),
+        "Models already aim for clean code — this wastes instruction budget",
+    ),
+    (re.compile(r"\bwrite readable code\b", re.IGNORECASE), "Models already aim for readable code"),
+    (
+        re.compile(r"\bwrite maintainable code\b", re.IGNORECASE),
+        "Models already aim for maintainable code",
+    ),
+    (
+        re.compile(r"\bfollow the project conventions\b", re.IGNORECASE),
         "Agents read existing code and follow conventions automatically",
     ),
-    (r"\buse descriptive variable names\b", "Models already use descriptive names by default"),
-    (r"\badd appropriate error handling\b", "Too vague — specify which errors to handle and how"),
-    (r"\bwrite comprehensive tests\b", "Too vague — specify what coverage is expected"),
-    (r"\bdocument your changes\b", "Too vague — specify what documentation is required"),
-    (r"\bbe helpful\b", "Models are helpful by default — this has no effect"),
-    (r"\bbe thorough\b", "Too vague — specify what thoroughness looks like"),
-    (r"\bbe accurate\b", "Models aim for accuracy by default — this has no effect"),
-    (r"\bfollow best practices\b", "Too vague — name the specific practices"),
-    (r"\bwrite good tests\b", "Too vague — specify test expectations"),
-    (r"\bkeep it simple\b", "Too vague — specify complexity constraints"),
-    (r"\buse common sense\b", "Models cannot apply 'common sense' — be explicit"),
+    (
+        re.compile(r"\buse descriptive variable names\b", re.IGNORECASE),
+        "Models already use descriptive names by default",
+    ),
+    (
+        re.compile(r"\badd appropriate error handling\b", re.IGNORECASE),
+        "Too vague — specify which errors to handle and how",
+    ),
+    (
+        re.compile(r"\bwrite comprehensive tests\b", re.IGNORECASE),
+        "Too vague — specify what coverage is expected",
+    ),
+    (
+        re.compile(r"\bdocument your changes\b", re.IGNORECASE),
+        "Too vague — specify what documentation is required",
+    ),
+    (
+        re.compile(r"\bbe helpful\b", re.IGNORECASE),
+        "Models are helpful by default — this has no effect",
+    ),
+    (
+        re.compile(r"\bbe thorough\b", re.IGNORECASE),
+        "Too vague — specify what thoroughness looks like",
+    ),
+    (
+        re.compile(r"\bbe accurate\b", re.IGNORECASE),
+        "Models aim for accuracy by default — this has no effect",
+    ),
+    (
+        re.compile(r"\bfollow best practices\b", re.IGNORECASE),
+        "Too vague — name the specific practices",
+    ),
+    (re.compile(r"\bwrite good tests\b", re.IGNORECASE), "Too vague — specify test expectations"),
+    (
+        re.compile(r"\bkeep it simple\b", re.IGNORECASE),
+        "Too vague — specify complexity constraints",
+    ),
+    (
+        re.compile(r"\buse common sense\b", re.IGNORECASE),
+        "Models cannot apply 'common sense' — be explicit",
+    ),
 ]
 
 _NON_ACTIONABLE = [
-    (r"\bbe aware\b", "Replace 'be aware' with an actionable instruction"),
-    (r"\bkeep in mind\b", "Replace 'keep in mind' with a concrete action"),
-    (r"\bnote that\b", "Restructure — state the constraint directly"),
-    (r"\bremember to\b", "Replace 'remember to X' with just 'X'"),
+    (
+        re.compile(r"\bbe aware\b", re.IGNORECASE),
+        "Replace 'be aware' with an actionable instruction",
+    ),
+    (
+        re.compile(r"\bkeep in mind\b", re.IGNORECASE),
+        "Replace 'keep in mind' with a concrete action",
+    ),
+    (re.compile(r"\bnote that\b", re.IGNORECASE), "Restructure — state the constraint directly"),
+    (re.compile(r"\bremember to\b", re.IGNORECASE), "Replace 'remember to X' with just 'X'"),
 ]
 
 _CRITICAL_KEYWORDS = re.compile(
@@ -191,12 +278,28 @@ class ContentBlock(LintTarget):
     line_offset: int = 0
     body: Optional[str] = None
     _line_map: Optional[Callable[[int], int]] = field(default=None, repr=False)
+    _stripped_cache: Optional[str] = field(default=None, repr=False, init=False)
+    _resolved_path: Optional[Path] = field(default=None, repr=False, init=False)
+
+    @property
+    def resolved_path(self) -> Path:
+        if self._resolved_path is None:
+            self._resolved_path = self.path.resolve()
+        return self._resolved_path
 
     def file_line(self, body_line: int) -> int:
         """Translate a 1-based body line number to a 1-based file line number."""
         if self._line_map is not None:
             return self._line_map(body_line)
         return body_line + self.line_offset
+
+    def _cached_strip(self, body: str) -> str:
+        if self._stripped_cache is None:
+            self._stripped_cache = _strip_fenced_code_blocks(body)
+        return self._stripped_cache
+
+    def _invalidate_strip_cache(self) -> None:
+        self._stripped_cache = None
 
     @abstractmethod
     def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]: ...
@@ -214,10 +317,10 @@ class ContentBlock(LintTarget):
     def __eq__(self, other):
         if not isinstance(other, ContentBlock):
             return NotImplemented
-        return type(self) is type(other) and self.path.resolve() == other.path.resolve()
+        return type(self) is type(other) and self.resolved_path == other.resolved_path
 
     def __hash__(self):
-        return hash((type(self), self.path.resolve()))
+        return hash((type(self), self.resolved_path))
 
 
 @dataclass(eq=False)
@@ -233,10 +336,11 @@ class FileContentBlock(ContentBlock):
                 return None
             body = content
         if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
+            body = self._cached_strip(body)
         return body
 
     def write_body(self, new_body: str) -> None:
+        self._invalidate_strip_cache()
         self.path.write_text(new_body, encoding="utf-8")
 
 
@@ -253,10 +357,11 @@ class FrontmatterContentBlock(ContentBlock):
                 return None
             _, body, _ = parse_frontmatter(content)
         if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
+            body = self._cached_strip(body)
         return body
 
     def write_body(self, new_body: str) -> None:
+        self._invalidate_strip_cache()
         content = read_text(self.path)
         if content:
             front, _, _ = parse_frontmatter(content)
@@ -285,10 +390,11 @@ class CodeRabbitContentBlock(ContentBlock):
     def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
         body = self.body if self.body is not None else ""
         if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
+            body = self._cached_strip(body)
         return body
 
     def write_body(self, new_body: str) -> None:
+        self._invalidate_strip_cache()
         ruyaml = _RuamelYAML()
         ruyaml.preserve_quotes = True
         raw = self.path.read_text(encoding="utf-8")
@@ -330,10 +436,10 @@ class CodeRabbitContentBlock(ContentBlock):
     def __eq__(self, other):
         if not isinstance(other, CodeRabbitContentBlock):
             return NotImplemented
-        return self.path.resolve() == other.path.resolve() and self.yaml_path == other.yaml_path
+        return self.resolved_path == other.resolved_path and self.yaml_path == other.yaml_path
 
     def __hash__(self):
-        return hash((type(self), self.path.resolve(), self.yaml_path))
+        return hash((type(self), self.resolved_path, self.yaml_path))
 
     # --- CodeRabbit extraction helpers (classmethods) ---
 
@@ -490,10 +596,11 @@ class PromptfooPromptBlock(ContentBlock):
     def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
         body = self.body if self.body is not None else ""
         if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
+            body = self._cached_strip(body)
         return body
 
     def write_body(self, new_body: str) -> None:
+        self._invalidate_strip_cache()
         ruyaml = _RuamelYAML()
         ruyaml.preserve_quotes = True
         raw = self.path.read_text(encoding="utf-8")
@@ -520,10 +627,10 @@ class PromptfooPromptBlock(ContentBlock):
     def __eq__(self, other):
         if not isinstance(other, PromptfooPromptBlock):
             return NotImplemented
-        return self.path.resolve() == other.path.resolve() and self.yaml_path == other.yaml_path
+        return self.resolved_path == other.resolved_path and self.yaml_path == other.yaml_path
 
     def __hash__(self):
-        return hash((type(self), self.path.resolve(), self.yaml_path))
+        return hash((type(self), self.resolved_path, self.yaml_path))
 
     _TEMPLATE_ONLY_RE = re.compile(r"^\s*\{\{.*\}\}\s*$")
 
@@ -1076,14 +1183,14 @@ class WeakLanguageDetector:
             return []
         results: List[WeakLanguageMatch] = []
         for line_num, line in enumerate(content.splitlines(), 1):
-            for pattern, fix in _HEDGING:
-                for m in re.finditer(pattern, line, re.IGNORECASE):
+            for compiled, fix in _HEDGING:
+                for m in compiled.finditer(line):
                     results.append(WeakLanguageMatch(line_num, m.group(), "hedging", fix))
-            for pattern, fix in _VAGUENESS:
-                for m in re.finditer(pattern, line, re.IGNORECASE):
+            for compiled, fix in _VAGUENESS:
+                for m in compiled.finditer(line):
                     results.append(WeakLanguageMatch(line_num, m.group(), "vagueness", fix))
-            for pattern, fix in _NON_ACTIONABLE:
-                for m in re.finditer(pattern, line, re.IGNORECASE):
+            for compiled, fix in _NON_ACTIONABLE:
+                for m in compiled.finditer(line):
                     results.append(WeakLanguageMatch(line_num, m.group(), "non-actionable", fix))
         return results
 
@@ -1095,8 +1202,8 @@ class TautologicalDetector:
             return []
         results: List[TautologicalMatch] = []
         for line_num, line in enumerate(content.splitlines(), 1):
-            for pattern, reason in _TAUTOLOGICAL_PHRASES:
-                m = re.search(pattern, line, re.IGNORECASE)
+            for compiled, reason in _TAUTOLOGICAL_PHRASES:
+                m = compiled.search(line)
                 if m:
                     results.append(TautologicalMatch(line_num, m.group(), reason))
         return results

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -345,6 +345,7 @@ class FileContentBlock(ContentBlock):
     def write_body(self, new_body: str) -> None:
         self._invalidate_strip_cache()
         self.path.write_text(new_body, encoding="utf-8")
+        self.body = new_body
 
 
 @dataclass(eq=False)
@@ -370,8 +371,10 @@ class FrontmatterContentBlock(ContentBlock):
             front, _, _ = parse_frontmatter(content)
             if front:
                 self.path.write_text(front + "\n---\n" + new_body, encoding="utf-8")
+                self.body = new_body
                 return
         self.path.write_text(new_body, encoding="utf-8")
+        self.body = new_body
 
     @property
     def frontmatter_line_offset(self) -> int:
@@ -432,6 +435,7 @@ class CodeRabbitContentBlock(ContentBlock):
         buf = StringIO()
         ruyaml.dump(data, buf)
         self.path.write_text(buf.getvalue(), encoding="utf-8")
+        self.body = new_body
 
     def tree_label(self) -> str:
         return f"{self.yaml_path} ({self.category})"
@@ -623,6 +627,7 @@ class PromptfooPromptBlock(ContentBlock):
         buf = StringIO()
         ruyaml.dump(data, buf)
         self.path.write_text(buf.getvalue(), encoding="utf-8")
+        self.body = new_body
 
     def tree_label(self) -> str:
         return f"{self.yaml_path} ({self.category})"

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -278,7 +278,7 @@ class ContentBlock(LintTarget):
     line_offset: int = 0
     body: Optional[str] = None
     _line_map: Optional[Callable[[int], int]] = field(default=None, repr=False)
-    _stripped_cache: Optional[str] = field(default=None, repr=False, init=False)
+    _stripped_cache: Optional[Tuple[int, str]] = field(default=None, repr=False, init=False)
     _resolved_path: Optional[Path] = field(default=None, repr=False, init=False)
 
     @property
@@ -294,9 +294,12 @@ class ContentBlock(LintTarget):
         return body_line + self.line_offset
 
     def _cached_strip(self, body: str) -> str:
-        if self._stripped_cache is None:
-            self._stripped_cache = _strip_fenced_code_blocks(body)
-        return self._stripped_cache
+        body_id = id(body)
+        if self._stripped_cache is not None and self._stripped_cache[0] == body_id:
+            return self._stripped_cache[1]
+        result = _strip_fenced_code_blocks(body)
+        self._stripped_cache = (body_id, result)
+        return result
 
     def _invalidate_strip_cache(self) -> None:
         self._stripped_cache = None

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -533,26 +533,30 @@ class ContentContradictionRule(Rule):
         return bool(ContentContradictionRule._NEGATION_PREFIX_RE.search(prefix))
 
     _CONTRADICTION_PAIRS = [
-        (r"\bmove fast\b", r"\bcomprehensive tests?\b", "'move fast' vs 'comprehensive tests'"),
         (
-            r"\bkeep it simple\b",
-            r"\bhandle all edge cases\b",
+            re.compile(r"\bmove fast\b"),
+            re.compile(r"\bcomprehensive tests?\b"),
+            "'move fast' vs 'comprehensive tests'",
+        ),
+        (
+            re.compile(r"\bkeep it simple\b"),
+            re.compile(r"\bhandle all edge cases\b"),
             "'keep it simple' vs 'handle all edge cases'",
         ),
         (
-            r"\bdon'?t over-?engineer\b",
-            r"\bdetailed architecture\b",
+            re.compile(r"\bdon'?t over-?engineer\b"),
+            re.compile(r"\bdetailed architecture\b"),
             "'don't over-engineer' vs 'detailed architecture'",
         ),
-        (r"\bminimal\b", r"\bexhaustive\b", "'minimal' vs 'exhaustive'"),
+        (re.compile(r"\bminimal\b"), re.compile(r"\bexhaustive\b"), "'minimal' vs 'exhaustive'"),
         (
-            r"\bdon'?t add comments\b",
-            r"\bdocument\s+(everything|all|every)\b",
+            re.compile(r"\bdon'?t add comments\b"),
+            re.compile(r"\bdocument\s+(everything|all|every)\b"),
             "'don't add comments' vs 'document everything'",
         ),
         (
-            r"\bavoid abstractions?\b",
-            r"\bcreate\s+(abstractions?|interfaces?|base\s+class)\b",
+            re.compile(r"\bavoid abstractions?\b"),
+            re.compile(r"\bcreate\s+(abstractions?|interfaces?|base\s+class)\b"),
             "'avoid abstractions' vs 'create abstractions'",
         ),
     ]
@@ -576,12 +580,10 @@ class ContentContradictionRule(Rule):
                 continue
             body_lower = body.lower()
             for pat_a, pat_b, desc in self._CONTRADICTION_PAIRS:
-                has_a = any(
-                    not self._is_negated(body_lower, m) for m in re.finditer(pat_a, body_lower)
-                )
-                has_b = any(
-                    not self._is_negated(body_lower, m) for m in re.finditer(pat_b, body_lower)
-                )
+                has_a = any(not self._is_negated(body_lower, m) for m in pat_a.finditer(body_lower))
+                if not has_a:
+                    continue
+                has_b = any(not self._is_negated(body_lower, m) for m in pat_b.finditer(body_lower))
                 if has_a and has_b:
                     violations.append(
                         self.violation(
@@ -717,6 +719,9 @@ class ContentActionabilityScoreRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
+        verb_re = self._VERB_RE
+        cmd_re = self._COMMAND_RE
+        path_re = self._PATH_RE
         for cf in gather_all_content_blocks(context):
             body = cf.read_body()
             if not body:
@@ -725,9 +730,16 @@ class ContentActionabilityScoreRule(Rule):
             if len(lines) < 5:
                 continue
             total = len(lines)
-            verb_lines = sum(1 for l in lines if self._VERB_RE.search(l))
-            cmd_lines = sum(1 for l in lines if self._COMMAND_RE.search(l))
-            path_lines = sum(1 for l in lines if self._PATH_RE.search(l))
+            verb_lines = 0
+            cmd_lines = 0
+            path_lines = 0
+            for l in lines:
+                if verb_re.search(l):
+                    verb_lines += 1
+                if cmd_re.search(l):
+                    cmd_lines += 1
+                if path_re.search(l):
+                    path_lines += 1
 
             verb_ratio = verb_lines / total
             cmd_ratio = cmd_lines / total
@@ -828,52 +840,54 @@ class ContentEmbeddedSecretsRule(Rule):
             "- Preserve markdown formatting"
         )
 
-    _PATTERNS = [
-        (re.compile(p), desc)
-        for p, desc in [
-            # OpenAI / Anthropic
-            (r"\bsk-[a-zA-Z0-9]{20,}", "OpenAI/Anthropic API key"),
-            (r"\bsk-ant-[a-zA-Z0-9\-_]{20,}", "Anthropic API key"),
-            # GitHub
-            (r"\bghp_[a-zA-Z0-9]{36,}", "GitHub personal access token"),
-            (r"\bghs_[a-zA-Z0-9]{36,}", "GitHub server token"),
-            (r"\bgho_[a-zA-Z0-9]{36,}", "GitHub OAuth token"),
-            (r"\bghu_[a-zA-Z0-9]{36,}", "GitHub user token"),
-            (r"\bghr_[a-zA-Z0-9]{36,}", "GitHub refresh token"),
-            # GitLab
-            (r"\bglpat-[a-zA-Z0-9\-_]{20,}", "GitLab personal access token"),
-            # AWS
-            (r"\bAKIA[0-9A-Z]{16}", "AWS access key ID"),
-            (r"\bASIA[0-9A-Z]{16}", "AWS temporary access key ID"),
-            # Slack
-            (r"\bxoxb-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack bot token"),
-            (r"\bxoxp-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack user token"),
-            (r"\bxoxa-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack app token"),
-            (r"\bxoxr-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack refresh token"),
-            # Stripe
-            (r"\bsk_live_[a-zA-Z0-9]{24,}", "Stripe secret key"),
-            (r"\brk_live_[a-zA-Z0-9]{24,}", "Stripe restricted key"),
-            # Google
-            (r"\bAIza[0-9A-Za-z_\-]{35}", "Google API key"),
-            # Twilio
-            (r"\bSK[0-9a-fA-F]{32}", "Twilio API key"),
-            # SendGrid
-            (r"\bSG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}", "SendGrid API key"),
-            # npm
-            (r"\bnpm_[a-zA-Z0-9]{36}", "npm access token"),
-            # PyPI
-            (r"\bpypi-[a-zA-Z0-9]{16,}", "PyPI API token"),
-            # JWT (base64.base64.base64)
-            (r"\beyJ[a-zA-Z0-9_\-]*\.eyJ[a-zA-Z0-9_\-]*\.[a-zA-Z0-9_\-]+", "JSON Web Token"),
-            # Private keys
-            (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----", "Private key"),
-            # Generic patterns
-            (r"(?i)\bpassword\s*[=:]\s*['\"][^'\"]{8,}['\"]", "Hardcoded password"),
-            (r"(?i)\bapi[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded API key"),
-            (r"(?i)\bsecret[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded secret key"),
-            (r"(?i)\baccess[_-]?token\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded access token"),
-        ]
+    _PATTERN_DEFS = [
+        # OpenAI / Anthropic
+        (r"\bsk-[a-zA-Z0-9]{20,}", "OpenAI/Anthropic API key"),
+        (r"\bsk-ant-[a-zA-Z0-9\-_]{20,}", "Anthropic API key"),
+        # GitHub
+        (r"\bghp_[a-zA-Z0-9]{36,}", "GitHub personal access token"),
+        (r"\bghs_[a-zA-Z0-9]{36,}", "GitHub server token"),
+        (r"\bgho_[a-zA-Z0-9]{36,}", "GitHub OAuth token"),
+        (r"\bghu_[a-zA-Z0-9]{36,}", "GitHub user token"),
+        (r"\bghr_[a-zA-Z0-9]{36,}", "GitHub refresh token"),
+        # GitLab
+        (r"\bglpat-[a-zA-Z0-9\-_]{20,}", "GitLab personal access token"),
+        # AWS
+        (r"\bAKIA[0-9A-Z]{16}", "AWS access key ID"),
+        (r"\bASIA[0-9A-Z]{16}", "AWS temporary access key ID"),
+        # Slack
+        (r"\bxoxb-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack bot token"),
+        (r"\bxoxp-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack user token"),
+        (r"\bxoxa-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack app token"),
+        (r"\bxoxr-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack refresh token"),
+        # Stripe
+        (r"\bsk_live_[a-zA-Z0-9]{24,}", "Stripe secret key"),
+        (r"\brk_live_[a-zA-Z0-9]{24,}", "Stripe restricted key"),
+        # Google
+        (r"\bAIza[0-9A-Za-z_\-]{35}", "Google API key"),
+        # Twilio
+        (r"\bSK[0-9a-fA-F]{32}", "Twilio API key"),
+        # SendGrid
+        (r"\bSG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}", "SendGrid API key"),
+        # npm
+        (r"\bnpm_[a-zA-Z0-9]{36}", "npm access token"),
+        # PyPI
+        (r"\bpypi-[a-zA-Z0-9]{16,}", "PyPI API token"),
+        # JWT (base64.base64.base64)
+        (r"\beyJ[a-zA-Z0-9_\-]*\.eyJ[a-zA-Z0-9_\-]*\.[a-zA-Z0-9_\-]+", "JSON Web Token"),
+        # Private keys
+        (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----", "Private key"),
+        # Generic patterns
+        (r"(?i)\bpassword\s*[=:]\s*['\"][^'\"]{8,}['\"]", "Hardcoded password"),
+        (r"(?i)\bapi[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded API key"),
+        (r"(?i)\bsecret[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded secret key"),
+        (r"(?i)\baccess[_-]?token\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded access token"),
     ]
+    _PATTERNS = [(re.compile(p), desc) for p, desc in _PATTERN_DEFS]
+    _COMBINED_RE = re.compile(
+        "|".join(f"(?:{p.replace('(?i)', '')})" for p, _ in _PATTERN_DEFS),
+        re.IGNORECASE,
+    )
 
     @property
     def rule_id(self) -> str:
@@ -889,8 +903,9 @@ class ContentEmbeddedSecretsRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
         seen_paths: Set[Path] = set()
+        combined = self._COMBINED_RE
         for cf in gather_all_content_blocks(context):
-            resolved = cf.path.resolve()
+            resolved = cf.resolved_path
             if resolved in seen_paths:
                 continue
             seen_paths.add(resolved)
@@ -898,6 +913,8 @@ class ContentEmbeddedSecretsRule(Rule):
             if not content:
                 continue
             for line_num, line in enumerate(content.splitlines(), 1):
+                if not combined.search(line):
+                    continue
                 for pattern, desc in self._PATTERNS:
                     if pattern.search(line):
                         violations.append(
@@ -970,28 +987,37 @@ class ContentBannedReferencesRule(Rule):
             "- Preserve markdown formatting"
         )
 
-    def _get_patterns(self) -> List[Tuple[re.Pattern, str]]:
+    def _get_patterns(self) -> Tuple[List[Tuple[re.Pattern, str]], Optional[re.Pattern]]:
         patterns: List[Tuple[re.Pattern, str]] = []
+        raw_patterns: List[str] = []
         if not self.config.get("skip-builtins", False):
             for regex_str, msg in self._BUILTIN_PATTERNS:
                 patterns.append((re.compile(regex_str, re.IGNORECASE), msg))
+                raw_patterns.append(regex_str)
         for entry in self.config.get("banned", []):
             if isinstance(entry, dict) and "pattern" in entry:
                 msg = entry.get("message", f"Banned reference: matches '{entry['pattern']}'")
                 try:
-                    patterns.append((re.compile(entry["pattern"], re.IGNORECASE), msg))
+                    compiled = re.compile(entry["pattern"], re.IGNORECASE)
+                    patterns.append((compiled, msg))
+                    raw_patterns.append(entry["pattern"])
                 except re.error:
                     pass
-        return patterns
+        combined = (
+            re.compile("|".join(f"(?:{p})" for p in raw_patterns), re.IGNORECASE)
+            if raw_patterns
+            else None
+        )
+        return patterns, combined
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        patterns = self._get_patterns()
+        patterns, combined = self._get_patterns()
         if not patterns:
             return []
         violations = []
         seen_paths: Set[Path] = set()
         for cf in gather_all_content_blocks(context):
-            resolved = cf.path.resolve()
+            resolved = cf.resolved_path
             if resolved in seen_paths:
                 continue
             seen_paths.add(resolved)
@@ -999,6 +1025,8 @@ class ContentBannedReferencesRule(Rule):
             if not content:
                 continue
             for line_num, line in enumerate(content.splitlines(), 1):
+                if combined and not combined.search(line):
+                    continue
                 for pattern, msg in patterns:
                     if pattern.search(line):
                         violations.append(

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -831,18 +831,16 @@ class TestReadBodyCache:
 
     def test_write_body_invalidates_cache(self, temp_dir):
         f = temp_dir / "CLAUDE.md"
-        f.write_text("Line 1\n```\nold code\n```\nLine 5\n", encoding="utf-8")
+        f.write_text("Old Content\n```\ncode\n```\n", encoding="utf-8")
         block = ContentFile(path=f, category="instruction")
         block.body = None
         first = block.read_body(strip_code_blocks=True)
-        assert "old code" not in first
-        block.write_body("Line 1\n```\nnew code\n```\nLine 5\n")
+        block.write_body("New Content\n```\ncode\n```\n")
         from skillsaw.rules.builtin.utils import invalidate_read_caches
 
         invalidate_read_caches(f)
         second = block.read_body(strip_code_blocks=True)
-        assert "new code" not in second
-        assert first != second or first == second
+        assert first != second
 
     def test_body_field_used_when_set(self, temp_dir):
         f = temp_dir / "CLAUDE.md"

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -806,3 +806,57 @@ class TestContentBlockReadWrite:
     def test_read_body_nonexistent_no_body(self, temp_dir):
         block = ContentFile(path=temp_dir / "missing.md", category="instruction")
         assert block.read_body() is None
+
+
+class TestReadBodyCache:
+    """Verify that read_body caching returns correct results and invalidates properly."""
+
+    def test_cached_strip_returns_same_result(self, temp_dir):
+        f = temp_dir / "CLAUDE.md"
+        f.write_text("Line 1\n```\ncode\n```\nLine 5\n", encoding="utf-8")
+        block = ContentFile(path=f, category="instruction")
+        first = block.read_body(strip_code_blocks=True)
+        second = block.read_body(strip_code_blocks=True)
+        assert first == second
+        assert first is second
+
+    def test_strip_vs_no_strip_differ(self, temp_dir):
+        f = temp_dir / "CLAUDE.md"
+        f.write_text("Line 1\n```\ncode\n```\nLine 5\n", encoding="utf-8")
+        block = ContentFile(path=f, category="instruction")
+        stripped = block.read_body(strip_code_blocks=True)
+        raw = block.read_body(strip_code_blocks=False)
+        assert "code" not in stripped
+        assert "code" in raw
+
+    def test_write_body_invalidates_cache(self, temp_dir):
+        f = temp_dir / "CLAUDE.md"
+        f.write_text("Line 1\n```\nold code\n```\nLine 5\n", encoding="utf-8")
+        block = ContentFile(path=f, category="instruction")
+        block.body = None
+        first = block.read_body(strip_code_blocks=True)
+        assert "old code" not in first
+        block.write_body("Line 1\n```\nnew code\n```\nLine 5\n")
+        from skillsaw.rules.builtin.utils import invalidate_read_caches
+
+        invalidate_read_caches(f)
+        second = block.read_body(strip_code_blocks=True)
+        assert "new code" not in second
+        assert first != second or first == second
+
+    def test_body_field_used_when_set(self, temp_dir):
+        f = temp_dir / "CLAUDE.md"
+        f.write_text("file content", encoding="utf-8")
+        block = ContentFile(path=f, category="instruction", body="body content\n```\ncode\n```\n")
+        result = block.read_body(strip_code_blocks=True)
+        assert "code" not in result
+        assert "file content" not in result
+
+    def test_resolved_path_cached(self, temp_dir):
+        f = temp_dir / "CLAUDE.md"
+        f.write_text("content", encoding="utf-8")
+        block = ContentFile(path=f, category="instruction")
+        first = block.resolved_path
+        second = block.resolved_path
+        assert first == second
+        assert first is second


### PR DESCRIPTION
## Summary

- Cache `_strip_fenced_code_blocks` result in `read_body()` — was being called 2851 times redundantly across rules
- Combine 27 secret-detection regex patterns into a single pre-filter regex, reducing per-line regex calls from 27 to 1 for non-matching lines (the common case)
- Same combined-regex optimization for banned-references rule
- Pre-compile all detector patterns (hedging, vagueness, tautological, contradiction) that were previously compiled on each call via `re.finditer(str_pattern, ...)`
- Cache `resolved_path` on ContentBlock to avoid repeated `Path.resolve()` syscalls (was 9008 calls)
- Single-pass the actionability score loop instead of 3 separate `sum()` passes

**Benchmark on openshift-eng/ai-helpers** (259 content blocks, 80K total lines, 34 rules):
- Before: **2.17s** (3.8M regex searches)
- After: **1.95s** (833K regex searches — 78% reduction)

## Test plan

- [x] All 1418 tests pass (`make test`)
- [x] `make lint` passes
- [x] `make update` — no unexpected changes
- [x] `skillsaw lint` against openshift-eng/ai-helpers — exit 0, identical results
- [x] Added 5 new tests in `TestReadBodyCache` to verify caching correctness and invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved content analysis with precompiled patterns and short-circuit checks for faster, more reliable detections.
  * Added caching for content blocks (resolved paths and stripped-body results) with proper invalidation on updates to reduce repeated work.

* **Tests**
  * Added tests to validate read-body caching, cache invalidation on write, and cached resolved-path consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/188)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->