### PR TITLE
Fix unhashable FrontmatteredBlock crashing llm_fix

### DIFF
--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -11,13 +11,21 @@ from typing import Iterator, List, Optional, Type, TypeVar
 T = TypeVar("T", bound="LintTarget")
 
 
-@dataclass
+@dataclass(eq=False)
 class LintTarget:
     """A node in the repository lint tree."""
 
     path: Path
     children: List["LintTarget"] = field(default_factory=list)
     parent: Optional["LintTarget"] = field(default=None, repr=False)
+
+    def __eq__(self, other):
+        if not isinstance(other, LintTarget):
+            return NotImplemented
+        return type(self) is type(other) and self.path.resolve() == other.path.resolve()
+
+    def __hash__(self):
+        return hash((type(self), self.path.resolve()))
 
     def walk(self) -> Iterator["LintTarget"]:
         yield self
@@ -144,7 +152,7 @@ class LintTarget:
         return "\n".join(lines)
 
 
-@dataclass
+@dataclass(eq=False)
 class MarketplaceConfigNode(LintTarget):
     """The .claude-plugin/marketplace.json manifest file."""
 
@@ -152,7 +160,7 @@ class MarketplaceConfigNode(LintTarget):
         return "marketplace.json"
 
 
-@dataclass
+@dataclass(eq=False)
 class MarketplaceNode(LintTarget):
     """A marketplace plugins directory."""
 
@@ -160,7 +168,7 @@ class MarketplaceNode(LintTarget):
         return f"{self.path.name}/ [marketplace]"
 
 
-@dataclass
+@dataclass(eq=False)
 class PluginNode(LintTarget):
     """A plugin directory."""
 
@@ -168,7 +176,7 @@ class PluginNode(LintTarget):
         return f"{self.path.name}/ [plugin]"
 
 
-@dataclass
+@dataclass(eq=False)
 class SkillNode(LintTarget):
     """A skill directory."""
 
@@ -176,7 +184,7 @@ class SkillNode(LintTarget):
         return f"{self.path.name}/ [skill]"
 
 
-@dataclass
+@dataclass(eq=False)
 class ApmConfigNode(LintTarget):
     """The apm.yml manifest file."""
 
@@ -184,7 +192,7 @@ class ApmConfigNode(LintTarget):
         return "apm.yml"
 
 
-@dataclass
+@dataclass(eq=False)
 class ApmNode(LintTarget):
     """The .apm/ directory container."""
 
@@ -192,7 +200,7 @@ class ApmNode(LintTarget):
         return ".apm/"
 
 
-@dataclass
+@dataclass(eq=False)
 class CodeRabbitNode(LintTarget):
     """A .coderabbit.yaml file container."""
 
@@ -200,7 +208,7 @@ class CodeRabbitNode(LintTarget):
         return ".coderabbit.yaml"
 
 
-@dataclass
+@dataclass(eq=False)
 class PromptfooConfigNode(LintTarget):
     """A promptfoo eval config or test fragment file."""
 

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -255,13 +255,19 @@ class ContentBlock(LintTarget):
     def tree_label(self) -> str:
         return f"{self.path.name} ({self.category})"
 
+    @property
+    def resolved_path(self) -> Path:
+        if not hasattr(self, "_resolved_path"):
+            self._resolved_path = self.path.resolve()
+        return self._resolved_path
+
     def __eq__(self, other):
         if not isinstance(other, ContentBlock):
             return NotImplemented
-        return type(self) is type(other) and self.path.resolve() == other.path.resolve()
+        return type(self) is type(other) and self.resolved_path == other.resolved_path
 
     def __hash__(self):
-        return hash((type(self), self.path.resolve()))
+        return hash((type(self), self.resolved_path))
 
 
 @dataclass(eq=False)
@@ -678,7 +684,7 @@ class BodyContent(ContentBlock):
         return "body"
 
 
