### PR TITLE
Bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Log in to Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
       
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -44,7 +44,7 @@ jobs:
             type=sha
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -35,7 +35,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist/
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/

--- a/.github/workflows/skillsaw-ecosystem-scout.yml
+++ b/.github/workflows/skillsaw-ecosystem-scout.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: claude-execution-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/skillsaw-issue-solver.yml
+++ b/.github/workflows/skillsaw-issue-solver.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: claude-execution-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/skillsaw-maintenance.yml
+++ b/.github/workflows/skillsaw-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: claude-execution-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/skillsaw-pr-review.yml
+++ b/.github/workflows/skillsaw-pr-review.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Restore last run timestamp
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .last-pr-review-run
           key: pr-review-last-run
@@ -107,14 +107,14 @@ jobs:
 
       - name: Cache last run timestamp
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .last-pr-review-run
           key: pr-review-last-run-${{ github.run_id }}
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: claude-execution-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload execution log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: panel-review-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/test-llm-integration.yml
+++ b/.github/workflows/test-llm-integration.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'stbenjam/skillsaw'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- Bumps all GitHub Actions to their latest major versions to resolve Node.js 20 deprecation warnings
- Node 20 actions will be forced to Node 24 on June 2, 2026, with full removal September 16, 2026

### Actions bumped

| Action | From | To | Workflows |
|---|---|---|---|
| `actions/upload-artifact` | v4 | v5 | release, review-panel, pr-review, maintenance, issue-solver, ecosystem-scout |
| `actions/download-artifact` | v4 | v5 | release |
| `actions/cache` | v4 | v5 | pr-review |
| `actions/setup-python` | v5 | v6 | pages, test-llm-integration |
| `actions/upload-pages-artifact` | v3 | v5 | pages |
| `actions/deploy-pages` | v4 | v5 | pages |
| `actions/checkout` | v4 | v5 | test-llm-integration |
| `docker/login-action` | v3 | v4 | docker |
| `docker/metadata-action` | v5 | v6 | docker |
| `docker/build-push-action` | v5 | v7 | docker |

## Test plan
- [ ] CI passes on all workflows
- [ ] Release workflow still publishes correctly (next release will verify)
- [ ] Docker build workflow runs successfully
- [ ] Pages deployment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)