### PR TITLE
Pin skillsaw version in GitHub Action

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.12.0"
+version: "0.12.1"
 
 rules:
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '.'
   version:
-    description: 'skillsaw version to install (e.g. "0.4.3"). Empty for latest.'
+    description: 'skillsaw version to install (e.g. "0.12.1"). Defaults to the version this action was released with.'
     required: false
     default: '0.12.1'
   strict:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.4.3"). Empty for latest.'
     required: false
-    default: ''
+    default: '0.12.0'
   strict:
     description: 'Treat warnings as errors'
     required: false
@@ -50,12 +50,10 @@ runs:
         SKILLSAW_VERSION: ${{ inputs.version }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
-        if [ -n "$SKILLSAW_VERSION" ]; then
-          pip install -q "skillsaw==$SKILLSAW_VERSION"
-        elif [ -f "$ACTION_PATH/pyproject.toml" ]; then
+        if [ -f "$ACTION_PATH/pyproject.toml" ]; then
           pip install -q "$ACTION_PATH"
         else
-          pip install -q skillsaw
+          pip install -q "skillsaw==$SKILLSAW_VERSION"
         fi
 
     - name: Run skillsaw

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.4.3"). Empty for latest.'
     required: false
-    default: '0.12.0'
+    default: '0.12.1'
   strict:
     description: 'Treat warnings as errors'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.12.0"
+version = "0.12.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PYPROJECT="$REPO_ROOT/pyproject.toml"
 INIT_PY="$REPO_ROOT/src/skillsaw/__init__.py"
+ACTION_YML="$REPO_ROOT/action.yml"
 
 current_version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$PYPROJECT")
 
@@ -27,6 +28,7 @@ import re, sys
 for path, pattern, repl in [
     ('$PYPROJECT', r'^version = \"$current_version\"', 'version = \"$new_version\"'),
     ('$INIT_PY', r'^__version__ = \"$current_version\"', '__version__ = \"$new_version\"'),
+    ('$ACTION_YML', r\"default: '$current_version'\", \"default: '$new_version'\"),
 ]:
     text = open(path).read()
     text = re.sub(pattern, repl, text, count=1, flags=re.MULTILINE)
@@ -36,3 +38,4 @@ for path, pattern, repl in [
 echo "Updated:"
 echo "  $PYPROJECT"
 echo "  $INIT_PY"
+echo "  $ACTION_YML"

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext


### PR DESCRIPTION
## Summary
- Pin the action's `version` input default to the current release (`0.12.0`) instead of empty, eliminating the unconstrained `pip install skillsaw` fallback
- Remove the branch that could install skillsaw without any version constraint
- Update `bump-version.sh` to keep `action.yml`'s default in sync on every version bump

## Test plan
- [x] Verified `bump-version.sh` correctly updates all three files (pyproject.toml, __init__.py, action.yml)
- [ ] Confirm action installs the pinned version when used via tag reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)