### PR TITLE
Pretty-print embedded JSON in docs HTML output

### DIFF
--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -397,7 +397,11 @@ def _render_page(docs: DocsOutput, theme: Optional[str] = None) -> str:
 
     data = _build_data(docs)
     # Escape </ sequences to prevent </script> from breaking out of the script tag
-    data_json = json.dumps(data, indent=2, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e")
+    data_json = (
+        json.dumps(data, indent=2, ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
 
     title = docs.title
     subtitle = _repo_type_label(docs.repo_type)

--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -397,7 +397,7 @@ def _render_page(docs: DocsOutput, theme: Optional[str] = None) -> str:
 
     data = _build_data(docs)
     # Escape </ sequences to prevent </script> from breaking out of the script tag
-    data_json = json.dumps(data, indent=None).replace("<", "\\u003c").replace(">", "\\u003e")
+    data_json = json.dumps(data, indent=2).replace("<", "\\u003c").replace(">", "\\u003e")
 
     title = docs.title
     subtitle = _repo_type_label(docs.repo_type)

--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -397,7 +397,7 @@ def _render_page(docs: DocsOutput, theme: Optional[str] = None) -> str:
 
     data = _build_data(docs)
     # Escape </ sequences to prevent </script> from breaking out of the script tag
-    data_json = json.dumps(data, indent=2).replace("<", "\\u003c").replace(">", "\\u003e")
+    data_json = json.dumps(data, indent=2, ensure_ascii=False).replace("<", "\\u003c").replace(">", "\\u003e")
 
     title = docs.title
     subtitle = _repo_type_label(docs.repo_type)


### PR DESCRIPTION
## Summary
- Change `json.dumps(data, indent=None)` to `json.dumps(data, indent=2)` in the HTML renderer
- The single-line JSON blob guaranteed merge conflicts whenever the generated docs file was committed

## Test plan
- [x] All tests pass
- [x] `skillsaw docs` output unchanged functionally, just formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)