### PR TITLE
[Auto] Apply _WALK_SKIP_DIRS to skill and promptfoo discovery

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -316,15 +316,15 @@ class RepositoryContext:
             for f in filenames:
                 yield Path(dirpath) / f
 
+    def _should_skip_dir(self, item: Path) -> bool:
+        """True if *item* is not a directory worth recursing into."""
+        return not item.is_dir() or item.name.startswith(".") or item.name in self._WALK_SKIP_DIRS
+
     def _has_skill_md_recursive(self, path: Path) -> bool:
         """Check if any subdirectory contains SKILL.md, recursively"""
         try:
             for item in path.iterdir():
-                if (
-                    not item.is_dir()
-                    or item.name.startswith(".")
-                    or item.name in self._WALK_SKIP_DIRS
-                ):
+                if self._should_skip_dir(item):
                     continue
                 if (item / "SKILL.md").exists():
                     return True
@@ -689,11 +689,7 @@ class RepositoryContext:
         """Discover skill directories within a parent directory, recursively"""
         try:
             for item in parent.iterdir():
-                if (
-                    not item.is_dir()
-                    or item.name.startswith(".")
-                    or item.name in self._WALK_SKIP_DIRS
-                ):
+                if self._should_skip_dir(item):
                     continue
                 resolved = item.resolve()
                 if resolved in discovered:

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import fnmatch
 from enum import Enum
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Set, TYPE_CHECKING
+from typing import Iterator, Optional, List, Dict, Any, Set, TYPE_CHECKING
 import json
 import logging
 import os
@@ -291,26 +291,40 @@ class RepositoryContext:
 
     def _is_promptfoo_repo(self) -> bool:
         """Check if this repository contains promptfoo eval configs."""
-        for pattern in ("promptfooconfig*.yaml", "promptfooconfig*.yml"):
-            if any(self.root_path.rglob(pattern)):
+        for f in self._walk_files(self.root_path):
+            if fnmatch.fnmatch(f.name, "promptfooconfig*.yaml") or fnmatch.fnmatch(
+                f.name, "promptfooconfig*.yml"
+            ):
                 return True
         evals_dir = self.root_path / "evals"
         if evals_dir.is_dir():
             from .rules.builtin.promptfoo import _is_promptfoo_config
             from .rules.builtin.utils import read_yaml
 
-            for pattern in ("*.yaml", "*.yml"):
-                for yaml_file in evals_dir.rglob(pattern):
-                    data, error = read_yaml(yaml_file)
-                    if not error and _is_promptfoo_config(data):
-                        return True
+            for yaml_file in self._walk_files(evals_dir):
+                if yaml_file.suffix not in (".yaml", ".yml"):
+                    continue
+                data, error = read_yaml(yaml_file)
+                if not error and _is_promptfoo_config(data):
+                    return True
         return False
+
+    def _walk_files(self, root: Path) -> Iterator[Path]:
+        """Yield all files under *root*, pruning ``_WALK_SKIP_DIRS`` directories."""
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in self._WALK_SKIP_DIRS]
+            for f in filenames:
+                yield Path(dirpath) / f
 
     def _has_skill_md_recursive(self, path: Path) -> bool:
         """Check if any subdirectory contains SKILL.md, recursively"""
         try:
             for item in path.iterdir():
-                if not item.is_dir() or item.name.startswith("."):
+                if (
+                    not item.is_dir()
+                    or item.name.startswith(".")
+                    or item.name in self._WALK_SKIP_DIRS
+                ):
                     continue
                 if (item / "SKILL.md").exists():
                     return True
@@ -675,7 +689,11 @@ class RepositoryContext:
         """Discover skill directories within a parent directory, recursively"""
         try:
             for item in parent.iterdir():
-                if not item.is_dir() or item.name.startswith("."):
+                if (
+                    not item.is_dir()
+                    or item.name.startswith(".")
+                    or item.name in self._WALK_SKIP_DIRS
+                ):
                     continue
                 resolved = item.resolve()
                 if resolved in discovered:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -562,3 +562,63 @@ def test_coderabbit_with_claude_md_gets_both_formats(temp_dir):
     context = RepositoryContext(temp_dir)
     assert HAS_CODERABBIT in context.detected_formats
     assert HAS_CLAUDE_MD in context.detected_formats
