### PR TITLE
[Auto] Surface rule crashes as ERROR violations

### DIFF
--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -308,8 +308,21 @@ class Linter:
                 violations.extend(rule_violations)
             except Exception as e:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
+                violations.append(self._crash_violation(rule, e))
 
         return self._filter_violations(violations)
+
+    @staticmethod
+    def _crash_violation(rule: Rule, exc: Exception, action: str = "check") -> RuleViolation:
+        """Surface a rule crash as an ERROR violation so it affects the exit code."""
+        return RuleViolation(
+            rule_id="rule-execution-error",
+            severity=Severity.ERROR,
+            message=(
+                f"Rule '{rule.rule_id}' crashed during {action}:"
+                f" {exc.__class__.__name__}: {exc}"
+            ),
+        )
 
     def fix(self) -> tuple[List[RuleViolation], List[AutofixResult]]:
         """
@@ -327,6 +340,7 @@ class Linter:
                 rule_violations = rule.check(self.context)
             except Exception as e:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
+                all_violations.append(self._crash_violation(rule, e))
                 continue
 
             checked.extend(rule_violations)
@@ -341,6 +355,7 @@ class Linter:
                     all_violations.extend(remaining)
                 except Exception as e:
                     print(f"Error fixing rule {rule.rule_id}: {e}", file=sys.stderr)
+                    all_violations.append(self._crash_violation(rule, e, action="fix"))
                     all_violations.extend(visible)
             else:
                 all_violations.extend(visible)

--- a/tests/fixtures/crashing-rule/.skillsaw-crash.py
+++ b/tests/fixtures/crashing-rule/.skillsaw-crash.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+
+
+class CrashingRule(Rule):
+    @property
+    def rule_id(self) -> str:
+        return "fixture-crashing-rule"
+
+    @property
+    def description(self) -> str:
+        return "Always raises to exercise rule-crash handling"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        raise RuntimeError("intentional crash")

--- a/tests/fixtures/crashing-rule/.skillsaw.yaml
+++ b/tests/fixtures/crashing-rule/.skillsaw.yaml
@@ -1,0 +1,2 @@
+custom-rules:
+  - .skillsaw-crash.py

--- a/tests/fixtures/crashing-rule/deploy-service/SKILL.md
+++ b/tests/fixtures/crashing-rule/deploy-service/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: deploy-service
+description: Deploy a service to Kubernetes using Helm charts
+compatibility: Requires helm, kubectl, and cluster credentials
+metadata:
+  author: platform-team
+  version: "2.1"
+---
+
+# Deploy Service
+
+Automates the deployment of microservices to Kubernetes clusters using
+Helm charts and environment-specific value overrides.
+
+## When to Use This Skill
+
+Use when deploying a service to staging or production, or when updating
+an existing deployment with new configuration.
+
+## Implementation Steps
+
+### Step 1: Validate Chart
+
+Run `helm lint charts/` to verify the Helm chart is syntactically valid.
+Check that all required values are defined in `values.yaml`:
+- `image.repository`
+- `image.tag`
+- `replicaCount`
+- `resources.limits.cpu`
+- `resources.limits.memory`
+
+### Step 2: Apply Configuration
+
+Merge environment-specific values from `values-{env}.yaml` with the
+base `values.yaml` file:
+```bash
+helm template my-service charts/ \
+  -f charts/values.yaml \
+  -f charts/values-$ENV.yaml \
+  --dry-run
+```
+
+Review the rendered manifest before applying.
+
+### Step 3: Execute Deployment
+
+Run `helm upgrade --install` with the merged configuration:
+```bash
+helm upgrade --install my-service charts/ \
+  -f charts/values.yaml \
+  -f charts/values-$ENV.yaml \
+  -n $NAMESPACE \
+  --wait --timeout 300s
+```
+
+### Step 4: Verify
+
+Run `kubectl rollout status deployment/my-service -n $NAMESPACE` to
+confirm all pods are ready. Check that health endpoints return 200.
+
+## Examples
+
+### Example 1: Deploy to Staging
+
+Deploy the user service to the staging cluster with default values:
+```bash
+helm upgrade --install user-service charts/ -f charts/values-staging.yaml -n staging
+```
+
+### Example 2: Deploy with Custom Tag
+
+Override the image tag for a specific build:
+```bash
+helm upgrade --install user-service charts/ --set image.tag=abc1234 -n production
+```

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1808,3 +1808,21 @@ class TestApplyPatch:
         assert result.returncode == 0
         assert "applied successfully" in result.stdout
         assert "(lint-path)" in target.read_text()
+
+
+# ── Rule crash handling (GH-263) ─────────────────────────────────
+
+
+class TestRuleCrashExitCode:
+    """A rule that raises must surface in the report and fail the lint."""
+
+    FIXTURE = "crashing-rule"
+
+    def test_rule_crash_fails_lint(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        args = [sys.executable, "-m", "skillsaw", "lint", str(repo)]
+        result = subprocess.run(args, capture_output=True, text=True, timeout=60)
+        assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+        assert "rule-execution-error" in result.stdout
+        assert "fixture-crashing-rule" in result.stdout
+        assert "intentional crash" in result.stdout

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -267,3 +267,43 @@ def test_rule_crash_in_fix_produces_error_violation(valid_plugin):
     assert len(crashes) == 1
     assert crashes[0].severity.value == "error"
     assert fixes == []
+
+
+class _CrashingFixRule:
+    """Stand-in rule whose check() succeeds but fix() always raises."""
+
+    rule_id = "crashing-fix-rule"
+    description = "fix always crashes"
+    supports_autofix = True
+
+    def check(self, context):
+        from skillsaw.rule import RuleViolation, Severity
+
+        return [
+            RuleViolation(
+                rule_id="crashing-fix-rule",
+                severity=Severity.WARNING,
+                message="needs fixing",
+            )
+        ]
+
+    def fix(self, context, violations):
+        raise RuntimeError("fix boom")
+
+
+def test_rule_crash_during_autofix_produces_error_violation(valid_plugin):
+    """A rule that raises during fix()'s autofix pass surfaces as an ERROR violation."""
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, LinterConfig.default())
+    linter.rules = [_CrashingFixRule()]
+
+    violations, fixes = linter.fix()
+
+    crashes = [v for v in violations if v.rule_id == "rule-execution-error"]
+    assert len(crashes) == 1
+    assert crashes[0].severity.value == "error"
+    assert "during fix" in crashes[0].message
+    assert "fix boom" in crashes[0].message
+    # The unfixed violations are still reported alongside the crash
+    assert any(v.rule_id == "crashing-fix-rule" for v in violations)
+    assert fixes == []

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -221,3 +221,49 @@ def test_self_lint():
     ]
 
     assert len(errors) == 0, f"Self-lint found errors: {errors}"
