### PR TITLE
Fix .mdc line offset by re-parenting CursorRuleBlock

### DIFF
--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -28,7 +28,6 @@ from skillsaw.rules.builtin.utils import (
     extract_section,
     frontmatter_key_line as _frontmatter_key_line,
     _extract_frontmatter_text,
-    _FRONTMATTER_RE,
     yaml_line_map as _yaml_line_map,
     yaml_key_line as _yaml_key_line_util,
     yaml_key_line_after as _yaml_key_line_after_util,
@@ -239,45 +238,6 @@ class FileContentBlock(ContentBlock):
 
     def write_body(self, new_body: str) -> None:
         self.path.write_text(new_body, encoding="utf-8")
-
-
-@dataclass(eq=False)
-class FrontmatterContentBlock(ContentBlock):
-    """A file with YAML frontmatter (e.g. .mdc) — frontmatter is stripped on read, preserved on write."""
-
-    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
-        if self.body is not None:
-            body = self.body
-        else:
-            content = read_text(self.path)
-            if content is None:
-                return None
-            _, body, _ = parse_frontmatter(content)
-        if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
-        return body
-
-    def write_body(self, new_body: str) -> None:
-        content = read_text(self.path)
-        if content:
-            m = _FRONTMATTER_RE.match(content)
-            if m:
-                raw_fm = m.group(0)
-                if not raw_fm.endswith("\n"):
-                    raw_fm += "\n"
-                self.path.write_text(raw_fm + new_body, encoding="utf-8")
-                return
-        self.path.write_text(new_body, encoding="utf-8")
-
-    @property
-    def frontmatter_line_offset(self) -> int:
-        content = read_text(self.path)
-        if not content:
-            return 0
-        fm_text, _ = _extract_frontmatter_text(content)
-        if fm_text is None:
-            return 0
-        return fm_text.count("\n") + 2  # frontmatter + closing ---
 
 
 @dataclass(eq=False)
@@ -598,13 +558,6 @@ class GeminiMdBlock(InstructionBlock):
     category: str = "gemini-md"
 
 
-@dataclass(eq=False)
-class CursorRuleBlock(FrontmatterContentBlock):
-    """.cursor/rules/*.mdc files."""
-
-    category: str = "instruction"
-
-
 def _parse_file_frontmatter(
     path: Path,
 ) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]:
@@ -725,6 +678,13 @@ class ParsedFrontmatterBlock(FileContentBlock):
         else:
             self.path.write_text(f"---\n{fm}---\n{content}", encoding="utf-8")
         self._fm_parsed = None
+
+
+@dataclass(eq=False)
+class CursorRuleBlock(ParsedFrontmatterBlock):
+    """.cursor/rules/*.mdc files."""
+
+    category: str = "instruction"
 
 
 @dataclass(eq=False)

--- a/tests/fixtures/cursor-rules/broken/.cursor/rules/test-rule.mdc
+++ b/tests/fixtures/cursor-rules/broken/.cursor/rules/test-rule.mdc
@@ -1,0 +1,12 @@
+---
+description: Test rule for reproducing line offset bug
+globs: "*.py"
+---
+
+# Python Guidelines
+
+Use 4-space indentation for all Python files.
+
+Run tests before committing changes.
+
+You should probably try to make sure tests work correctly before pushing.

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -14,7 +14,7 @@ from skillsaw.rules.builtin.content_analysis import (
     gather_all_instruction_files,
     gather_all_content_files,
     ContentFile,
-    FrontmatterContentBlock,
+    CursorRuleBlock,
     _strip_fenced_code_blocks,
 )
 from skillsaw.context import RepositoryContext
@@ -788,17 +788,15 @@ class TestContentBlockReadWrite:
         block.write_body("new content")
         assert f.read_text(encoding="utf-8") == "new content"
 
-    def test_frontmatter_write_body_preserves_raw_frontmatter(self, temp_dir):
-        """Regression: write_body must preserve raw frontmatter, not write dict repr."""
+    def test_cursor_rule_block_reads_full_file(self, temp_dir):
+        """CursorRuleBlock reads full file content including frontmatter."""
         f = temp_dir / "test.mdc"
-        f.write_text("---\nname: my-rule\ndescription: A test rule\n---\noriginal body\n")
-        block = FrontmatterContentBlock(path=f, category="cursor-rule")
-        block.write_body("new body\n")
-        result = f.read_text(encoding="utf-8")
-        assert result.startswith("---\n")
-        assert "name: my-rule" in result
-        assert "new body" in result
-        assert "{" not in result, "dict repr was written instead of raw YAML"
+        f.write_text("---\ndescription: A test rule\n---\noriginal body\n")
+        block = CursorRuleBlock(path=f)
+        body = block.read_body()
+        assert "---" in body
+        assert "description: A test rule" in body
+        assert "original body" in body
 
     def test_file_line_with_offset(self):
         block = ContentFile(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -295,6 +295,22 @@ class TestAgentskills:
 
 
 @pytest.mark.integration
+class TestCursorRules:
+
+    def test_mdc_frontmatter_line_offset(self, tmp_path):
+        """Violations in .mdc files must report file line numbers, not body-relative."""
+        repo = copy_fixture("cursor-rules/broken", tmp_path)
+        r = run_lint(repo)
+        weak = by_rule(r)["content-weak-language"]
+        assert len(weak) >= 1
+        for v in weak:
+            assert v["line"] == 12, (
+                f"expected file line 12, got {v['line']} "
+                f"(off by {12 - v['line']} due to missing frontmatter offset)"
+            )
+
+
+@pytest.mark.integration
 class TestDotClaude:
 
     def test_clean_dot_claude_passes(self, tmp_path):


### PR DESCRIPTION
## Summary

`CursorRuleBlock` extended `FrontmatterContentBlock`, which stripped frontmatter in `read_body()` without compensating `line_offset`. This caused all content violations in `.cursor/rules/*.mdc` files to be reported at wrong line numbers (off by the frontmatter size).

Fix: re-parent `CursorRuleBlock` to `ParsedFrontmatterBlock` — the same base class used by `CommandBlock`, `AgentBlock`, `SkillBlock`, and `PluginRuleBlock`. These all read the full file content so line numbers are file-absolute, with frontmatter accessible via separate properties.

`FrontmatterContentBlock` had no remaining subclasses and has been removed.

Reproducer: #215

## Test plan
- [x] New integration test asserts correct line number (12) for violation in `.mdc` with frontmatter
- [x] New unit test confirms `CursorRuleBlock.read_body()` returns full file content
- [x] All 1490 tests pass, `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)