### PR TITLE
Spruce up Onboarding with AI section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,17 @@ skillsaw   # exit 0
 
 For all commands and flags, see the [CLI Reference](https://skillsaw.org/cli/).
 
-> **AI-assisted onboarding:** The `skillsaw-onboard` skill automates the
-> entire adoption process — install, lint, autofix, manual fixes, CI setup,
-> and baseline. In Claude Code: `claude plugin marketplace add stbenjam/skillsaw`,
-> then `claude plugin install skillsaw@skillsaw-marketplace`, then type
-> `/skillsaw-onboard`. For other agents, see the
-> [Getting Started guide](https://skillsaw.org/getting-started/#onboarding-with-ai).
+> [!TIP]
+> **:sparkles: Onboard with AI** — let your coding agent handle the entire setup in one shot.
+>
+> **Claude Code:**
+> ```bash
+> claude plugin marketplace add stbenjam/skillsaw
+> claude plugin install skillsaw@skillsaw-marketplace
+> ```
+> Then type `/skillsaw-onboard` — it installs skillsaw, lints your repo, autofixes what it can, walks you through manual fixes, sets up CI, and creates a baseline.
+>
+> **Other agents** — see the [Getting Started guide](https://skillsaw.org/getting-started/#onboarding-with-ai).
 
 ## Installation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,23 +26,30 @@ Over time, fix violations and re-run `skillsaw baseline` to shrink the
 accepted set. See the [Baseline guide](baseline.md) for details on how
 fingerprinting works and configuration options.
 
-## Onboarding with AI
+## :sparkles: Onboard with AI
 
-The **skillsaw-onboard** skill automates the entire adoption process — it
-installs skillsaw, runs the linter, applies autofixes, manually fixes
-remaining violations, sets up CI, and creates a baseline. Your AI coding
-agent handles everything interactively.
+!!! tip "Skip the manual setup — let your AI coding agent do it all"
+
+    The **`/skillsaw-onboard`** skill walks your agent through the full
+    adoption flow in one interactive session:
+
+    | | Step | What happens |
+    |---|---|---|
+    | :material-numeric-1-circle:{ .step-icon } | **Install** | Adds skillsaw to your project |
+    | :material-numeric-2-circle:{ .step-icon } | **Lint** | Runs a full scan of your repo |
+    | :material-numeric-3-circle:{ .step-icon } | **Autofix** | Applies deterministic fixes automatically |
+    | :material-numeric-4-circle:{ .step-icon } | **Manual fix** | Your agent resolves remaining violations interactively |
+    | :material-numeric-5-circle:{ .step-icon } | **CI** | Sets up CI to lint on every PR |
+    | :material-numeric-6-circle:{ .step-icon } | **Baseline** | Accepts any leftover violations so you start clean |
 
 === "Claude Code"
-
-    Add the marketplace and install the plugin:
 
     ```bash
     claude plugin marketplace add stbenjam/skillsaw
     claude plugin install skillsaw@skillsaw-marketplace
     ```
 
-    Then in Claude Code, type `/skillsaw-onboard` to start.
+    Then type **`/skillsaw-onboard`** and follow the prompts.
 
 === "Other AI coding agents"
 

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -162,6 +162,48 @@
     border-color: #546e7a;
 }
 
+/* Onboarding admonition — sparkle gradient */
+.md-typeset .admonition.tip {
+    border-color: #4fc3f7;
+    background: linear-gradient(135deg, #1a2a3020 0%, #1a3a4a30 100%);
+}
+
+.md-typeset .admonition.tip > .admonition-title {
+    background-color: #4fc3f718;
+    font-size: 1.05em;
+}
+
+.md-typeset .admonition.tip > .admonition-title::before {
+    background-color: #4fc3f7;
+}
+
+/* Onboarding step icons */
+.step-icon {
+    color: #4fc3f7;
+}
+
+/* Onboarding step table — borderless, compact */
+.md-typeset .admonition.tip table {
+    border: none;
+    background: transparent;
+    margin-top: 0.4rem;
+    margin-bottom: 0;
+}
+
+.md-typeset .admonition.tip table th {
+    display: none;
+}
+
+.md-typeset .admonition.tip table td {
+    border: none;
+    padding: 0.25em 0.5em;
+    background: transparent;
+}
+
+.md-typeset .admonition.tip table tr:hover td {
+    background: transparent;
+}
+
 /* Tabs */
 .md-typeset .tabbed-labels > label.tabbed-alternate--active {
     color: var(--md-accent-fg-color);


### PR DESCRIPTION
Use GitHub's TIP admonition for a colored callout box, add sparkles, and include the install commands directly in the callout so users can get started without clicking through.