-@dataclass
+@dataclass(eq=False)
 class FrontmatteredBlock(LintTarget):
     """Container for files with YAML frontmatter followed by a markdown body.
 
@@ -693,6 +699,20 @@ class FrontmatteredBlock(LintTarget):
     _fm_parsed: Optional[
         Tuple[Optional[Dict[str, Any]], Optional[str], Optional[int], str, int]
     ] = field(default=None, init=False, repr=False)
+
+    @property
+    def resolved_path(self) -> Path:
+        if not hasattr(self, "_resolved_path"):
+            self._resolved_path = self.path.resolve()
+        return self._resolved_path
+
+    def __eq__(self, other):
+        if not isinstance(other, FrontmatteredBlock):
+            return NotImplemented
+        return type(self) is type(other) and self.resolved_path == other.resolved_path
+
+    def __hash__(self):
+        return hash((type(self), self.resolved_path))
 
     def walk(self) -> Iterator["LintTarget"]:
         self._ensure_parsed()

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -638,13 +638,25 @@ def _parse_file_frontmatter(
     return fm, None, None, body, fm_line_count
 
 
-@dataclass
+@dataclass(eq=False)
 class FrontmatterField(LintTarget):
     """A single key-value pair from YAML frontmatter, exposed as a tree node."""
 
     name: str = ""
     value: Any = None
     field_line: Optional[int] = None
+
+    def __eq__(self, other):
+        if not isinstance(other, FrontmatterField):
+            return NotImplemented
+        return (
+            type(self) is type(other)
+            and self.path.resolve() == other.path.resolve()
+            and self.name == other.name
+        )
+
+    def __hash__(self):
+        return hash((type(self), self.path.resolve(), self.name))
 
     def tree_label(self) -> str:
         return f"frontmatter:{self.name}"

--- a/tests/fixtures/llm-fix-frontmattered/missing-description/SKILL.md
+++ b/tests/fixtures/llm-fix-frontmattered/missing-description/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: missing-description
+---
+
+# Missing Description Skill
+
+Deploy a service to Kubernetes using Helm charts.
+
+## Steps
+
+1. Run `helm lint charts/` to verify the chart is valid
+2. Run `helm upgrade --install` with the correct values
+3. Run `kubectl rollout status` to confirm pods are ready

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -330,3 +330,34 @@ def test_tree_all_rules_use_tree(temp_dir):
                                 f"{py_file.name}:{node.name}.check() "
                                 f"uses context.skills instead of tree"
                             )
+
+
+def test_all_lint_targets_are_hashable():
+    """Every LintTarget subclass must be hashable (usable as a dict key).
+
+    llm_fix groups violations by block via dict.setdefault(block, []).
+    If a LintTarget subclass is decorated with bare @dataclass (without
+    eq=False), Python generates __eq__ and sets __hash__ = None, making
+    it unhashable. Regression guard for GH-245.
+    """
+    # Force-import all modules that define LintTarget subclasses
+    import importlib
+
+    for mod in [
+        "skillsaw.lint_target",
+        "skillsaw.rules.builtin.content_analysis",
+    ]:
+        importlib.import_module(mod)
+
+    def _all_subclasses(cls):
+        result = set()
+        for sub in cls.__subclasses__():
+            result.add(sub)
+            result.update(_all_subclasses(sub))
+        return result
+
+    for cls in _all_subclasses(LintTarget):
+        assert cls.__hash__ is not None, (
+            f"{cls.__qualname__} is not hashable — "
+            f"add @dataclass(eq=False) and define __eq__/__hash__"
+        )

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -831,11 +831,13 @@ class TestLLMFixFrontmatteredBlock:
 
         from skillsaw.rules.builtin.content_analysis import SkillBlock
 
-        assert isinstance(fm_violations[0].block, SkillBlock), (
-            "Violation block must be a SkillBlock to exercise the bug path"
-        )
+        assert isinstance(
+            fm_violations[0].block, SkillBlock
+        ), "Violation block must be a SkillBlock to exercise the bug path"
 
-        fixed_frontmatter = "name: missing-description\ndescription: Deploy a service to the production cluster\n"
+        fixed_frontmatter = (
+            "name: missing-description\ndescription: Deploy a service to the production cluster\n"
+        )
         provider = _fake_fix_provider(fixed_frontmatter)
         result = linter.llm_fix(provider)
         assert result.violations_before > 0

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -5,7 +5,9 @@ a real LLM (live, requires SKILLSAW_LLM_INTEGRATION=1 + OPENROUTER_API_KEY).
 """
 
 import os
+import shutil
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable, List, Optional
 
 import pytest
@@ -792,3 +794,48 @@ class TestYAMLContentBlockLLMFix:
             assert isinstance(pi, list)
             assert len(pi) >= 1
             assert (pi[0].get("instructions") or "").strip() == case.fixed_content.strip()
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def copy_fixture(name, tmp_path):
+    src = FIXTURES / name
+    dst = tmp_path / name.replace("/", "_")
+    shutil.copytree(src, dst)
+    return dst
+
+
+class TestLLMFixFrontmatteredBlock:
+    """Regression test for GH-245: FrontmatteredBlock subclasses as dict keys.
+
+    skill-frontmatter violations carry a SkillBlock (a FrontmatteredBlock
+    subclass) as the block reference. llm_fix groups violations by block
+    via dict.setdefault(block, []), which requires __hash__. Before the
+    fix, @dataclass without eq=False made SkillBlock unhashable, crashing
+    with TypeError.
+    """
+
+    def test_llm_fix_skill_frontmatter(self, tmp_path):
+        """llm_fix must not crash when grouping violations on a SkillBlock."""
+        root = copy_fixture("llm-fix-frontmattered", tmp_path)
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        context = RepositoryContext(root)
+        linter = Linter(context, config)
+
+        violations = linter.run()
+        fm_violations = [v for v in violations if v.rule_id == "skill-frontmatter"]
+        assert len(fm_violations) >= 1, "Expected skill-frontmatter violation"
+
+        from skillsaw.rules.builtin.content_analysis import SkillBlock
+
+        assert isinstance(fm_violations[0].block, SkillBlock), (
+            "Violation block must be a SkillBlock to exercise the bug path"
+        )
+
+        fixed_frontmatter = "name: missing-description\ndescription: Deploy a service to the production cluster\n"
+        provider = _fake_fix_provider(fixed_frontmatter)
+        result = linter.llm_fix(provider)
+        assert result.violations_before > 0


### PR DESCRIPTION
FrontmatteredBlock was decorated with @dataclass (without eq=False), causing Python to generate __eq__ and set __hash__ = None. This made subclasses like SkillBlock unusable as dict keys, crashing llm_fix when grouping violations by block.

I ran into this error running:

```
skillsaw fix --model sonnet
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal comparison and hashing so project items are compared consistently, reducing flaky behavior.

* **Bug Fixes**
  * Stabilized frontmatter handling to avoid incorrect duplicates or mismatches during linting and fixes.

* **Tests**
  * Added regression and integration tests to ensure all lint targets remain hashable and that automated fixes for frontmatter run without crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->