### PR TITLE
Add CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 3'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      matrix:
+        language: [python, javascript]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary
- Add CodeQL security scanning for Python and JavaScript
- Runs on push to main, PRs, and weekly (Wednesdays 4:17 AM UTC)
- Scans both Python source and generated JavaScript in docs HTML

## Test plan
- [x] Workflow syntax is valid
- [x] CI should run CodeQL on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)