### PR TITLE
Exclude frontmatter from content-rule analysis

### DIFF
--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -127,7 +127,6 @@ def _extract_plugin(context: RepositoryContext, plugin_node: PluginNode) -> Plug
 def _extract_commands(plugin_node: PluginNode) -> List[CommandDoc]:
     docs = []
     for block in plugin_node.find(CommandBlock):
-        fm = block.frontmatter or {}
         name_lines = block.section("Name").strip().splitlines()
         full_name = name_lines[0] if name_lines else ""
         synopsis = _strip_fences(block.section("Synopsis"))
@@ -136,7 +135,7 @@ def _extract_commands(plugin_node: PluginNode) -> List[CommandDoc]:
             CommandDoc(
                 name=block.path.stem,
                 file_path=block.path,
-                description=fm.get("description", ""),
+                description=block.field_value("description", ""),
                 full_name=full_name,
                 synopsis=synopsis,
                 body=body_text,
@@ -162,23 +161,20 @@ def _extract_skill(skill_node: SkillNode) -> Optional[SkillDoc]:
     if not blocks:
         return None
     block = blocks[0]
-    fm = block.frontmatter
-    if fm is None:
-        fm = {}
 
-    allowed_tools = fm.get("allowed-tools", [])
+    allowed_tools = block.field_value("allowed-tools", [])
     if isinstance(allowed_tools, str):
         allowed_tools = [allowed_tools]
     if not isinstance(allowed_tools, list):
         allowed_tools = []
 
     return SkillDoc(
-        name=fm.get("name", skill_node.path.name),
+        name=block.field_value("name", skill_node.path.name),
         dir_path=skill_node.path,
-        description=fm.get("description", ""),
-        license=fm.get("license", ""),
-        compatibility=fm.get("compatibility", ""),
-        metadata=fm.get("metadata", {}),
+        description=block.field_value("description", ""),
+        license=block.field_value("license", ""),
+        compatibility=block.field_value("compatibility", ""),
+        metadata=block.field_value("metadata", {}),
         allowed_tools=allowed_tools or [],
         body=block.body_text.strip(),
     )
@@ -190,12 +186,11 @@ def _extract_skill(skill_node: SkillNode) -> Optional[SkillDoc]:
 def _extract_agents(plugin_node: PluginNode) -> List[AgentDoc]:
     docs = []
     for block in plugin_node.find(AgentBlock):
-        fm = block.frontmatter or {}
         docs.append(
             AgentDoc(
-                name=fm.get("name", block.path.stem),
+                name=block.field_value("name", block.path.stem),
                 file_path=block.path,
-                description=fm.get("description", ""),
+                description=block.field_value("description", ""),
                 body=block.body_text.strip(),
             )
         )
@@ -267,16 +262,15 @@ def _extract_mcp_servers(plugin_node: PluginNode, plugin_meta: dict) -> List[Mcp
 def _extract_rules(plugin_node: PluginNode) -> List[RuleFileDoc]:
     docs = []
     for block in plugin_node.find(PluginRuleBlock):
-        fm = block.frontmatter or {}
         globs: List[str] = []
-        paths = fm.get("paths", [])
+        paths = block.field_value("paths", [])
         if isinstance(paths, list):
             globs = [str(p) for p in paths]
         docs.append(
             RuleFileDoc(
                 name=block.path.stem,
                 file_path=block.path,
-                description=fm.get("description", ""),
+                description=block.field_value("description", ""),
                 globs=globs,
                 body=block.body_text.strip(),
             )

--- a/src/skillsaw/rules/builtin/agents.py
+++ b/src/skillsaw/rules/builtin/agents.py
@@ -64,20 +64,20 @@ class AgentFrontmatterRule(Rule):
                 )
                 continue
 
-            if block.frontmatter is None:
+            if not block.has_frontmatter:
                 violations.append(
                     self.violation("Missing frontmatter", file_path=block.path, block=block)
                 )
                 continue
 
-            if "name" not in block.frontmatter:
+            if not block.field("name"):
                 violations.append(
                     self.violation(
                         "Missing 'name' in frontmatter", file_path=block.path, block=block
                     )
                 )
 
-            if "description" not in block.frontmatter:
+            if not block.field("description"):
                 violations.append(
                     self.violation(
                         "Missing 'description' in frontmatter", file_path=block.path, block=block

--- a/src/skillsaw/rules/builtin/agentskills.py
+++ b/src/skillsaw/rules/builtin/agentskills.py
@@ -179,8 +179,7 @@ class AgentSkillValidRule(Rule):
                 )
                 continue
 
-            frontmatter = block.frontmatter
-            if frontmatter is None:
+            if not block.has_frontmatter:
                 violations.append(
                     self.violation(
                         "Missing YAML frontmatter (must start with ---)",
@@ -189,7 +188,7 @@ class AgentSkillValidRule(Rule):
                 )
                 continue
 
-            name = frontmatter.get("name")
+            name = block.field_value("name")
             if not name:
                 violations.append(
                     self.violation("Missing required 'name' field", file_path=block.path)
@@ -211,7 +210,7 @@ class AgentSkillValidRule(Rule):
                     )
                 )
 
-            desc = frontmatter.get("description")
+            desc = block.field_value("description")
             if not desc:
                 violations.append(
                     self.violation("Missing required 'description' field", file_path=block.path)
@@ -225,18 +224,20 @@ class AgentSkillValidRule(Rule):
                     )
                 )
 
-            if "license" in frontmatter and not isinstance(frontmatter["license"], str):
+            license_fld = block.field("license")
+            if license_fld and not isinstance(license_fld.value, str):
                 violations.append(
                     self.violation(
                         "'license' must be a string",
                         file_path=block.path,
-                        line=block.key_line("license"),
+                        line=license_fld.field_line,
                     )
                 )
 
-            if "compatibility" in frontmatter:
-                compat = frontmatter["compatibility"]
-                compat_line = block.key_line("compatibility")
+            compat_fld = block.field("compatibility")
+            if compat_fld:
+                compat = compat_fld.value
+                compat_line = compat_fld.field_line
                 if not isinstance(compat, str):
                     violations.append(
                         self.violation(
@@ -262,9 +263,10 @@ class AgentSkillValidRule(Rule):
                         )
                     )
 
-            if "metadata" in frontmatter:
-                meta = frontmatter["metadata"]
-                meta_line = block.key_line("metadata")
+            meta_fld = block.field("metadata")
+            if meta_fld:
+                meta = meta_fld.value
+                meta_line = meta_fld.field_line
                 if not isinstance(meta, dict):
                     violations.append(
                         self.violation(
@@ -284,9 +286,10 @@ class AgentSkillValidRule(Rule):
                                 )
                             )
 
-            if "allowed-tools" in frontmatter:
-                at = frontmatter["allowed-tools"]
-                at_line = block.key_line("allowed-tools")
+            at_fld = block.field("allowed-tools")
+            if at_fld:
+                at = at_fld.value
+                at_line = at_fld.field_line
                 if isinstance(at, list):
                     if not all(isinstance(item, str) for item in at):
                         violations.append(
@@ -309,8 +312,9 @@ class AgentSkillValidRule(Rule):
             for field_name in extra_required:
                 if field_name in self.BUILTIN_REQUIRED:
                     continue
-                if not frontmatter.get(field_name):
-                    line = block.key_line(field_name) if field_name in frontmatter else None
+                if not block.field_value(field_name):
+                    fld = block.field(field_name)
+                    line = fld.field_line if fld else None
                     violations.append(
                         self.violation(
                             f"Missing required field '{field_name}'",
@@ -321,7 +325,7 @@ class AgentSkillValidRule(Rule):
 
             required_meta = self.config.get("required-metadata", [])
             if required_meta:
-                meta = frontmatter.get("metadata")
+                meta = block.field_value("metadata")
                 meta_line = block.key_line("metadata")
                 if meta is None:
                     if "metadata" not in extra_required:
@@ -377,10 +381,10 @@ class AgentSkillNameRule(Rule):
             if not blocks:
                 continue
             block = blocks[0]
-            if block.frontmatter_error or block.frontmatter is None:
+            if block.frontmatter_error or not block.has_frontmatter:
                 continue
 
-            name = block.frontmatter.get("name")
+            name = block.field_value("name")
             if not name or not isinstance(name, str):
                 continue
 
@@ -645,10 +649,10 @@ class AgentSkillDescriptionRule(Rule):
             if not blocks:
                 continue
             block = blocks[0]
-            if block.frontmatter_error or block.frontmatter is None:
+            if block.frontmatter_error or not block.has_frontmatter:
                 continue
 
-            desc = block.frontmatter.get("description")
+            desc = block.field_value("description")
             if not desc or not isinstance(desc, str):
                 continue
 
@@ -829,12 +833,12 @@ class AgentSkillEvalsRule(Rule):
                 )
             elif isinstance(skill_name, str):
                 skill_blocks = skill_node.find(SkillBlock)
-                fm = skill_blocks[0].frontmatter if skill_blocks else None
-                if fm and fm.get("name") != skill_name:
+                fm_name = skill_blocks[0].field_value("name") if skill_blocks else None
+                if fm_name is not None and fm_name != skill_name:
                     violations.append(
                         self.violation(
                             f"'skill_name' ({skill_name!r}) does not match "
-                            f"SKILL.md name ({fm.get('name')!r})",
+                            f"SKILL.md name ({fm_name!r})",
                             file_path=evals_json,
                         )
                     )

--- a/src/skillsaw/rules/builtin/command_format.py
+++ b/src/skillsaw/rules/builtin/command_format.py
@@ -124,11 +124,11 @@ class CommandFrontmatterRule(Rule):
                 )
                 continue
 
-            if block.frontmatter is None:
+            if not block.has_frontmatter:
                 violations.append(self.violation("Missing frontmatter", file_path=block.path))
                 continue
 
-            if "description" not in block.frontmatter:
+            if not block.field("description"):
                 violations.append(
                     self.violation("Missing 'description' in frontmatter", file_path=block.path)
                 )

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -731,10 +731,22 @@ class FrontmatteredBlock(LintTarget):
                 )
             )
 
+    def field(self, name: str) -> Optional[FrontmatterField]:
+        """Return the ``FrontmatterField`` child with the given key name, or ``None``."""
+        for fld in self.find(FrontmatterField):
+            if fld.name == name:
+                return fld
+        return None
+
+    def field_value(self, name: str, default: Any = None) -> Any:
+        """Return the value of the named frontmatter field, or *default*."""
+        fld = self.field(name)
+        return fld.value if fld is not None else default
+
     @property
-    def frontmatter(self) -> Optional[Dict[str, Any]]:
+    def has_frontmatter(self) -> bool:
         self._ensure_parsed()
-        return self._fm_parsed[0]
+        return self._fm_parsed[0] is not None
 
     @property
     def frontmatter_error(self) -> Optional[str]:

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -667,7 +667,9 @@ class BodyContent(ContentBlock):
         if content is None or not content.startswith("---"):
             self.path.write_text(new_body, encoding="utf-8")
         else:
-            _, file_body, _ = parse_frontmatter(content)
+            fm, file_body, _ = parse_frontmatter(content)
+            if fm is None:
+                raise ValueError("Cannot rewrite body: frontmatter is malformed")
             fm_section = content[: len(content) - len(file_body)]
             self.path.write_text(fm_section + new_body, encoding="utf-8")
         self.body = new_body
@@ -702,6 +704,9 @@ class FrontmatteredBlock(LintTarget):
             self._build_children()
 
     def _build_children(self) -> None:
+        self.children = [
+            c for c in self.children if not isinstance(c, (FrontmatterField, BodyContent))
+        ]
         fm = self._fm_parsed[0]
         if fm:
             for key, value in fm.items():
@@ -711,6 +716,7 @@ class FrontmatteredBlock(LintTarget):
                         name=key,
                         value=value,
                         field_line=self.key_line(key),
+                        parent=self,
                     )
                 )
         body_text = self._fm_parsed[3]
