### PR TITLE
[Auto] Fix LLM dry-run deleting pre-existing empty-body files

### DIFF
--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -1133,7 +1133,12 @@ class Linter:
                 if bpath in restored:
                     continue
                 restored.add(bpath)
-                original_content = block_file_originals.get(bpath)
+                if bpath not in block_file_originals:
+                    # Every processed block was snapshotted above; if a path
+                    # is somehow missing, skip rather than risk deleting a
+                    # file we have no snapshot for.
+                    continue
+                original_content = block_file_originals[bpath]
                 if original_content is None:
                     if bpath.exists():
                         bpath.unlink()

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -977,6 +977,19 @@ class Linter:
             else:
                 originals[fpath] = None
 
+        # Snapshot block files before any processing so dry-run can restore
+        # them verbatim. None means the file did not exist before the run —
+        # only those may be unlinked on restore (a pre-existing file whose
+        # block text was empty must be restored, not deleted).
+        block_file_originals: Dict[Path, Optional[str]] = {}
+        for block in block_violations:
+            bpath = block.path.resolve()
+            if bpath not in block_file_originals:
+                if bpath.exists():
+                    block_file_originals[bpath] = bpath.read_text(encoding="utf-8")
+                else:
+                    block_file_originals[bpath] = None
+
         violations_before = len(llm_violations)
         total_units = len(block_violations) + len(file_violations)
         root_resolved = self.context.root_path.resolve()
@@ -1112,14 +1125,20 @@ class Linter:
                         fpath.unlink()
                 else:
                     fpath.write_text(original_content, encoding="utf-8")
+            restored: Set[Path] = set()
             for br in block_results:
-                if br["changed"]:
-                    if not br["original_body"] and br["block"].path.exists():
-                        br["block"].path.unlink()
-                    elif br.get("frontmatter_mode"):
-                        br["block"].write_frontmatter_text(br["original_body"])
-                    else:
-                        br["block"].write_body(br["original_body"])
+                if not br["changed"]:
+                    continue
+                bpath = br["block"].path.resolve()
+                if bpath in restored:
+                    continue
+                restored.add(bpath)
+                original_content = block_file_originals.get(bpath)
+                if original_content is None:
+                    if bpath.exists():
+                        bpath.unlink()
+                else:
+                    bpath.write_text(original_content, encoding="utf-8")
 
         return LLMFixResult(
             files_modified=[] if dry_run else kept_files,

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -462,6 +462,32 @@ class TestLLMFixDryRun:
         assert len(result.files_modified) == 0
         assert len(result.diffs) > 0
 
+    def test_dry_run_preserves_preexisting_file_with_empty_block(self, tmp_path):
+        """Dry-run must not delete a pre-existing file whose original block
+        text was empty (GH-267).
+
+        A SKILL.md without frontmatter has an empty frontmatter block, which
+        previously hit the "file didn't exist" unlink branch on restore.
+        """
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        skill_md = skill_dir / "SKILL.md"
+        original = "# My Skill\n\nUse this skill to deploy services to production.\n"
+        skill_md.write_text(original, encoding="utf-8")
+
+        config = LinterConfig.default()
+        config.llm.model = "fake-model"
+        context = RepositoryContext(tmp_path)
+        linter = Linter(context, config)
+
+        provider = _fake_fix_provider(
+            "name: my-skill\ndescription: Use when deploying services to production\n"
+        )
+        linter.llm_fix(provider, dry_run=True)
+
+        assert skill_md.exists(), "Dry-run deleted a pre-existing file"
+        assert skill_md.read_text(encoding="utf-8") == original
+
     def test_dry_run_rollback_preserves_original(self, tmp_path):
         """Dry-run rollback when LLM changes don't improve violations.
 


### PR DESCRIPTION
## Summary

In `skillsaw fix --llm --dry-run`, the restore path for block results treated an empty original block body as "the file did not exist" and `unlink()`ed it. A pre-existing file whose lintable block text was empty — e.g. a `SKILL.md` with a body but no frontmatter (empty frontmatter block in frontmatter-mode fixes) — was deleted by a dry run.

The fix snapshots every block file's full content before any processing starts (a `None` sentinel marks files that genuinely don't exist, mirroring the existing `originals` map for file-based violations). On dry-run, each touched file is restored verbatim from its snapshot; only files the run itself created are unlinked.

Restoring the whole file (instead of writing the original block text back through the block API) is also more correct: `write_frontmatter_text("")` cannot represent a "no frontmatter" original at all (it raises `Frontmatter must be a YAML mapping`), and a pre-run snapshot per path restores files with multiple processed blocks deterministically.

Closes #267

## Testing

- New regression test: a pre-existing `SKILL.md` with a body but no frontmatter goes through a fake-provider frontmatter fix in dry-run; the file must survive with its exact original content. On main this test fails — the file is deleted.
- Existing dry-run tests (`test_dry_run_no_write`, `test_dry_run_rollback_preserves_original`, `test_dry_run_cleans_up_created_file`) still pass, covering the restore and created-file-cleanup paths.
- Full suite passes: 1586 passed, 15 skipped.
- `skillsaw lint` exits 0 on `openshift-eng/ai-helpers`.

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a dry_run mode issue where pre-existing files with empty frontmatter blocks could be incorrectly deleted during block-based LLM processing. The system now captures and preserves file contents before processing begins, then properly restores them afterward, ensuring dry_run mode consistently maintains all existing files in their original, unmodified state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->