### PR TITLE
Omit null values from baseline JSON; promote Baseline in docs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - Repository Types: repo-types.md
   - Configuration: configuration.md
   - Autofixing: autofixing.md
+  - Baseline: baseline.md
   - Rules:
     - rules/index.md
     - AgentSkills: rules/agentskills.md
@@ -94,7 +95,6 @@ nav:
     - Promptfoo: rules/promptfoo.md
     - APM: rules/apm.md
   - Guides:
-    - Baseline: baseline.md
     - custom-rules.md
     - scaffolding.md
     - ci.md

--- a/src/skillsaw/baseline.py
+++ b/src/skillsaw/baseline.py
@@ -140,7 +140,9 @@ def save_baseline(path: Path, baseline: BaselineFile) -> None:
         "version": baseline.version,
         "generated_by": baseline.generated_by,
         "generated_at": baseline.generated_at,
-        "violations": [asdict(e) for e in baseline.violations],
+        "violations": [
+            {k: v for k, v in asdict(e).items() if v is not None} for e in baseline.violations
+        ],
     }
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 

--- a/src/skillsaw/baseline.py
+++ b/src/skillsaw/baseline.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections import Counter
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -141,7 +141,7 @@ def save_baseline(path: Path, baseline: BaselineFile) -> None:
         "generated_by": baseline.generated_by,
         "generated_at": baseline.generated_at,
         "violations": [
-            {k: v for k, v in asdict(e).items() if v is not None} for e in baseline.violations
+            {k: v for k, v in e.__dict__.items() if v is not None} for e in baseline.violations
         ],
     }
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Omit null-valued fields from baseline JSON entries to reduce file size
- Move Baseline from Guides subsection to top-level nav item, directly below Autofixing

## Test plan
- [x] All 1471 tests pass
- [x] Lint passes
- [x] `skillsaw` exits 0 against openshift-eng/ai-helpers
- [x] `load_baseline` already uses `.get()` with defaults, so missing keys are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized navigation structure with baseline documentation now accessible as a top-level item for improved discoverability.

* **Bug Fixes**
  * Updated baseline file format to exclude empty values, resulting in cleaner and more compact JSON output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->