### PR TITLE
Fix Pages deploy: remove unused custom_dir

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
   favicon: images/logo-only.png
   icon:
     repo: fontawesome/brands/github
-  custom_dir: docs/overrides
+
 
 extra_css:
   - stylesheets/custom.css


### PR DESCRIPTION
## Summary

- Removes `custom_dir: docs/overrides` from mkdocs.yml — the directory was empty and not tracked by git, causing `mkdocs build` to fail in CI

Fixes https://github.com/stbenjam/skillsaw/actions/runs/26457026911/job/77893831478

## Test plan

- [x] `mkdocs build` succeeds locally after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)