### PR TITLE
Fix frontmatter write_body corruption and line offset bugs

### DIFF
--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -28,6 +28,7 @@ from skillsaw.rules.builtin.utils import (
     extract_section,
     frontmatter_key_line as _frontmatter_key_line,
     _extract_frontmatter_text,
+    _FRONTMATTER_RE,
     yaml_line_map as _yaml_line_map,
     yaml_key_line as _yaml_key_line_util,
     yaml_key_line_after as _yaml_key_line_after_util,
@@ -259,9 +260,12 @@ class FrontmatterContentBlock(ContentBlock):
     def write_body(self, new_body: str) -> None:
         content = read_text(self.path)
         if content:
-            front, _, _ = parse_frontmatter(content)
-            if front:
-                self.path.write_text(front + "\n---\n" + new_body, encoding="utf-8")
+            m = _FRONTMATTER_RE.match(content)
+            if m:
+                raw_fm = m.group(0)
+                if not raw_fm.endswith("\n"):
+                    raw_fm += "\n"
+                self.path.write_text(raw_fm + new_body, encoding="utf-8")
                 return
         self.path.write_text(new_body, encoding="utf-8")
 
@@ -270,10 +274,10 @@ class FrontmatterContentBlock(ContentBlock):
         content = read_text(self.path)
         if not content:
             return 0
-        front, _, _ = parse_frontmatter(content)
-        if front is None:
+        fm_text, _ = _extract_frontmatter_text(content)
+        if fm_text is None:
             return 0
-        return front.count("\n") + 2  # frontmatter + closing ---
+        return fm_text.count("\n") + 2  # frontmatter + closing ---
 
 
 @dataclass(eq=False)

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -271,7 +271,7 @@ class FrontmatterContentBlock(ContentBlock):
         if not content:
             return 0
         front, _, _ = parse_frontmatter(content)
-        if not front:
+        if front is None:
             return 0
         return front.count("\n") + 2  # frontmatter + closing ---
 

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -14,6 +14,7 @@ from skillsaw.rules.builtin.content_analysis import (
     gather_all_instruction_files,
     gather_all_content_files,
     ContentFile,
+    FrontmatterContentBlock,
     _strip_fenced_code_blocks,
 )
 from skillsaw.context import RepositoryContext
@@ -786,6 +787,18 @@ class TestContentBlockReadWrite:
         block = ContentFile(path=f, category="instruction")
         block.write_body("new content")
         assert f.read_text(encoding="utf-8") == "new content"
+
+    def test_frontmatter_write_body_preserves_raw_frontmatter(self, temp_dir):
+        """Regression: write_body must preserve raw frontmatter, not write dict repr."""
+        f = temp_dir / "test.mdc"
+        f.write_text("---\nname: my-rule\ndescription: A test rule\n---\noriginal body\n")
+        block = FrontmatterContentBlock(path=f, category="cursor-rule")
+        block.write_body("new body\n")
+        result = f.read_text(encoding="utf-8")
+        assert result.startswith("---\n")
+        assert "name: my-rule" in result
+        assert "new body" in result
+        assert "{" not in result, "dict repr was written instead of raw YAML"
 
     def test_file_line_with_offset(self):
         block = ContentFile(


### PR DESCRIPTION
## Summary
- **write_body crash**: `FrontmatterContentBlock.write_body()` called `parse_frontmatter()` which returns a dict, then tried to concatenate it with strings — crashes with `TypeError: unsupported operand type(s) for +: 'dict' and 'str'` on any LLM autofix of `.mdc` files or files with YAML frontmatter
- **frontmatter_line_offset**: Used `parse_frontmatter()` (returns dict) and called `.count("\n")` on it — would crash with `AttributeError` if reached

Both fixed by using `_FRONTMATTER_RE` / `_extract_frontmatter_text` which work with raw strings.

Found by Gemini in #190 (closed without merging).

## Test plan
- [x] New regression test confirms crash without fix, passes with fix
- [x] All 1489 tests pass
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)