### PR TITLE
[Auto] Include baseline-suppressed count in --output reports

### DIFF
--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -616,7 +616,13 @@ def _run_lint(args):
     for output_path, fmt in output_formats.items():
         if fmt not in report_cache:
             report_cache[fmt] = format_report(
-                fmt, violations, context, linter.rules, cli_version, verbose=args.verbose
+                fmt,
+                violations,
+                context,
+                linter.rules,
+                cli_version,
+                verbose=args.verbose,
+                baseline_suppressed=linter.baseline_suppressed_count,
             )
         out_path = Path(output_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -104,7 +104,7 @@ def format_report(
     elif fmt == "json":
         from .json_fmt import format_json
 
-        return format_json(violations, context, rules, version, verbose)
+        return format_json(violations, context, rules, version, verbose, baseline_suppressed)
     elif fmt == "sarif":
         from .sarif import format_sarif
 

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -13,6 +13,7 @@ def format_json(
     rules: List[Rule],
     version: str,
     verbose: bool = False,
+    baseline_suppressed: int = 0,
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
@@ -54,6 +55,7 @@ def format_json(
             "errors": errors,
             "warnings": warnings,
             "info": info,
+            "baseline_suppressed": baseline_suppressed,
         },
     }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1504,6 +1504,19 @@ class TestBaseline:
         assert r["rc"] == 0
         assert summary(r)["warnings"] == 0
 
+    def test_output_report_includes_baseline_suppressed(self, tmp_path):
+        """--output file reports must carry the same baseline-suppressed count as stdout."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        run_baseline(repo)
+        json_path = tmp_path / "report.json"
+        r = run_lint(repo, "--output", f"json:{json_path}")
+        assert r["rc"] == 0
+        stdout_suppressed = summary(r)["baseline_suppressed"]
+        assert stdout_suppressed > 0
+
+        file_report = json.loads(json_path.read_text())
+        assert file_report["summary"]["baseline_suppressed"] == stdout_suppressed
+
     def test_lint_no_baseline_flag(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
         run_baseline(repo)


### PR DESCRIPTION
## Summary

`skillsaw lint --output FILE` wrote reports that omitted the baseline-suppressed count: the file-report loop in `__main__.py` never passed `baseline_suppressed` to `format_report`, so written reports disagreed with stdout.

Two changes:

- The `--output` loop now passes `baseline_suppressed=linter.baseline_suppressed_count`, matching the stdout call (the cache key is per-format and the count is constant per run, so caching is unaffected).
- The JSON formatter's `summary` gains an additive `baseline_suppressed` field. Without it the pass-through only helped text-format file reports — JSON had nowhere to carry the number, and JSON is what file-report consumers parse for baseline accounting.

SARIF/HTML/code-climate are unchanged; their schemas have no natural slot for the count and nothing in them currently claims a suppressed total.

Closes #266

## Testing

- New integration test: baseline a fixture, lint with `--output json:report.json`, assert the file's `summary.baseline_suppressed` is non-zero and equals stdout's. Fails on main.
- Full suite passes: 1586 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)