### PR TITLE
Print version as first line of text output

### DIFF
--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -464,6 +464,7 @@ def _run_lint(args):
         sys.exit(1)
 
     if args.fmt == "text":
+        print(f"skillsaw {cli_version}")
         print(f"Linting: {args.path}\n")
     context = RepositoryContext(args.path)
 


### PR DESCRIPTION
## Summary
- Print `skillsaw X.Y.Z` as the very first line of text output, before the `Linting:` line
- Ensures the version is visible even if the process crashes during linting

## Test plan
- [x] `make test` — all 1525 tests pass
- [x] Smoke test: `.venv/bin/skillsaw lint` shows version as first line

🤖 Generated with [Claude Code](https://claude.com/claude-code)