@@ -721,6 +727,7 @@ class FrontmatteredBlock(LintTarget):
                     category=self.category,
                     line_offset=self._fm_parsed[4],
                     body=body_text,
+                    parent=self,
                 )
             )
 

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -14,7 +14,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
 
 import yaml
 
@@ -649,38 +649,56 @@ class FrontmatterField(LintTarget):
         return len(str(self.value)) // 4
 
 
-@dataclass
-class BodyContent(LintTarget):
-    """The markdown body of a frontmattered file, after the closing ``---``."""
+@dataclass(eq=False)
+class BodyContent(ContentBlock):
+    """The lintable markdown body of a frontmattered file."""
 
-    text: str = ""
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
+        if not self.body:
+            return None
+        body = self.body
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+            body = _strip_html_comments(body)
+        return body
+
+    def write_body(self, new_body: str) -> None:
+        content = read_text(self.path)
+        if content is None or not content.startswith("---"):
+            self.path.write_text(new_body, encoding="utf-8")
+        else:
+            _, file_body, _ = parse_frontmatter(content)
+            fm_section = content[: len(content) - len(file_body)]
+            self.path.write_text(fm_section + new_body, encoding="utf-8")
+        self.body = new_body
 
     def tree_label(self) -> str:
         return "body"
 
-    def estimate_tokens(self) -> int:
-        return len(self.text) // 4 if self.text else 0
 
