### PR TITLE
Add persist-credentials: false to checkout steps

### DIFF
--- a/.github/workflows/test-action-review.yml
+++ b/.github/workflows/test-action-review.yml
@@ -7,12 +7,14 @@ on:
 
 jobs:
   review:
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: ./review

--- a/.github/workflows/test-action-review.yml
+++ b/.github/workflows/test-action-review.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   review:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: ./
         with:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: stbenjam/skillsaw@v0
         with:
           strict: true
@@ -52,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: stbenjam/skillsaw@v0
         with:
           strict: true


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to `actions/checkout` in CI doc examples and local test action workflows
- Prevents GITHUB_TOKEN from persisting in git config where later third-party action steps could read it

Prompted by https://github.com/opendatahub-io/agent-eval-harness/pull/75#discussion_r3313540121

Note: the same PR suggested gating the review workflow on `conclusion == 'success'`, but that's incorrect for this use case — skillsaw exits non-zero when it finds violations, and the review workflow needs to run in that case to post comments.

## Test plan
- [x] Docs-only + workflow config change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)