### PR TITLE
Bump upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
 
     - name: Upload report artifact
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: skillsaw-report
         path: ${{ steps.lint.outputs.report-file }}
@@ -104,7 +104,7 @@ runs:
         echo '${{ github.event.pull_request.head.sha }}' > /tmp/skillsaw-head-sha
     - name: Upload PR metadata
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: skillsaw-pr-metadata
         path: |

--- a/review/action.yml
+++ b/review/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download report artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: skillsaw-report
         path: /tmp/skillsaw-review
@@ -22,7 +22,7 @@ runs:
         github-token: ${{ inputs.token }}
 
     - name: Download PR metadata
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: skillsaw-pr-metadata
         path: /tmp/skillsaw-review


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` from v4 to v7 in `action.yml`
- Bump `actions/download-artifact` from v4 to v8 in `review/action.yml`

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

## Test plan
- [x] CI should pass on this PR (exercises both actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)