+@dataclass
+class FrontmatteredBlock(LintTarget):
+    """Container for files with YAML frontmatter followed by a markdown body.
 
-@dataclass(eq=False)
-class FrontmatteredBlock(FileContentBlock):
-    """Content block whose file has YAML frontmatter followed by a markdown body.
-
-    ``read_body()`` returns only the markdown body (after the closing ``---``),
-    keeping frontmatter out of content-rule analysis.  Individual frontmatter
-    keys are exposed as ``FrontmatterField`` children in the lint tree.
+    Not a ``ContentBlock`` itself — the lintable content lives in the
+    ``BodyContent`` child node.  Frontmatter keys are exposed as
+    ``FrontmatterField`` children.
     """
 
+    category: str = ""
     content_lintable_fields: Tuple[str, ...] = ()
 
     _fm_parsed: Optional[
         Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str, int]
     ] = field(default=None, init=False, repr=False)
 
+    def walk(self) -> Iterator["LintTarget"]:
+        self._ensure_parsed()
+        yield from super().walk()
+
     def _ensure_parsed(self) -> None:
         if self._fm_parsed is None:
             self._fm_parsed = _parse_file_frontmatter(self.path)
-            self.line_offset = self._fm_parsed[4]
             self._build_children()
 
     def _build_children(self) -> None:
@@ -697,7 +715,14 @@ class FrontmatteredBlock(FileContentBlock):
                 )
         body_text = self._fm_parsed[3]
         if body_text:
-            self.children.append(BodyContent(path=self.path, text=body_text))
+            self.children.append(
+                BodyContent(
+                    path=self.path,
+                    category=self.category,
+                    line_offset=self._fm_parsed[4],
+                    body=body_text,
+                )
+            )
 
     @property
     def frontmatter(self) -> Optional[Dict[str, Any]]:
@@ -719,30 +744,6 @@ class FrontmatteredBlock(FileContentBlock):
         self._ensure_parsed()
         return self._fm_parsed[3]
 
-    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
-        if self.body is not None:
-            body = self.body
-        else:
-            self._ensure_parsed()
-            body = self._fm_parsed[3]
-        if not body:
-            return None
-        if strip_code_blocks:
-            body = _strip_fenced_code_blocks(body)
-            body = _strip_html_comments(body)
-        return body
-
-    def write_body(self, new_body: str) -> None:
-        content = read_text(self.path)
-        if content is None or not content.startswith("---"):
-            self.path.write_text(new_body, encoding="utf-8")
-            self._fm_parsed = None
-            return
-        _, body, _ = parse_frontmatter(content)
-        fm_section = content[: len(content) - len(body)]
-        self.path.write_text(fm_section + new_body, encoding="utf-8")
-        self._fm_parsed = None
-
     def key_line(self, key: str) -> Optional[int]:
         return _frontmatter_key_line(self.path, key)
 
@@ -755,12 +756,12 @@ class FrontmatteredBlock(FileContentBlock):
             return {}
         return _yaml_line_map(fm_text, line_offset=offset)
 
-    def tree_label(self) -> str:
-        return super().tree_label()
-
     def estimate_tokens(self) -> int:
         self._ensure_parsed()
-        return sum(c.estimate_tokens() for c in self.children)
+        return super().estimate_tokens()
+
+    def tree_label(self) -> str:
+        return f"{self.path.name} ({self.category})"
 
     def read_frontmatter_text(self) -> str:
         """Return the raw YAML text between the --- delimiters (no delimiters)."""

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -607,33 +607,97 @@ class GeminiMdBlock(InstructionBlock):
 
 def _parse_file_frontmatter(
     path: Path,
-) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]:
+) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str, int]:
     """Parse YAML frontmatter from a markdown file.
 
