### PR TITLE
Fix --no-custom-rules bypass on agentskill-name rename re-lint

### DIFF
--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -873,7 +873,13 @@ def _run_fix(args):
 
         if not dry_run and any(f.rule_id == "agentskill-name" for f in applied):
             context = RepositoryContext(args.path)
-            linter = Linter(context, config, rule_ids=rule_ids, skip_rule_ids=skip_rule_ids)
+            linter = Linter(
+                context,
+                config,
+                rule_ids=rule_ids,
+                skip_rule_ids=skip_rule_ids,
+                no_custom_rules=args.no_custom_rules,
+            )
             rename_applied, rename_suggested = linter.fix_and_apply(confidence)
             applied.extend(rename_applied)
             suggested.extend(rename_suggested)

--- a/tests/fixtures/custom-rule-rename-bypass/.skillsaw-sentinel.py
+++ b/tests/fixtures/custom-rule-rename-bypass/.skillsaw-sentinel.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+from typing import List
+
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+
+sentinel = Path(os.environ.get("SKILLSAW_SENTINEL", "/dev/null"))
+sentinel.write_text("custom rule was imported")
+
+
+class SentinelRule(Rule):
+    @property
+    def rule_id(self) -> str:
+        return "sentinel-rule"
+
+    @property
+    def description(self) -> str:
+        return "Writes a sentinel file on import to detect unwanted custom-rule loading"
+
+    def default_severity(self) -> Severity:
+        return Severity.INFO
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return []

--- a/tests/fixtures/custom-rule-rename-bypass/.skillsaw-sentinel.py
+++ b/tests/fixtures/custom-rule-rename-bypass/.skillsaw-sentinel.py
@@ -4,8 +4,9 @@ from typing import List
 
 from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
 
-sentinel = Path(os.environ.get("SKILLSAW_SENTINEL", "/dev/null"))
-sentinel.write_text("custom rule was imported")
+sentinel_env = os.environ.get("SKILLSAW_SENTINEL")
+if sentinel_env:
+    Path(sentinel_env).write_text("custom rule was imported")
 
 
 class SentinelRule(Rule):

--- a/tests/fixtures/custom-rule-rename-bypass/.skillsaw.yaml
+++ b/tests/fixtures/custom-rule-rename-bypass/.skillsaw.yaml
@@ -1,0 +1,2 @@
+custom-rules:
+  - .skillsaw-sentinel.py

--- a/tests/fixtures/custom-rule-rename-bypass/Wrong_Name/SKILL.md
+++ b/tests/fixtures/custom-rule-rename-bypass/Wrong_Name/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: wrong-name
+description: A skill with a mismatched directory name to trigger agentskill-name rename
+---
+
+# Wrong Name
+
+This skill exists to test that custom rules are not loaded during
+the post-rename re-lint when `--no-custom-rules` is used.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1422,6 +1422,51 @@ class TestRuleFilter:
         assert result.returncode == 0
 
 
+# ── Custom-rule bypass on rename re-lint (GH-257) ────────────────
+
+
+class TestNoCustomRulesRenameBypass:
+    """--no-custom-rules must be honoured on the post-rename re-lint pass."""
+
+    FIXTURE = "custom-rule-rename-bypass"
+
+    def test_no_custom_rules_blocks_import_after_rename(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        sentinel = tmp_path / "sentinel.txt"
+        env = {**os.environ, "SKILLSAW_SENTINEL": str(sentinel)}
+        args = [
+            sys.executable,
+            "-m",
+            "skillsaw",
+            "fix",
+            "--no-custom-rules",
+            str(repo),
+        ]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+        assert result.returncode == 0, f"fix failed: {result.stderr}"
+        assert not sentinel.exists(), (
+            "Custom rule was imported despite --no-custom-rules " "(sentinel file was created)"
+        )
+
+    def test_custom_rules_loaded_without_flag(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        sentinel = tmp_path / "sentinel.txt"
+        env = {**os.environ, "SKILLSAW_SENTINEL": str(sentinel)}
+        args = [
+            sys.executable,
+            "-m",
+            "skillsaw",
+            "fix",
+            str(repo),
+        ]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+        assert result.returncode == 0, f"fix failed: {result.stderr}"
+        assert sentinel.exists(), (
+            "Custom rule was NOT imported without --no-custom-rules "
+            "(fixture does not exercise the code path)"
+        )
+
+
 # ── Baseline ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Passes `no_custom_rules=args.no_custom_rules` to the rebuilt `Linter` in the post-rename re-lint branch of `_run_fix()`, closing a security gap where custom-rule code could execute despite `--no-custom-rules`
- Adds regression tests with a fixture that uses a sentinel file to detect unwanted custom-rule imports — verifies the flag blocks import after rename, and that the fixture actually exercises the code path without the flag

Fixes #257

## Test plan

- [x] `make test` — all 1583 tests pass (including 2 new regression tests)
- [x] `make lint` — clean
- [x] `skillsaw lint` against `openshift-eng/ai-helpers` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `--no-custom-rules` flag was not being respected during the fix command's re-linting phase after applying autofixes.

* **Tests**
  * Added integration tests to verify `--no-custom-rules` behavior during the fix command's re-linting process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->