### PR TITLE
[Auto] Parse config version leniently instead of crashing

### DIFF
--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -3,6 +3,7 @@ Configuration management for skillsaw
 """
 
 import os
+import re
 
 import yaml
 from pathlib import Path
@@ -22,7 +23,21 @@ _DEFAULT_EXCLUDE_PATTERNS = [
 
 
 def _parse_version(v: str) -> Tuple[int, ...]:
-    return tuple(int(x) for x in v.split("."))
+    """Parse a version string leniently into a comparable numeric tuple.
+
+    The ``version`` field is user-controlled config, so common variants of
+    ``X.Y.Z`` must not crash the lint: a leading ``v`` (``v0.12.0``) and
+    pre-release/build suffixes (``0.12.0-rc1``, ``0.12.0+build5``) are
+    accepted. Components that still aren't numeric contribute their leading
+    digits, or 0 when there are none.
+    """
+    v = str(v).strip().lstrip("vV")
+    v = re.split(r"[-+]", v, maxsplit=1)[0]
+    parts = []
+    for component in v.split("."):
+        m = re.match(r"\d+", component.strip())
+        parts.append(int(m.group()) if m else 0)
+    return tuple(parts)
 
 
 @dataclass

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -29,7 +29,9 @@ def _parse_version(v: str) -> Tuple[int, ...]:
     ``X.Y.Z`` must not crash the lint: a leading ``v`` (``v0.12.0``) and
     pre-release/build suffixes (``0.12.0-rc1``, ``0.12.0+build5``) are
     accepted. Components that still aren't numeric contribute their leading
-    digits, or 0 when there are none.
+    digits, or 0 when there are none. Results are zero-padded to at least
+    three components so short versions like "1.2" compare correctly against
+    "1.2.0" (tuple comparison would otherwise rank (1, 2) below (1, 2, 0)).
     """
     v = str(v).strip().lstrip("vV")
     v = re.split(r"[-+]", v, maxsplit=1)[0]
@@ -37,6 +39,8 @@ def _parse_version(v: str) -> Tuple[int, ...]:
     for component in v.split("."):
         m = re.match(r"\d+", component.strip())
         parts.append(int(m.group()) if m else 0)
+    while len(parts) < 3:
+        parts.append(0)
     return tuple(parts)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -396,8 +396,11 @@ def test_parse_version_lenient_forms():
     assert _parse_version("0.12.0-rc1") == (0, 12, 0)
     assert _parse_version("0.12.0+build5") == (0, 12, 0)
     assert _parse_version("2026.06.09") == (2026, 6, 9)
+    # Short versions are zero-padded so "1.2" compares equal to "1.2.0"
+    assert _parse_version("1") == (1, 0, 0)
+    assert _parse_version("1.2") == (1, 2, 0)
     # Fully non-numeric components degrade to 0 rather than raising
-    assert _parse_version("abc") == (0,)
+    assert _parse_version("abc") == (0, 0, 0)
 
 
 def test_prerelease_version_does_not_crash_version_gate(temp_dir, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -387,6 +387,59 @@ def test_float_version_does_not_crash(tmp_path):
     assert config.version == "1.0"
 
 
+def test_parse_version_lenient_forms():
+    """Common non-strict version forms parse without crashing"""
+    from skillsaw.config import _parse_version
+
+    assert _parse_version("0.12.0") == (0, 12, 0)
+    assert _parse_version("v0.12.0") == (0, 12, 0)
+    assert _parse_version("0.12.0-rc1") == (0, 12, 0)
+    assert _parse_version("0.12.0+build5") == (0, 12, 0)
+    assert _parse_version("2026.06.09") == (2026, 6, 9)
+    # Fully non-numeric components degrade to 0 rather than raising
+    assert _parse_version("abc") == (0,)
+
+
+def test_prerelease_version_does_not_crash_version_gate(temp_dir, tmp_path):
+    """A pre-release version string in config must not crash is_rule_enabled"""
+    (temp_dir / "CLAUDE.md").write_text("# Test")
+    context = RepositoryContext(temp_dir)
+    config_file = tmp_path / ".skillsaw.yaml"
+    config_file.write_text('version: "0.12.0-rc1"\nrules: {}\n')
+    config = LinterConfig.from_file(config_file)
+    # Gate behaves as 0.12.0: since 0.7.0 rules pass, future rules are blocked
+    assert config.is_rule_enabled(
+        "content-weak-language",
+        context,
+        formats=ALL_INSTRUCTION_FORMATS,
+        since_version="0.7.0",
+    )
+    assert (
+        config.is_rule_enabled(
+            "content-weak-language",
+            context,
+            formats=ALL_INSTRUCTION_FORMATS,
+            since_version="99.0.0",
+        )
+        is False
+    )
+
+
+def test_v_prefixed_version_does_not_crash_version_gate(temp_dir, tmp_path):
+    """A v-prefixed version string in config must not crash is_rule_enabled"""
+    (temp_dir / "CLAUDE.md").write_text("# Test")
+    context = RepositoryContext(temp_dir)
+    config_file = tmp_path / ".skillsaw.yaml"
+    config_file.write_text('version: "v0.12.0"\nrules: {}\n')
+    config = LinterConfig.from_file(config_file)
+    assert config.is_rule_enabled(
+        "content-weak-language",
+        context,
+        formats=ALL_INSTRUCTION_FORMATS,
+        since_version="0.7.0",
+    )
+
+
 def test_version_gates_new_rules(temp_dir):
     """Rules with since > config version are skipped when not explicitly configured"""
     (temp_dir / "CLAUDE.md").write_text("# Test")


### PR DESCRIPTION
## Summary

A `.skillsaw.yaml` whose `version` isn't a strict `X.Y.Z` numeric triple — a pre-release suffix (`0.12.0-rc1`), a `v` prefix (`v0.12.0`), or any non-integer component — crashed every lint with `Error: invalid literal for int() with base 10: '0-rc1'`, with no hint that the `version` field was at fault.

`_parse_version` now parses defensively:

- strips a leading `v`/`V`
- drops pre-release/build suffixes (`-rc1`, `+build5`)
- non-numeric components contribute their leading digits, or `0` when there are none
- coerces non-string input via `str()` for extra safety

So `"0.12.0-rc1"` gates as `(0, 12, 0)` and the version gate never raises on user-controlled config.

Closes #259

## Testing

- Unit tests for `_parse_version` covering `0.12.0`, `v0.12.0`, `0.12.0-rc1`, `0.12.0+build5`, date-style, and fully non-numeric versions.
- Regression tests for `is_rule_enabled` with pre-release and v-prefixed config versions, verifying sane gate behavior (no crash, correct since-version comparisons); both fail on main.
- Full suite passes: 1588 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)