### PR TITLE
Fix review action not updating comments when line numbers change

### DIFF
--- a/action/review.py
+++ b/action/review.py
@@ -109,22 +109,33 @@ def sync_comments(repo, pr_number, new_comments):
 
     replied_to = {c["in_reply_to_id"] for c in all_comments if c.get("in_reply_to_id")}
 
-    current_fps = {c["fingerprint"] for c in new_comments}
+    new_by_fp = {c["fingerprint"]: c for c in new_comments}
+    moved_fps = set()
     deleted = 0
     for fp, comment in existing.items():
-        if fp in current_fps:
+        if fp not in new_by_fp:
+            if comment["id"] in replied_to:
+                continue
+            try:
+                github_api("DELETE", f"/repos/{repo}/pulls/comments/{comment['id']}")
+                deleted += 1
+            except urllib.error.HTTPError:
+                pass
             continue
-        if comment["id"] in replied_to:
-            continue
-        try:
-            github_api("DELETE", f"/repos/{repo}/pulls/comments/{comment['id']}")
-            deleted += 1
-        except urllib.error.HTTPError:
-            pass
+        new = new_by_fp[fp]
+        old_line = comment.get("line")
+        new_line = new.get("line")
+        if old_line != new_line and comment["id"] not in replied_to:
+            try:
+                github_api("DELETE", f"/repos/{repo}/pulls/comments/{comment['id']}")
+                moved_fps.add(fp)
+                deleted += 1
+            except urllib.error.HTTPError:
+                pass
     if deleted:
-        print(f"Deleted {deleted} comment(s) for fixed issues.")
+        print(f"Deleted {deleted} comment(s) for fixed/moved issues.")
 
-    return [c for c in new_comments if c["fingerprint"] not in existing]
+    return [c for c in new_comments if c["fingerprint"] not in existing or c["fingerprint"] in moved_fps]
 
 
 def upsert_summary_comment(repo, pr_number, non_diff_violations):

--- a/action/review.py
+++ b/action/review.py
@@ -125,13 +125,14 @@ def sync_comments(repo, pr_number, new_comments):
         new = new_by_fp[fp]
         old_line = comment.get("line")
         new_line = new.get("line")
-        if old_line != new_line and comment["id"] not in replied_to:
-            try:
-                github_api("DELETE", f"/repos/{repo}/pulls/comments/{comment['id']}")
-                moved_fps.add(fp)
-                deleted += 1
-            except urllib.error.HTTPError:
-                pass
+        if old_line != new_line:
+            if comment["id"] not in replied_to:
+                try:
+                    github_api("DELETE", f"/repos/{repo}/pulls/comments/{comment['id']}")
+                    deleted += 1
+                except urllib.error.HTTPError:
+                    pass
+            moved_fps.add(fp)
     if deleted:
         print(f"Deleted {deleted} comment(s) for fixed/moved issues.")
 


### PR DESCRIPTION
## Summary

When a violation moved to a different line (same rule, file, and message), the review action kept the old comment at the stale line because the fingerprint matched. Now `sync_comments` detects line changes, deletes the old comment, and re-posts at the correct position.

Found while testing #215 — the `.mdc` line offset fix (#216) corrected the reported line from 10 to 14, but the review comment stayed stuck on line 10.

## Test plan
- [x] All 1490 tests pass
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment synchronization for pull requests to accurately track and manage comments that move to different line numbers or resolve issues, using enhanced fingerprint-based identification to properly distinguish between fixed, moved, and new issues, resulting in more accurate cleanup summaries and feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->