### PR TITLE
[Auto] Treat bare skillsaw-disable-next-line as suppress-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,13 @@ Suppress a single line:
 Follow best practices for error handling.
 ```
 
+Omitting the rule IDs suppresses all rules on the next line:
+
+```markdown
+<!-- skillsaw-disable-next-line -->
+This line is exempt from every rule.
+```
+
 Suppress multiple rules at once:
 
 ```markdown

--- a/src/skillsaw/suppression.py
+++ b/src/skillsaw/suppression.py
@@ -45,7 +45,7 @@ from typing import Dict, FrozenSet, List, Optional, Set
 # Directive patterns applied to the *text inside* an HTML comment.
 # These match the full comment body, allowing arbitrary whitespace/newlines.
 _DISABLE_NEXT_LINE_DIR = re.compile(
-    r"skillsaw-disable-next-line(?:\s+([\w,\s-]+))?",
+    r"skillsaw-disable-next-line(?![\w-])(?:\s+([\w,\s-]+))?",
     re.IGNORECASE,
 )
 _DISABLE_DIR = re.compile(

--- a/src/skillsaw/suppression.py
+++ b/src/skillsaw/suppression.py
@@ -16,6 +16,8 @@ Markdown / HTML::
     <!-- skillsaw-disable rule-a, rule-b -->
     <!-- skillsaw-enable -->  (re-enables all)
 
+    <!-- skillsaw-disable-next-line -->  (suppresses all rules on the next line)
+
 YAML::
 
     # skillsaw-disable rule-id
@@ -43,7 +45,7 @@ from typing import Dict, FrozenSet, List, Optional, Set
 # Directive patterns applied to the *text inside* an HTML comment.
 # These match the full comment body, allowing arbitrary whitespace/newlines.
 _DISABLE_NEXT_LINE_DIR = re.compile(
-    r"skillsaw-disable-next-line\s+([\w,\s-]+)",
+    r"skillsaw-disable-next-line(?:\s+([\w,\s-]+))?",
     re.IGNORECASE,
 )
 _DISABLE_DIR = re.compile(
@@ -97,7 +99,7 @@ class _CommentParser(HTMLParser):
         m = _DISABLE_NEXT_LINE_DIR.search(text)
         if m:
             self.directives.append(
-                _Directive("disable-next-line", _parse_rule_ids(m.group(1)), line)
+                _Directive("disable-next-line", _parse_rule_ids(m.group(1) or ""), line)
             )
             return
 
@@ -140,7 +142,9 @@ def _extract_yaml_directives(content: str) -> List[_Directive]:
         m2 = _DISABLE_NEXT_LINE_DIR.search(text)
         if m2:
             directives.append(
-                _Directive("disable-next-line", _parse_rule_ids(m2.group(1)), line, is_yaml=True)
+                _Directive(
+                    "disable-next-line", _parse_rule_ids(m2.group(1) or ""), line, is_yaml=True
+                )
             )
             continue
 
@@ -270,9 +274,13 @@ def build_suppression_map(content: str, line_offset: int = 0) -> SuppressionMap:
             # this line is itself a directive, carry it forward.
             continue
 
-        # Apply next-line suppression
+        # Apply next-line suppression (empty rule list means "all rules",
+        # matching the block disable/enable directives)
         if next_line_rules is not None:
-            suppressed_lines.setdefault(file_line, set()).update(next_line_rules)
+            if next_line_rules:
+                suppressed_lines.setdefault(file_line, set()).update(next_line_rules)
+            else:
+                fully_suppressed_lines.add(file_line)
             next_line_rules = None
 
         # Apply "disable all" to this line

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -131,6 +131,22 @@ class TestBuildSuppressionMap:
         assert not smap.is_suppressed("content-weak-language", 3)
         assert not smap.is_suppressed("content-tautological", 3)
 
+    def test_disable_next_line_no_rules_suppresses_all(self):
+        """Bare <!-- skillsaw-disable-next-line --> suppresses all rules on the next line."""
+        content = (
+            "Line one\n"
+            "<!-- skillsaw-disable-next-line -->\n"
+            "Try to handle errors.\n"
+            "Try to handle errors again.\n"
+        )
+        smap = build_suppression_map(content)
+        # Line 3 should be suppressed for any rule
+        assert smap.is_suppressed("content-weak-language", 3)
+        assert smap.is_suppressed("content-tautological", 3)
+        # Lines 1 and 4 should NOT be suppressed
+        assert not smap.is_suppressed("content-weak-language", 1)
+        assert not smap.is_suppressed("content-weak-language", 4)
+
     def test_disable_all(self):
         """Bare <!-- skillsaw-disable --> should suppress all rules."""
         content = (
@@ -346,6 +362,16 @@ class TestBuildSuppressionMap:
         )
         smap = build_suppression_map(content)
         assert smap.is_suppressed("promptfoo-valid", 3)
+        assert not smap.is_suppressed("promptfoo-valid", 4)
+
+    def test_yaml_disable_next_line_no_rules_suppresses_all(self):
+        """Bare # skillsaw-disable-next-line suppresses all rules on the next line."""
+        content = (
+            "providers:\n" "# skillsaw-disable-next-line\n" "tests: 42\n" "scenarios: also-bad\n"
+        )
+        smap = build_suppression_map(content)
+        assert smap.is_suppressed("promptfoo-valid", 3)
+        assert smap.is_suppressed("any-other-rule", 3)
         assert not smap.is_suppressed("promptfoo-valid", 4)
 
     def test_yaml_disable_all(self):

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -573,3 +573,11 @@ class TestInlineSuppressionIntegration:
 
         pf = [v for v in violations if v.rule_id == "promptfoo-valid"]
         assert len(pf) == 0
+
+
+def test_unknown_hyphenated_directive_not_treated_as_bare_disable():
+    """A longer token like skillsaw-disable-next-line-foo is not a directive."""
+    content = "Line one\n" "<!-- skillsaw-disable-next-line-custom -->\n" "Try to handle errors.\n"
+    smap = build_suppression_map(content)
+    assert not smap.is_suppressed("content-weak-language", 3)
+    assert not smap.is_suppressed("any-rule", 3)


### PR DESCRIPTION
## Summary

A bare `<!-- skillsaw-disable-next-line -->` (no rule IDs) silently suppressed nothing: the directive regex required at least one rule ID, while the block `skillsaw-disable` / `skillsaw-enable` directives treat an empty rule list as "all rules."

This makes the next-line form consistent:

- The rule-ID group in `_DISABLE_NEXT_LINE_DIR` is now optional (`(?:\s+([\w,\s-]+))?`), so the group only matches after whitespace and bare directives parse with an empty rule list.
- `build_suppression_map` now maps an empty next-line rule list to full suppression of the following line, matching the bare block-disable semantics.
- README documents the bare next-line form.

Closes #264

## Testing

- New unit tests for the bare directive in both HTML-comment (markdown) and `#`-comment (YAML) forms.
- Full suite passes: 1589 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)