### PR TITLE
Add security comments to CI workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
 - 🏗️ **Scaffolding** — `skillsaw add` generates plugins, skills, commands, agents, and hooks
 - 📝 **Docs** — `skillsaw docs` generates HTML or Markdown documentation
 - 🔌 **Extensible** — Custom rules, banned patterns, per-rule thresholds
-- 🤖 **CI-Ready** — GitHub Action with inline PR comments, deduplication, and thread resolution
+- 🤖 **CI-Ready** — GitHub Action with inline PR comments; GitLab Code Quality via `--format gitlab`
 - ⚡ **Version-Gated** — New rules gated behind config versions — no surprises on upgrade
 
 ## Table of Contents
@@ -44,7 +44,7 @@ Keep your skills sharp. A linter with built-in content intelligence for [agentsk
   - [Via pip](#via-pip)
   - [From source](#from-source)
   - [Using Docker](#using-docker)
-  - [GitHub Action](#github-action)
+  - [CI Integration](#ci-integration)
 - [Repository Types](#repository-types)
   - [agentskills.io Skills](#agentskillsio-skills)
   - [Single Plugin](#single-plugin)
@@ -178,105 +178,28 @@ docker pull ghcr.io/stbenjam/skillsaw:latest
 docker run -v $(pwd):/workspace ghcr.io/stbenjam/skillsaw
 ```
 
-### GitHub Action
-
-The GitHub Action installs skillsaw, runs it, and prints violations in the CI
-log. A separate review action posts violations as inline PR comments with
-automatic deduplication and thread resolution.
-
-#### Basic usage (lint only)
+### CI Integration
 
 ```yaml
-name: Lint
-
-on: [pull_request]
-
-permissions:
-  contents: read
-
-jobs:
-  skillsaw:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: stbenjam/skillsaw@v0
-        with:
-          strict: true
-```
-
-#### With PR review comments
-
-To post inline comments on PRs (including fork PRs), use the two-workflow
-pattern. The lint workflow runs with read-only permissions and uploads the
-report as an artifact. A second workflow triggers on completion and posts
-comments with write permissions — without ever checking out untrusted code.
-
-```yaml
-# .github/workflows/lint.yml
-name: Lint
-
-on:
-  pull_request:
-  push:
-    branches: [main]
-
-permissions:
-  contents: read
-
-jobs:
-  skillsaw:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: stbenjam/skillsaw@v0
-        with:
-          strict: true
+# GitHub Actions
+- uses: stbenjam/skillsaw@v0
+  with:
+    strict: true
 ```
 
 ```yaml
-# .github/workflows/lint-review.yml
-name: Lint Review
-
-on:
-  workflow_run:
-    workflows: ["Lint"]
-    types: [completed]
-
-jobs:
-  review:
-    if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v5
-      - uses: stbenjam/skillsaw/review@v0
+# GitLab CI — outputs Code Quality JSON for MR widgets
+skillsaw:
+  script:
+    - pip install skillsaw==0.11.0
+    - skillsaw lint --format gitlab . > gl-code-quality-report.json
+  artifacts:
+    reports:
+      codequality: gl-code-quality-report.json
 ```
 
-#### Inputs
-
-| Input | Description | Default |
-|-------|-------------|---------|
-| `path` | Path to lint | `.` |
-| `version` | Specific skillsaw version to install | latest |
-| `strict` | Treat warnings as errors | `false` |
-| `verbose` | Include info-level violations | `false` |
-
-#### Outputs
-
-| Output | Description |
-|--------|-------------|
-| `exit-code` | skillsaw exit code (0=pass, 1=errors, 2=strict+warnings) |
-| `errors` | Number of errors found |
-| `warnings` | Number of warnings found |
-| `report-file` | Path to JSON report file |
-
-#### PR comment behavior
-
-- Each violation gets its own inline comment on the relevant line or file
-- Comments are deduplicated across re-runs using content fingerprinting
-- When a violation is fixed, its comment thread is automatically resolved
-- Comments with human replies are preserved
+For PR review comments, the secure two-workflow pattern, and full configuration
+options, see the [CI Integration guide](https://skillsaw.org/ci/).
 
 ## Repository Types
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -106,6 +106,22 @@ jobs:
 | `warnings` | Number of warnings found |
 | `report-file` | Path to JSON report file |
 
+### Pinning to a commit SHA
+
+The examples above use `@v0` for brevity. For supply-chain protection,
+replace `@v0` with a pinned commit SHA:
+
+```yaml
+- uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
+```
+
+This prevents a compromised tag from injecting malicious code into your
+workflow. Find the current SHA for a tag with:
+
+```bash
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git v0
+```
+
 ### PR comment behavior
 
 - Each violation gets its own inline comment on the relevant line or file

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -80,9 +80,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # Checks out the base branch (main), not the PR branch — no untrusted
-      # code is executed. The checkout is needed for the action definition only.
-      - uses: actions/checkout@v5
       # Reads the lint report artifact from the Lint workflow and posts inline
       # PR comments. Does not run skillsaw or execute any PR code.
       - uses: stbenjam/skillsaw/review@v0

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -106,7 +106,7 @@ jobs:
 | `warnings` | Number of warnings found |
 | `report-file` | Path to JSON report file |
 
-### Pinning to a commit SHA
+### Supply Chain Protection
 
 The examples above use `@v0` for brevity. For supply-chain protection,
 replace `@v0` with a pinned commit SHA:
@@ -115,8 +115,10 @@ replace `@v0` with a pinned commit SHA:
 - uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
 ```
 
-This prevents a compromised tag from injecting malicious code into your
-workflow. Find the current SHA for a tag with:
+While this project follows current best practices — PyPI trusted provenance,
+2FA, signed releases — pinning to a SHA prevents a compromised tag from
+injecting malicious code into your workflow. Find the current SHA for a
+tag with:
 
 ```bash
 git ls-remote --tags https://github.com/stbenjam/skillsaw.git v0

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -42,6 +42,8 @@ on:
   push:
     branches: [main]
 
+# SECURITY: This workflow runs on untrusted PR code, so it has read-only
+# permissions. It cannot post comments — that's handled by lint-review.yml.
 permissions:
   contents: read
 
@@ -59,6 +61,12 @@ jobs:
 # .github/workflows/lint-review.yml
 name: Lint Review
 
+# SECURITY: workflow_run triggers run in the context of the BASE branch (main),
+# not the PR branch. This workflow never checks out or executes untrusted PR
+# code — it only downloads the lint report artifact produced by the Lint
+# workflow and posts review comments. This is GitHub's recommended pattern for
+# safely granting write permissions to PR feedback workflows.
+# See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
 on:
   workflow_run:
     workflows: ["Lint"]
@@ -66,12 +74,17 @@ on:
 
 jobs:
   review:
+    # Only run for pull requests, not push events.
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      # Checks out the base branch (main), not the PR branch — no untrusted
+      # code is executed. The checkout is needed for the action definition only.
       - uses: actions/checkout@v5
+      # Reads the lint report artifact from the Lint workflow and posts inline
+      # PR comments. Does not run skillsaw or execute any PR code.
       - uses: stbenjam/skillsaw/review@v0
 ```
 


### PR DESCRIPTION
## Summary
- Add inline comments to the two-workflow CI examples in `docs/ci.md` explaining why the pattern is safe
- Covers: why lint has read-only perms, why `workflow_run` runs in base branch context, why the review workflow never executes PR code
- Aims to prevent false positives from security scanners (zizmor, CodeRabbit) that flag `workflow_run` without considering the usage pattern

Prompted by https://github.com/opendatahub-io/odh-test-gen/pull/25#discussion_r3312864096

## Test plan
- [x] `make lint` passes
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CI workflow documentation with enhanced security explanations, covering permission models and code execution safeguards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->