+
+
+class _CrashingRule:
+    """Stand-in rule whose check() always raises."""
+
+    rule_id = "crashing-rule"
+    description = "always crashes"
+    supports_autofix = False
+
+    def check(self, context):
+        raise RuntimeError("boom")
+
+
+def test_rule_crash_produces_error_violation(valid_plugin, capsys):
+    """A rule that raises during check() surfaces as an ERROR violation."""
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, LinterConfig.default())
+    linter.rules = [_CrashingRule()]
+
+    violations = linter.run()
+
+    crashes = [v for v in violations if v.rule_id == "rule-execution-error"]
+    assert len(crashes) == 1
+    assert crashes[0].severity.value == "error"
+    assert "crashing-rule" in crashes[0].message
+    assert "RuntimeError" in crashes[0].message
+    assert "boom" in crashes[0].message
+    # Still printed to stderr for visibility
+    assert "Error running rule crashing-rule" in capsys.readouterr().err
+
+    errors, _, _ = get_counts(violations)
+    assert errors >= 1
+
+
+def test_rule_crash_in_fix_produces_error_violation(valid_plugin):
+    """A rule that raises during fix()'s check pass surfaces as an ERROR violation."""
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, LinterConfig.default())
+    linter.rules = [_CrashingRule()]
+
+    violations, fixes = linter.fix()
+
+    crashes = [v for v in violations if v.rule_id == "rule-execution-error"]
+    assert len(crashes) == 1
+    assert crashes[0].severity.value == "error"
+    assert fixes == []


### PR DESCRIPTION
## Summary

Rule exceptions during `lint`/`fix` were caught, printed to stderr, and swallowed: the crashing rule's violations were dropped and `skillsaw` still exited 0, so in CI a crashing rule silently stopped being enforced.

Crashes are now also surfaced as a synthetic `rule-execution-error` ERROR violation (same pattern as the existing `invalid-config` synthetic violations), which means:

- They appear in every report format, not just stderr.
- They count toward the error total, so `lint` exits 1.
- The message includes the rule ID, exception type, and exception message.

All three swallow sites are covered: `run()`, the check pass in `fix()`, and autofix failures in `fix()` (reported with `during fix`). The stderr print is kept for visibility.

Closes #263

## Testing

- Unit tests: crashing rule in `run()` and `fix()` produces an ERROR `rule-execution-error` violation and still prints to stderr.
- Integration test with a new `crashing-rule` fixture (custom rule that raises): the CLI exits 1 and the report names the crashed rule.
- Full suite passes: 1588 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)