### PR TITLE
Fix XSS in docs HTML renderer

### DIFF
--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -736,7 +736,8 @@ def _get_js() -> str:
     var nr = document.getElementById('no-results');
     var html = '';
     var typeLabels = {plugins:'Plugins',commands:'Commands',skills:'Skills',agents:'Agents',hooks:'Hooks',mcp_servers:'MCP Servers',rules:'Rules'};
-    var label = typeLabels[type] || type;
+    if (!typeLabels[type]) return;
+    var label = typeLabels[type];
 
     if (type === 'plugins' && IS_MARKETPLACE) {
       html += '<div class="search-results-heading">'+label+' ('+allPlugins.length+')</div>';
@@ -762,7 +763,7 @@ def _get_js() -> str:
         items.forEach(function(r) {
           var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\\''+escAttr(r.plugin)+'\\')"' : '';
           html += '<div class="search-result-item"'+onclick+'>';
-          html += '<div class="search-result-icon '+r.icon+'">'+r.iconChar+'</div>';
+          html += '<div class="search-result-icon '+esc(r.icon)+'">'+esc(r.iconChar)+'</div>';
           html += '<div class="search-result-content"><div class="search-result-title">'+esc(r.name)+'</div>';
           html += '<div class="search-result-subtitle">'+esc(r.desc)+'</div></div>';
           if (r.plugin) html += '<span class="search-result-plugin">'+esc(r.plugin)+'</span>';

--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -736,7 +736,11 @@ def _get_js() -> str:
     var nr = document.getElementById('no-results');
     var html = '';
     var typeLabels = {plugins:'Plugins',commands:'Commands',skills:'Skills',agents:'Agents',hooks:'Hooks',mcp_servers:'MCP Servers',rules:'Rules'};
-    if (!typeLabels[type]) return;
+    if (!typeLabels[type]) {
+      el.innerHTML = '';
+      nr.classList.add('show');
+      return;
+    }
     var label = typeLabels[type];
 
     if (type === 'plugins' && IS_MARKETPLACE) {


### PR DESCRIPTION
## Summary
- Fix CodeQL `js/xss` high-severity alert in generated docs pages
- `renderTypeView()` now rejects unknown type values from `window.location.hash` instead of injecting them raw into `innerHTML`
- Added `esc()` calls on icon class/char values as defense-in-depth

This fixes [the CodeQL alert](https://github.com/openshift-eng/ai-helpers/security/code-scanning/938) blocking openshift-eng/ai-helpers#505. After merging, ai-helpers needs to regenerate its `docs/index.html` with the updated skillsaw.

## Test plan
- [x] All 1501 tests pass
- [x] Lint clean
- [ ] After merge, bump skillsaw in ai-helpers and verify CodeQL passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Corrected type label rendering behavior to properly validate type existence before displaying, eliminating fallback to raw type values and ensuring consistent behavior
* Enhanced HTML escaping for icon elements in search result items to prevent potential rendering issues and improve security

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->