-    Returns (frontmatter_dict, error_string, error_line, body_after_frontmatter).
+    Returns (frontmatter_dict, error_string, error_line, body_after_frontmatter,
+    fm_line_count).  ``fm_line_count`` is the number of file lines occupied by
+    the frontmatter block (including the ``---`` delimiters).
     """
     content = read_text(path)
     if content is None:
-        return None, f"Failed to read file: {path}", None, ""
+        return None, f"Failed to read file: {path}", None, "", 0
     if not content.startswith("---"):
-        return None, None, None, content
+        return None, None, None, content, 0
     fm, body, error_line = parse_frontmatter(content)
     if fm is None:
-        return None, "Invalid frontmatter (malformed YAML or missing closing ---)", error_line, body
-    return fm, None, None, body
+        return (
+            None,
+            "Invalid frontmatter (malformed YAML or missing closing ---)",
+            error_line,
+            body,
+            0,
+        )
+    fm_line_count = content[: len(content) - len(body)].count("\n")
+    return fm, None, None, body, fm_line_count
+
+
+@dataclass
+class FrontmatterField(LintTarget):
+    """A single key-value pair from YAML frontmatter, exposed as a tree node."""
+
+    name: str = ""
+    value: Any = None
+    field_line: Optional[int] = None
+
+    def tree_label(self) -> str:
+        return f"frontmatter:{self.name}"
+
+    def estimate_tokens(self) -> int:
+        if self.value is None:
+            return 0
+        return len(str(self.value)) // 4
+
+
+@dataclass
+class BodyContent(LintTarget):
+    """The markdown body of a frontmattered file, after the closing ``---``."""
+
+    text: str = ""
+
+    def tree_label(self) -> str:
+        return "body"
+
+    def estimate_tokens(self) -> int:
+        return len(self.text) // 4 if self.text else 0
 
 
 @dataclass(eq=False)
-class ParsedFrontmatterBlock(FileContentBlock):
-    """File content block with lazy-parsed YAML frontmatter."""
+class FrontmatteredBlock(FileContentBlock):
+    """Content block whose file has YAML frontmatter followed by a markdown body.
 