+
+
+def test_skill_in_node_modules_not_detected(temp_dir):
+    """SKILL.md inside node_modules should not mark the repo as agentskills."""
+    dep_skill = temp_dir / "node_modules" / "some-dep" / "skills" / "helper"
+    dep_skill.mkdir(parents=True)
+    (dep_skill / "SKILL.md").write_text("---\nname: helper\ndescription: A dep skill\n---\nBody\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.AGENTSKILLS not in context.repo_types
+    assert dep_skill not in [s.resolve() for s in context.skills]
+
+
+def test_skill_in_venv_not_discovered(temp_dir):
+    """Skills vendored in venv/__pycache__ are not discovered alongside real skills."""
+    real_skill = temp_dir / "skills" / "real-skill"
+    real_skill.mkdir(parents=True)
+    (real_skill / "SKILL.md").write_text(
+        "---\nname: real-skill\ndescription: A real skill\n---\nBody\n"
+    )
+    for skip_dir in ("venv", "__pycache__", "node_modules"):
+        vendored = temp_dir / skip_dir / "pkg" / "vendored-skill"
+        vendored.mkdir(parents=True)
+        (vendored / "SKILL.md").write_text(
+            "---\nname: vendored-skill\ndescription: Vendored\n---\nBody\n"
+        )
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.AGENTSKILLS in context.repo_types
+    skill_names = {s.name for s in context.skills}
+    assert "real-skill" in skill_names
+    assert "vendored-skill" not in skill_names
+
+
+def test_promptfoo_config_in_node_modules_not_detected(temp_dir):
+    """promptfooconfig.yaml inside node_modules should not mark the repo as promptfoo."""
+    dep = temp_dir / "node_modules" / "promptfoo-dep"
+    dep.mkdir(parents=True)
+    (dep / "promptfooconfig.yaml").write_text("prompts:\n  - 'test'\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.PROMPTFOO not in context.repo_types
+
+
+def test_promptfoo_eval_in_evals_node_modules_not_detected(temp_dir):
+    """promptfoo-shaped YAML under evals/node_modules should not mark the repo as promptfoo."""
+    dep = temp_dir / "evals" / "node_modules" / "dep"
+    dep.mkdir(parents=True)
+    (dep / "eval.yaml").write_text("prompts:\n  - 'test'\nproviders:\n  - openai:gpt-4\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.PROMPTFOO not in context.repo_types
+
+
+def test_promptfoo_config_at_root_still_detected(temp_dir):
+    """promptfooconfig.yaml outside skip dirs is still detected."""
+    (temp_dir / "promptfooconfig.yaml").write_text("prompts:\n  - 'test'\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.PROMPTFOO in context.repo_types


### PR DESCRIPTION
## Summary

Skill and promptfoo discovery recursed into `node_modules`, `venv`, `__pycache__`, and other heavy directories, ignoring the `_WALK_SKIP_DIRS` set already defined and used by `_find_named_instructions_md`. This slowed startup on large JS/Python repos and could discover/lint skills and promptfoo configs shipped inside third-party dependencies.

Changes in `src/skillsaw/context.py`:

- `_has_skill_md_recursive` and `_discover_skills_in_dir` now skip `_WALK_SKIP_DIRS` names in addition to dot-directories.
- `_is_promptfoo_repo` no longer uses bare `rglob` over the whole tree; it walks with a new `_walk_files` helper that prunes `_WALK_SKIP_DIRS` (both for root-level `promptfooconfig*` discovery and the `evals/` scan).

Closes #265

## Testing

- 5 new regression tests covering SKILL.md and promptfoo configs inside `node_modules`/`venv`/`__pycache__` (all 4 negative cases fail without the fix), plus a positive case confirming root-level detection still works.
- Full suite passes: 1590 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)