-    _fm_parsed: Optional[Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str]] = (
-        field(default=None, init=False, repr=False)
-    )
+    ``read_body()`` returns only the markdown body (after the closing ``---``),
+    keeping frontmatter out of content-rule analysis.  Individual frontmatter
+    keys are exposed as ``FrontmatterField`` children in the lint tree.
+    """
+
+    content_lintable_fields: Tuple[str, ...] = ()
+
+    _fm_parsed: Optional[
+        Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str, int]
+    ] = field(default=None, init=False, repr=False)
 
     def _ensure_parsed(self) -> None:
         if self._fm_parsed is None:
             self._fm_parsed = _parse_file_frontmatter(self.path)
+            self.line_offset = self._fm_parsed[4]
+            self._build_children()
+
+    def _build_children(self) -> None:
+        fm = self._fm_parsed[0]
+        if fm:
+            for key, value in fm.items():
+                self.children.append(
+                    FrontmatterField(
+                        path=self.path,
+                        name=key,
+                        value=value,
+                        field_line=self.key_line(key),
+                    )
+                )
+        body_text = self._fm_parsed[3]
+        if body_text:
+            self.children.append(BodyContent(path=self.path, text=body_text))
 
     @property
     def frontmatter(self) -> Optional[Dict[str, Any]]:
@@ -655,6 +719,30 @@ class ParsedFrontmatterBlock(FileContentBlock):
         self._ensure_parsed()
         return self._fm_parsed[3]
 
+    def read_body(self, *, strip_code_blocks: bool = True) -> Optional[str]:
+        if self.body is not None:
+            body = self.body
+        else:
+            self._ensure_parsed()
+            body = self._fm_parsed[3]
+        if not body:
+            return None
+        if strip_code_blocks:
+            body = _strip_fenced_code_blocks(body)
+            body = _strip_html_comments(body)
+        return body
+
+    def write_body(self, new_body: str) -> None:
+        content = read_text(self.path)
+        if content is None or not content.startswith("---"):
+            self.path.write_text(new_body, encoding="utf-8")
+            self._fm_parsed = None
+            return
+        _, body, _ = parse_frontmatter(content)
+        fm_section = content[: len(content) - len(body)]
+        self.path.write_text(fm_section + new_body, encoding="utf-8")
+        self._fm_parsed = None
+
     def key_line(self, key: str) -> Optional[int]:
         return _frontmatter_key_line(self.path, key)
 
@@ -668,12 +756,11 @@ class ParsedFrontmatterBlock(FileContentBlock):
         return _yaml_line_map(fm_text, line_offset=offset)
 
     def tree_label(self) -> str:
-        label = super().tree_label()
-        fm = self.frontmatter
-        if fm and isinstance(fm.get("description"), str):
-            desc_tokens = len(fm["description"]) // 4
-            label += f" [desc: {desc_tokens:,} tokens]"
-        return label
+        return super().tree_label()
+
+    def estimate_tokens(self) -> int:
+        self._ensure_parsed()
+        return sum(c.estimate_tokens() for c in self.children)
 
     def read_frontmatter_text(self) -> str:
         """Return the raw YAML text between the --- delimiters (no delimiters)."""
@@ -727,15 +814,18 @@ class ParsedFrontmatterBlock(FileContentBlock):
         self._fm_parsed = None
 
 
+ParsedFrontmatterBlock = FrontmatteredBlock
+
+
 @dataclass(eq=False)
-class CursorRuleBlock(ParsedFrontmatterBlock):
+class CursorRuleBlock(FrontmatteredBlock):
     """.cursor/rules/*.mdc files."""
 
     category: str = "instruction"
 
 
 @dataclass(eq=False)
-class CommandBlock(ParsedFrontmatterBlock):
+class CommandBlock(FrontmatteredBlock):
     """commands/*.md in plugins."""
 
     category: str = "command"
@@ -748,14 +838,14 @@ class CommandBlock(ParsedFrontmatterBlock):
 
 
 @dataclass(eq=False)
-class AgentBlock(ParsedFrontmatterBlock):
+class AgentBlock(FrontmatteredBlock):
     """agents/*.md in plugins or APM agent files."""
 
     category: str = "agent"
 
 
 @dataclass(eq=False)
-class SkillBlock(ParsedFrontmatterBlock):
+class SkillBlock(FrontmatteredBlock):
     """SKILL.md in skills."""
 
     category: str = "skill"
@@ -769,7 +859,7 @@ class SkillRefBlock(FileContentBlock):
 
 
 @dataclass(eq=False)
-class PluginRuleBlock(ParsedFrontmatterBlock):
+class PluginRuleBlock(FrontmatteredBlock):
     """rules/*.md in plugins."""
 
     category: str = "rule"

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -19,6 +19,7 @@ from skillsaw.rules.builtin.utils import read_text
 from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_blocks,
     ContentBlock,
+    FrontmatterField,
     SkillRefBlock,
     WeakLanguageDetector,
     TautologicalDetector,
@@ -897,16 +898,11 @@ class ContentEmbeddedSecretsRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        seen_paths: Set[Path] = set()
         for cf in gather_all_content_blocks(context):
-            resolved = cf.path.resolve()
-            if resolved in seen_paths:
+            body = cf.read_body(strip_code_blocks=False)
+            if not body:
                 continue
-            seen_paths.add(resolved)
-            content = read_text(cf.path)
-            if not content:
-                continue
-            for line_num, line in enumerate(content.splitlines(), 1):
+            for line_num, line in enumerate(body.splitlines(), 1):
                 for pattern, desc in self._PATTERNS:
                     if pattern.search(line):
                         violations.append(
@@ -914,6 +910,19 @@ class ContentEmbeddedSecretsRule(Rule):
                                 f"Potential secret detected: {desc}",
                                 block=cf,
                                 line=line_num,
+                            )
+                        )
+                        break
+            for fld in cf.find(FrontmatterField):
+                text = str(fld.value) if fld.value is not None else ""
+                for pattern, desc in self._PATTERNS:
+                    if pattern.search(text):
+                        violations.append(
+                            self.violation(
+                                f"Potential secret detected in frontmatter "
+                                f"field '{fld.name}': {desc}",
+                                file_path=cf.path,
+                                line=fld.field_line,
                             )
                         )
                         break
@@ -998,16 +1007,11 @@ class ContentBannedReferencesRule(Rule):
         if not patterns:
             return []
         violations = []
-        seen_paths: Set[Path] = set()
         for cf in gather_all_content_blocks(context):
-            resolved = cf.path.resolve()
-            if resolved in seen_paths:
+            body = cf.read_body(strip_code_blocks=False)
+            if not body:
                 continue
-            seen_paths.add(resolved)
-            content = read_text(cf.path)
-            if not content:
-                continue
-            for line_num, line in enumerate(content.splitlines(), 1):
+            for line_num, line in enumerate(body.splitlines(), 1):
                 for pattern, msg in patterns:
                     if pattern.search(line):
                         violations.append(

--- a/src/skillsaw/rules/builtin/content_rules.py
+++ b/src/skillsaw/rules/builtin/content_rules.py
@@ -913,19 +913,19 @@ class ContentEmbeddedSecretsRule(Rule):
                             )
                         )
                         break
-            for fld in cf.find(FrontmatterField):
-                text = str(fld.value) if fld.value is not None else ""
-                for pattern, desc in self._PATTERNS:
-                    if pattern.search(text):
-                        violations.append(
-                            self.violation(
-                                f"Potential secret detected in frontmatter "
-                                f"field '{fld.name}': {desc}",
-                                file_path=cf.path,
-                                line=fld.field_line,
-                            )
+        for fld in context.lint_tree.find(FrontmatterField):
+            text = str(fld.value) if fld.value is not None else ""
+            for pattern, desc in self._PATTERNS:
+                if pattern.search(text):
+                    violations.append(
+                        self.violation(
+                            f"Potential secret detected in frontmatter "
+                            f"field '{fld.name}': {desc}",
+                            file_path=fld.path,
+                            line=fld.field_line,
                         )
-                        break
+                    )
+                    break
         return violations
 
 

--- a/src/skillsaw/rules/builtin/context_budget.py
+++ b/src/skillsaw/rules/builtin/context_budget.py
@@ -136,10 +136,10 @@ class ContextBudgetRule(Rule):
             if warn_limit is None and error_limit is None:
                 continue
             for block in context.lint_tree.find(block_type):
-                fm = block.frontmatter
-                if not fm or not isinstance(fm.get("description"), str):
+                desc = block.field_value("description")
+                if not isinstance(desc, str):
                     continue
-                tokens = _estimate_tokens(fm["description"])
+                tokens = _estimate_tokens(desc)
                 if error_limit is not None and tokens > error_limit:
                     violations.append(
                         self.violation(

--- a/src/skillsaw/rules/builtin/openclaw.py
+++ b/src/skillsaw/rules/builtin/openclaw.py
@@ -6,8 +6,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
-from skillsaw.lint_target import SkillNode
-from skillsaw.rules.builtin.content_analysis import SkillBlock
+from skillsaw.rules.builtin.content_analysis import FrontmatterField, SkillBlock
 
 VALID_OS_VALUES = {"darwin", "linux", "win32"}
 VALID_INSTALL_KINDS = {"brew", "node", "go", "uv", "download"}
@@ -38,15 +37,11 @@ class OpenclawMetadataRule(Rule):
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
 
-        for skill_node in context.lint_tree.find(SkillNode):
-            blocks = skill_node.find(SkillBlock)
-            if not blocks:
+        for block in context.lint_tree.find(SkillBlock):
+            metadata_fields = [f for f in block.find(FrontmatterField) if f.name == "metadata"]
+            if not metadata_fields:
                 continue
-            block = blocks[0]
-            if block.frontmatter_error or block.frontmatter is None:
-                continue
-
-            metadata = block.frontmatter.get("metadata")
+            metadata = metadata_fields[0].value
             if not isinstance(metadata, dict):
                 continue
 

--- a/src/skillsaw/rules/builtin/skills.py
+++ b/src/skillsaw/rules/builtin/skills.py
@@ -71,7 +71,7 @@ class SkillFrontmatterRule(Rule):
                 )
                 continue
 
-            if block.frontmatter is None:
+            if not block.has_frontmatter:
                 violations.append(
                     self.violation(
                         "Missing frontmatter (recommended for SKILL.md)",
@@ -81,7 +81,7 @@ class SkillFrontmatterRule(Rule):
                 )
                 continue
 
-            if "name" not in block.frontmatter:
+            if not block.field("name"):
                 violations.append(
                     self.violation(
                         "Missing 'name' in SKILL.md frontmatter",
@@ -90,7 +90,7 @@ class SkillFrontmatterRule(Rule):
                     )
                 )
 
-            if "description" not in block.frontmatter:
+            if not block.field("description"):
                 violations.append(
                     self.violation(
                         "Missing 'description' in SKILL.md frontmatter",

--- a/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/SKILL.md
+++ b/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ui-test
+description: Browser-based UI test execution against live clusters
+user-invocable: true
+allowedTools:
+  - Bash(python3 *scripts/run_tests.py*)
+  - Bash(python3 *scripts/collect_results.py*)
+  - Read
+  - Write
+---
+
+# UI Test Runner
+
+Runs browser-based UI tests against live clusters.
+
+## Steps
+
+1. Run scripts/run_tests.py to execute all UI tests
+2. Collect results with the results collector

--- a/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/scripts/collect_results.py
+++ b/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/scripts/collect_results.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+"""Collect test results into a report."""

--- a/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/scripts/run_tests.py
+++ b/tests/fixtures/frontmatter-paths/.claude/skills/ui-test/scripts/run_tests.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+"""Run UI test suite."""

--- a/tests/fixtures/frontmatter-paths/CLAUDE.md
+++ b/tests/fixtures/frontmatter-paths/CLAUDE.md
@@ -1,0 +1,3 @@
+# UI Test Project
+
+This project runs browser-based UI tests.

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -14,6 +14,7 @@ from skillsaw.rules.builtin.content_analysis import (
     gather_all_instruction_files,
     gather_all_content_files,
     ContentFile,
+    BodyContent,
     CursorRuleBlock,
     FrontmatteredBlock,
     FrontmatterField,
@@ -791,24 +792,27 @@ class TestContentBlockReadWrite:
         assert f.read_text(encoding="utf-8") == "new content"
 
     def test_frontmattered_block_excludes_frontmatter(self, temp_dir):
-        """FrontmatteredBlock.read_body() returns only the markdown body."""
+        """BodyContent.read_body() returns only the markdown body."""
         f = temp_dir / "test.mdc"
         f.write_text("---\ndescription: A test rule\n---\noriginal body\n")
         block = CursorRuleBlock(path=f)
-        body = block.read_body()
+        bodies = block.find(BodyContent)
+        assert len(bodies) == 1
+        body = bodies[0].read_body()
         assert "---" not in body
         assert "description: A test rule" not in body
         assert "original body" in body
 
     def test_frontmattered_block_line_offset(self, temp_dir):
-        """FrontmatteredBlock sets line_offset from frontmatter line count."""
+        """BodyContent sets line_offset from frontmatter line count."""
         f = temp_dir / "test.mdc"
         f.write_text("---\ndescription: test\nglobs: '*.py'\n---\nBody line 1\nBody line 2\n")
         block = CursorRuleBlock(path=f)
-        body = block.read_body(strip_code_blocks=False)
+        body_node = block.find(BodyContent)[0]
+        body = body_node.read_body(strip_code_blocks=False)
         assert body == "Body line 1\nBody line 2\n"
-        assert block.line_offset == 4
-        assert block.file_line(1) == 5
+        assert body_node.line_offset == 4
+        assert body_node.file_line(1) == 5
 
     def test_frontmattered_block_write_body_preserves_frontmatter(self, temp_dir):
         """write_body() preserves frontmatter and only replaces the body."""
@@ -816,18 +820,20 @@ class TestContentBlockReadWrite:
         original = "---\ndescription: A test rule\nglobs: '*.py'\n---\nOriginal body\n"
         f.write_text(original)
         block = CursorRuleBlock(path=f)
-        block.write_body("New body content\n")
+        body_node = block.find(BodyContent)[0]
+        body_node.write_body("New body content\n")
         result = f.read_text(encoding="utf-8")
         assert result == "---\ndescription: A test rule\nglobs: '*.py'\n---\nNew body content\n"
 
     def test_frontmattered_block_no_frontmatter(self, temp_dir):
-        """FrontmatteredBlock without frontmatter returns full content."""
+        """FrontmatteredBlock without frontmatter has BodyContent with full content."""
         f = temp_dir / "test.mdc"
         f.write_text("Just plain content\nNo frontmatter here\n")
         block = CursorRuleBlock(path=f)
-        body = block.read_body(strip_code_blocks=False)
+        body_node = block.find(BodyContent)[0]
+        body = body_node.read_body(strip_code_blocks=False)
         assert body == "Just plain content\nNo frontmatter here\n"
-        assert block.line_offset == 0
+        assert body_node.line_offset == 0
 
     def test_frontmattered_block_has_field_children(self, temp_dir):
         """FrontmatteredBlock creates FrontmatterField children for each key."""

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -840,7 +840,6 @@ class TestContentBlockReadWrite:
         f = temp_dir / "test.mdc"
         f.write_text("---\ndescription: A test rule\nglobs: '*.py'\n---\nBody\n")
         block = CursorRuleBlock(path=f)
-        _ = block.frontmatter  # trigger lazy parse
         fields = block.find(FrontmatterField)
         assert len(fields) == 2
         names = {fld.name for fld in fields}

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -15,6 +15,8 @@ from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_files,
     ContentFile,
     CursorRuleBlock,
+    FrontmatteredBlock,
+    FrontmatterField,
     _strip_fenced_code_blocks,
 )
 from skillsaw.context import RepositoryContext
@@ -788,15 +790,59 @@ class TestContentBlockReadWrite:
         block.write_body("new content")
         assert f.read_text(encoding="utf-8") == "new content"
 
-    def test_cursor_rule_block_reads_full_file(self, temp_dir):
-        """CursorRuleBlock reads full file content including frontmatter."""
+    def test_frontmattered_block_excludes_frontmatter(self, temp_dir):
+        """FrontmatteredBlock.read_body() returns only the markdown body."""
         f = temp_dir / "test.mdc"
         f.write_text("---\ndescription: A test rule\n---\noriginal body\n")
         block = CursorRuleBlock(path=f)
         body = block.read_body()
-        assert "---" in body
-        assert "description: A test rule" in body
+        assert "---" not in body
+        assert "description: A test rule" not in body
         assert "original body" in body
+
+    def test_frontmattered_block_line_offset(self, temp_dir):
+        """FrontmatteredBlock sets line_offset from frontmatter line count."""
+        f = temp_dir / "test.mdc"
+        f.write_text("---\ndescription: test\nglobs: '*.py'\n---\nBody line 1\nBody line 2\n")
+        block = CursorRuleBlock(path=f)
+        body = block.read_body(strip_code_blocks=False)
+        assert body == "Body line 1\nBody line 2\n"
+        assert block.line_offset == 4
+        assert block.file_line(1) == 5
+
+    def test_frontmattered_block_write_body_preserves_frontmatter(self, temp_dir):
+        """write_body() preserves frontmatter and only replaces the body."""
+        f = temp_dir / "test.mdc"
+        original = "---\ndescription: A test rule\nglobs: '*.py'\n---\nOriginal body\n"
+        f.write_text(original)
+        block = CursorRuleBlock(path=f)
+        block.write_body("New body content\n")
+        result = f.read_text(encoding="utf-8")
+        assert result == "---\ndescription: A test rule\nglobs: '*.py'\n---\nNew body content\n"
+
+    def test_frontmattered_block_no_frontmatter(self, temp_dir):
+        """FrontmatteredBlock without frontmatter returns full content."""
+        f = temp_dir / "test.mdc"
+        f.write_text("Just plain content\nNo frontmatter here\n")
+        block = CursorRuleBlock(path=f)
+        body = block.read_body(strip_code_blocks=False)
+        assert body == "Just plain content\nNo frontmatter here\n"
+        assert block.line_offset == 0
+
+    def test_frontmattered_block_has_field_children(self, temp_dir):
+        """FrontmatteredBlock creates FrontmatterField children for each key."""
+        f = temp_dir / "test.mdc"
+        f.write_text("---\ndescription: A test rule\nglobs: '*.py'\n---\nBody\n")
+        block = CursorRuleBlock(path=f)
+        _ = block.frontmatter  # trigger lazy parse
+        fields = block.find(FrontmatterField)
+        assert len(fields) == 2
+        names = {fld.name for fld in fields}
+        assert names == {"description", "globs"}
+        desc = [fld for fld in fields if fld.name == "description"][0]
+        assert desc.value == "A test rule"
+        assert desc.field_line == 2
+        assert desc.tree_label() == "frontmatter:description"
 
     def test_file_line_with_offset(self):
         block = ContentFile(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1002,6 +1002,17 @@ class TestUnlinkedInternalReferenceAutofix:
 
         assert fixed_line_count == original_line_count
 
+    def test_frontmatter_paths_not_flagged(self, tmp_path):
+        """Path-like strings in YAML frontmatter must not trigger violations."""
+        repo = copy_fixture("frontmatter-paths", tmp_path)
+        r = run_lint(repo)
+        unlinked = [
+            v for v in violations(r) if v["rule_id"] == "content-unlinked-internal-reference"
+        ]
+        assert len(unlinked) == 1
+        assert "scripts/run_tests.py" in unlinked[0]["message"]
+        assert unlinked[0]["line"] == 18
+
 
 # ── SAFE Autofix Idempotency Suite ──────────────────────────────
 


### PR DESCRIPTION
## Summary

- Renames `ParsedFrontmatterBlock` → `FrontmatteredBlock` and overrides `read_body()` to return only the markdown body after `---`, so content rules never see or modify frontmatter
- Adds `FrontmatterField` and `BodyContent` as tree nodes — frontmatter keys and the body are now visible in the lint tree with accurate token counts
- Fixes `content-embedded-secrets` and `content-banned-references` to use `read_body()` instead of reading files directly (golden rule: operate on tree nodes)
- Secrets rule additionally scans `FrontmatterField` values so secrets in frontmatter `description` fields are still caught

## Test plan

- [x] Updated `test_cursor_rule_block_reads_full_file` → `test_frontmattered_block_excludes_frontmatter`
- [x] Added unit tests for line_offset, write_body round-trip, no-frontmatter edge case, FrontmatterField children
- [x] Added integration test with `frontmatter-paths` fixture verifying `allowedTools` paths are not flagged
- [x] `make test` — 1516 passed, 0 failed
- [x] `make lint` — clean
- [x] Tested against `openshift-eng/ai-helpers` — no regressions

Fixes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line number accuracy for violations reported in files with YAML frontmatter
  * Extended secret pattern detection to include frontmatter field values in addition to document body

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stbenjam/skillsaw/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->