### PR TITLE
Support file paths and multiple paths as CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ it for repeated use).
 # 1. See what skillsaw detects in your repo
 skillsaw tree
 
-# 2. Lint it
+# 2. Lint it (current directory by default — also accepts multiple
+#    directories and/or SKILL.md files: skillsaw lint dir1/ dir2/SKILL.md)
 skillsaw
 
 # 3. Fix what you can automatically

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ Lint agent skills, plugins, and AI coding assistant context
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
+| `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover from the first path) |  |
 | `-v`, `--verbose` | Show info-level messages |  |
 | `--strict` | Treat warnings as errors (exit with error code if warnings exist) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
@@ -30,7 +30,7 @@ Automatically fix lint violations
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-c`, `--config` | Path to .skillsaw.yaml config file |  |
+| `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover from the first path) |  |
 | `--llm`, `--ai` | Use LLM-powered fixes for content violations |  |
 | `--model` | Override LLM model (default: from config or claude-sonnet-4-20250514) |  |
 | `--max-iterations` | Max fix iterations per file (default: 3) |  |

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -77,7 +77,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         "-c",
         "--config",
         type=Path,
-        help="Path to .skillsaw.yaml config file (default: auto-discover)",
+        help="Path to .skillsaw.yaml config file (default: auto-discover from the first path)",
     )
     lint_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Show info-level messages"
@@ -175,7 +175,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         "-c",
         "--config",
         type=Path,
-        help="Path to .skillsaw.yaml config file",
+        help="Path to .skillsaw.yaml config file (default: auto-discover from the first path)",
     )
     fix_parser.add_argument(
         "--llm",
@@ -459,42 +459,29 @@ def _run_tree(args):
 
 
 def _resolve_lint_paths(paths):
-    """Resolve file paths to parent dirs and deduplicate exact matches.
+    """Normalize CLI paths into a unique list of directories to lint.
 
-    Pass 1 of dedup: normalizes CLI input before creating RepositoryContexts.
+    Files resolve to their parent directory, then exact duplicates and
+    paths nested inside another entry are dropped (a parent's
+    RepositoryContext already discovers everything beneath it).
+    First-seen order is preserved.
     """
-    if isinstance(paths, Path):
-        paths = [paths]
-    seen = set()
-    result = []
+    normalized = []
     for p in paths:
         resolved = p.resolve()
         if resolved.is_file():
             resolved = resolved.parent
-        if resolved not in seen:
-            seen.add(resolved)
-            result.append(resolved)
-    return result
+        normalized.append(resolved)
 
-
-def _dedup_discovered_paths(paths):
-    """Remove duplicate and child paths from discovered file lists.
-
-    Pass 2 of dedup: after RepositoryContexts discover their files,
-    drop any path that is a child of another path in the list.
-    """
-    resolved = [p.resolve() for p in paths]
     seen = set()
-    unique = []
-    for p in resolved:
-        if p not in seen:
-            seen.add(p)
-            unique.append(p)
-
     result = []
-    for p in unique:
-        if not any(p != other and _is_subpath(p, other) for other in unique):
-            result.append(p)
+    for p in normalized:
+        if p in seen:
+            continue
+        if any(p != other and _is_subpath(p, other) for other in normalized):
+            continue
+        seen.add(p)
+        result.append(p)
     return result
 
 
@@ -528,7 +515,11 @@ def _build_merged_context(contexts):
     """Build a merged context from multiple RepositoryContexts."""
     if len(contexts) == 1:
         return contexts[0]
-    root_path = Path(os.path.commonpath([c.root_path for c in contexts]))
+    try:
+        root_path = Path(os.path.commonpath([c.root_path for c in contexts]))
+    except ValueError:
+        # No common ancestor (e.g. different drives on Windows)
+        root_path = contexts[0].root_path
     repo_types = set()
     plugins = []
     skills = []
@@ -536,8 +527,6 @@ def _build_merged_context(contexts):
         repo_types |= ctx.repo_types
         plugins.extend(ctx.plugins)
         skills.extend(ctx.skills)
-    plugins = _dedup_discovered_paths(plugins)
-    skills = _dedup_discovered_paths(skills)
     return _MergedContext(root_path, repo_types, plugins, skills)
 
 
@@ -558,6 +547,9 @@ def _handle_apply_patch_for_lint(args):
     paths = _resolve_lint_paths(args.path)
     if not paths:
         print("Error: No path provided for --apply-patch", file=sys.stderr)
+        sys.exit(1)
+    if len(paths) > 1:
+        print("Error: --apply-patch accepts a single path", file=sys.stderr)
         sys.exit(1)
     if not paths[0].exists():
         print(f"Error: Path not found: {paths[0]}", file=sys.stderr)
@@ -595,12 +587,11 @@ def _run_lint(args):
 
     _handle_apply_patch_for_lint(args)
 
-    # Validate raw paths before resolution (a nonexistent file would
-    # otherwise resolve to its existing parent and silently disappear)
-    raw_paths = args.path if isinstance(args.path, list) else [args.path]
+    # Validate paths as given, before file→parent normalization, so error
+    # messages reference exactly what the user typed
     missing_count = 0
     valid_raw_paths = []
-    for p in raw_paths:
+    for p in args.path:
         if not p.exists():
             print(f"Error: Path not found: {p}", file=sys.stderr)
             missing_count += 1
@@ -613,9 +604,7 @@ def _run_lint(args):
     if not valid_raw_paths:
         sys.exit(1)
 
-    # Resolve files to parent dirs, dedup exact matches, then drop children
     paths = _resolve_lint_paths(valid_raw_paths)
-    paths = _dedup_discovered_paths(paths)
 
     if args.fmt == "text":
         print(f"skillsaw {cli_version}")
@@ -988,16 +977,21 @@ def _run_llm_fix_inline(args, linter, config):
 
 
 def _run_fix(args):
-    paths = _resolve_lint_paths(args.path)
-    paths = _dedup_discovered_paths(paths)
+    # Unlike lint, fix mutates files — fail fast on any missing path
+    # before touching anything, referencing exactly what the user typed
+    missing = [p for p in args.path if not p.exists()]
+    for p in missing:
+        print(f"Error: Path not found: {p}", file=sys.stderr)
+    if missing:
+        sys.exit(1)
 
-    for p in paths:
-        if not p.exists():
-            print(f"Error: Path not found: {p}", file=sys.stderr)
-            sys.exit(1)
+    paths = _resolve_lint_paths(args.path)
 
     if getattr(args, "apply_patch", False):
-        root_path = paths[0].resolve()
+        if len(paths) > 1:
+            print("Error: --apply-patch accepts a single path", file=sys.stderr)
+            sys.exit(1)
+        root_path = paths[0]
         patch_path = _resolve_patch_path(args, root_path)
         _apply_llm_patch(patch_path, root_path)
         sys.exit(0)
@@ -1025,51 +1019,57 @@ def _run_fix(args):
         print("Error: --rule and --skip-rule cannot be combined", file=sys.stderr)
         sys.exit(1)
 
-    for fix_path in paths:
-        context = RepositoryContext(fix_path)
-
-        try:
-            linter = Linter(
-                context,
-                config,
-                rule_ids=rule_ids,
-                skip_rule_ids=skip_rule_ids,
-                no_custom_rules=args.no_custom_rules,
-            )
-        except ValueError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
-
     if not args.use_llm:
         import difflib
 
         dry_run = getattr(args, "dry_run", False)
         confidence = AutofixConfidence.SUGGEST if args.suggest else AutofixConfidence.SAFE
-        applied, suggested = linter.fix_and_apply(confidence, dry_run=dry_run)
 
-        if not dry_run and any(f.rule_id == "agentskill-name" for f in applied):
+        # (fix, repo root) pairs — the root relativizes paths in dry-run diffs
+        applied = []
+        suggested = []
+        for fix_path in paths:
             context = RepositoryContext(fix_path)
-            linter = Linter(
-                context,
-                config,
-                rule_ids=rule_ids,
-                skip_rule_ids=skip_rule_ids,
-                no_custom_rules=args.no_custom_rules,
-            )
-            rename_applied, rename_suggested = linter.fix_and_apply(confidence)
-            applied.extend(rename_applied)
-            suggested.extend(rename_suggested)
+            try:
+                linter = Linter(
+                    context,
+                    config,
+                    rule_ids=rule_ids,
+                    skip_rule_ids=skip_rule_ids,
+                    no_custom_rules=args.no_custom_rules,
+                )
+            except ValueError as e:
+                print(f"Error: {e}", file=sys.stderr)
+                sys.exit(1)
+
+            path_applied, path_suggested = linter.fix_and_apply(confidence, dry_run=dry_run)
+
+            if not dry_run and any(f.rule_id == "agentskill-name" for f in path_applied):
+                context = RepositoryContext(fix_path)
+                linter = Linter(
+                    context,
+                    config,
+                    rule_ids=rule_ids,
+                    skip_rule_ids=skip_rule_ids,
+                    no_custom_rules=args.no_custom_rules,
+                )
+                rename_applied, rename_suggested = linter.fix_and_apply(confidence)
+                path_applied.extend(rename_applied)
+                path_suggested.extend(rename_suggested)
+
+            applied.extend((f, context.root_path) for f in path_applied)
+            suggested.extend(path_suggested)
 
         c = _ansi_colors()
 
         if applied:
             label = "Would fix" if dry_run else "Fixed"
             print(f"{label} {len(applied)} issue(s):")
-            for fix in applied:
+            for fix, root in applied:
                 print(f"  {c['bold']}✓ [{fix.file_path}] {fix.description}{c['reset']}")
                 if dry_run and fix.original_content != fix.fixed_content:
                     try:
-                        rel = fix.file_path.relative_to(context.root_path)
+                        rel = fix.file_path.relative_to(root)
                     except ValueError:
                         rel = fix.file_path
                     diff_lines = difflib.unified_diff(
@@ -1103,6 +1103,24 @@ def _run_fix(args):
             print(f"\n{c['yellow']}dry-run — no files were modified{c['reset']}")
 
         sys.exit(0)
+
+    # LLM fix runs an interactive session against one repository
+    if len(paths) > 1:
+        print("Error: --llm accepts a single path", file=sys.stderr)
+        sys.exit(1)
+
+    context = RepositoryContext(paths[0])
+    try:
+        linter = Linter(
+            context,
+            config,
+            rule_ids=rule_ids,
+            skip_rule_ids=skip_rule_ids,
+            no_custom_rules=args.no_custom_rules,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if args.model:
         config.llm.model = args.model

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -68,10 +68,10 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     )
     lint_parser.add_argument(
         "path",
-        nargs="?",
+        nargs="*",
         type=Path,
-        default=Path.cwd(),
-        help="Path to skill, plugin, or marketplace directory (default: current directory)",
+        default=[Path.cwd()],
+        help="Paths to skill, plugin, or marketplace directories/files (default: current directory)",
     )
     lint_parser.add_argument(
         "-c",
@@ -166,10 +166,10 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     )
     fix_parser.add_argument(
         "path",
-        nargs="?",
+        nargs="*",
         type=Path,
-        default=Path.cwd(),
-        help="Path to repository (default: current directory)",
+        default=[Path.cwd()],
+        help="Paths to repositories or files (default: current directory)",
     )
     fix_parser.add_argument(
         "-c",
@@ -458,13 +458,111 @@ def _run_tree(args):
     sys.exit(0)
 
 
+def _resolve_lint_paths(paths):
+    """Resolve file paths to parent dirs and deduplicate exact matches.
+
+    Pass 1 of dedup: normalizes CLI input before creating RepositoryContexts.
+    """
+    if isinstance(paths, Path):
+        paths = [paths]
+    seen = set()
+    result = []
+    for p in paths:
+        resolved = p.resolve()
+        if resolved.is_file():
+            resolved = resolved.parent
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+    return result
+
+
+def _dedup_discovered_paths(paths):
+    """Remove duplicate and child paths from discovered file lists.
+
+    Pass 2 of dedup: after RepositoryContexts discover their files,
+    drop any path that is a child of another path in the list.
+    """
+    resolved = [p.resolve() for p in paths]
+    seen = set()
+    unique = []
+    for p in resolved:
+        if p not in seen:
+            seen.add(p)
+            unique.append(p)
+
+    result = []
+    for p in unique:
+        if not any(p != other and _is_subpath(p, other) for other in unique):
+            result.append(p)
+    return result
+
+
+def _is_subpath(child, parent):
+    """Check if child is a strict subpath of parent."""
+    try:
+        child.relative_to(parent)
+        return child != parent
+    except ValueError:
+        return False
+
+
+class _MergedContext:
+    """Duck-typed context for formatters when linting multiple paths."""
+
+    def __init__(self, root_path, repo_types, plugins, skills):
+        self.root_path = root_path
+        self.repo_types = repo_types
+        self.plugins = plugins
+        self.skills = skills
+
+    @property
+    def repo_type(self):
+        for t in RepositoryContext._TYPE_PRIORITY:
+            if t in self.repo_types:
+                return t
+        return RepositoryType.UNKNOWN
+
+
+def _build_merged_context(contexts):
+    """Build a merged context from multiple RepositoryContexts."""
+    if len(contexts) == 1:
+        return contexts[0]
+    root_path = Path(os.path.commonpath([c.root_path for c in contexts]))
+    repo_types = set()
+    plugins = []
+    skills = []
+    for ctx in contexts:
+        repo_types |= ctx.repo_types
+        plugins.extend(ctx.plugins)
+        skills.extend(ctx.skills)
+    plugins = _dedup_discovered_paths(plugins)
+    skills = _dedup_discovered_paths(skills)
+    return _MergedContext(root_path, repo_types, plugins, skills)
+
+
+def _dedup_rules(rules):
+    """Deduplicate rules by rule_id, preserving first occurrence."""
+    seen = set()
+    result = []
+    for rule in rules:
+        if rule.rule_id not in seen:
+            seen.add(rule.rule_id)
+            result.append(rule)
+    return result
+
+
 def _handle_apply_patch_for_lint(args):
     if not getattr(args, "apply_patch", False):
         return
-    if not args.path.exists():
-        print(f"Error: Path not found: {args.path}", file=sys.stderr)
+    paths = _resolve_lint_paths(args.path)
+    if not paths:
+        print("Error: No path provided for --apply-patch", file=sys.stderr)
         sys.exit(1)
-    root_path = args.path.resolve()
+    if not paths[0].exists():
+        print(f"Error: Path not found: {paths[0]}", file=sys.stderr)
+        sys.exit(1)
+    root_path = paths[0].resolve()
     patch_path = _resolve_patch_path(args, root_path)
     _apply_llm_patch(patch_path, root_path)
     sys.exit(0)
@@ -497,16 +595,34 @@ def _run_lint(args):
 
     _handle_apply_patch_for_lint(args)
 
-    if not args.path.exists():
-        print(f"Error: Path not found: {args.path}", file=sys.stderr)
+    # Validate raw paths before resolution (a nonexistent file would
+    # otherwise resolve to its existing parent and silently disappear)
+    raw_paths = args.path if isinstance(args.path, list) else [args.path]
+    missing_count = 0
+    valid_raw_paths = []
+    for p in raw_paths:
+        if not p.exists():
+            print(f"Error: Path not found: {p}", file=sys.stderr)
+            missing_count += 1
+        else:
+            valid_raw_paths.append(p)
+
+    if missing_count:
+        print(f"{missing_count} path(s) not found", file=sys.stderr)
+
+    if not valid_raw_paths:
         sys.exit(1)
+
+    # Resolve files to parent dirs, dedup exact matches, then drop children
+    paths = _resolve_lint_paths(valid_raw_paths)
+    paths = _dedup_discovered_paths(paths)
 
     if args.fmt == "text":
         print(f"skillsaw {cli_version}")
-        print(f"Linting: {args.path}\n")
-    context = RepositoryContext(args.path)
+        print(f"Linting: {', '.join(str(p) for p in paths)}\n")
 
     # Override repo_types if --type was provided
+    override_types = None
     if args.repo_types:
         type_map = {t.value: t for t in RepositoryType}
         override_types = set()
@@ -519,14 +635,6 @@ def _run_lint(args):
                 )
                 sys.exit(1)
             override_types.add(type_map[val])
-        context.repo_types = override_types
-
-    if context.repo_type == RepositoryType.UNKNOWN:
-        print("Warning: Directory doesn't appear to be a recognized repository", file=sys.stderr)
-        print(
-            "Expected: .claude-plugin/plugin.json, plugins/ directory, or SKILL.md (agentskills.io)\n",
-            file=sys.stderr,
-        )
 
     if args.config:
         config_path = args.config
@@ -534,7 +642,7 @@ def _run_lint(args):
             print(f"Error: Config file not found: {config_path}", file=sys.stderr)
             sys.exit(1)
     else:
-        config_path = find_config(args.path)
+        config_path = find_config(paths[0])
 
     if config_path:
         try:
@@ -554,7 +662,7 @@ def _run_lint(args):
     if not args.no_baseline:
         from .baseline import find_baseline, load_baseline
 
-        baseline_path = find_baseline(config.config_dir or args.path)
+        baseline_path = find_baseline(config.config_dir or paths[0])
 
         if baseline_path:
             try:
@@ -572,69 +680,99 @@ def _run_lint(args):
     if rule_ids and skip_rule_ids:
         print("Error: --rule and --skip-rule cannot be combined", file=sys.stderr)
         sys.exit(1)
-    try:
-        linter = Linter(
-            context,
-            config,
-            rule_ids=rule_ids,
-            skip_rule_ids=skip_rule_ids,
-            baseline=baseline,
-            no_custom_rules=args.no_custom_rules,
-        )
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
 
-    if args.fix:
-        import warnings
+    # Create a context and linter per path, collect violations
+    all_violations = []
+    all_rules = []
+    contexts = []
+    baseline_suppressed = 0
+    for lint_path in paths:
+        context = RepositoryContext(lint_path)
+        if override_types:
+            context.repo_types = override_types
+        contexts.append(context)
 
-        fix_cmd = "skillsaw fix --llm" if args.use_llm else "skillsaw fix"
-        msg = (
-            f"`skillsaw lint --fix` is deprecated and will be removed in 1.0. "
-            f"Use `{fix_cmd}` instead."
-        )
-        warnings.warn(msg, DeprecationWarning, stacklevel=1)
-        print(f"Warning: {msg}", file=sys.stderr)
-        violations, fixes = linter.fix()
-        applied = linter.apply_fixes(fixes)
-        if applied and args.fmt == "text":
-            print(f"Fixed {len(applied)} issue(s):")
-            for fix in applied:
-                print(f"  ✓ [{fix.file_path}] {fix.description}")
-            print()
-        suggested = [f for f in fixes if f not in applied]
-        if suggested and args.fmt == "text":
-            print(f"Suggested fixes ({len(suggested)} — review before applying):")
-            for fix in suggested:
-                print(f"  ? [{fix.file_path}] {fix.description}")
-            print()
-        if args.use_llm:
-            _run_llm_fix_inline(args, linter, config)
-    else:
-        violations = linter.run()
-
-    if baseline and args.fmt == "text":
-        stale = linter.stale_baseline_entries
-        if stale:
+        if context.repo_type == RepositoryType.UNKNOWN:
             print(
-                f"Baseline: {len(stale)} stale"
-                f" {'entry' if len(stale) == 1 else 'entries'}"
-                f" (violations resolved since baseline was set)"
+                "Warning: Directory doesn't appear to be a recognized repository",
+                file=sys.stderr,
             )
-            if args.verbose:
-                for entry in stale:
-                    location = f" [{entry.file_path}]" if entry.file_path else ""
-                    print(f"  - {entry.rule_id}{location}: {entry.message}")
-            print("  Run `skillsaw baseline` to update.\n")
+            print(
+                "Expected: .claude-plugin/plugin.json, plugins/ directory,"
+                " or SKILL.md (agentskills.io)\n",
+                file=sys.stderr,
+            )
+
+        try:
+            linter = Linter(
+                context,
+                config,
+                rule_ids=rule_ids,
+                skip_rule_ids=skip_rule_ids,
+                baseline=baseline,
+                no_custom_rules=args.no_custom_rules,
+            )
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if args.fix:
+            import warnings
+
+            fix_cmd = "skillsaw fix --llm" if args.use_llm else "skillsaw fix"
+            msg = (
+                f"`skillsaw lint --fix` is deprecated and will be removed in 1.0. "
+                f"Use `{fix_cmd}` instead."
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+            print(f"Warning: {msg}", file=sys.stderr)
+            violations, fixes = linter.fix()
+            applied = linter.apply_fixes(fixes)
+            if applied and args.fmt == "text":
+                print(f"Fixed {len(applied)} issue(s):")
+                for fix in applied:
+                    print(f"  ✓ [{fix.file_path}] {fix.description}")
+                print()
+            suggested = [f for f in fixes if f not in applied]
+            if suggested and args.fmt == "text":
+                print(f"Suggested fixes ({len(suggested)} — review before applying):")
+                for fix in suggested:
+                    print(f"  ? [{fix.file_path}] {fix.description}")
+                print()
+            if args.use_llm:
+                _run_llm_fix_inline(args, linter, config)
+        else:
+            violations = linter.run()
+
+        all_violations.extend(violations)
+        all_rules.extend(linter.rules)
+        baseline_suppressed += linter.baseline_suppressed_count
+
+        if baseline and args.fmt == "text":
+            stale = linter.stale_baseline_entries
+            if stale:
+                print(
+                    f"Baseline: {len(stale)} stale"
+                    f" {'entry' if len(stale) == 1 else 'entries'}"
+                    f" (violations resolved since baseline was set)"
+                )
+                if args.verbose:
+                    for entry in stale:
+                        location = f" [{entry.file_path}]" if entry.file_path else ""
+                        print(f"  - {entry.rule_id}{location}: {entry.message}")
+                print("  Run `skillsaw baseline` to update.\n")
+
+    merged_context = _build_merged_context(contexts)
+    unique_rules = _dedup_rules(all_rules)
 
     stdout_output = format_report(
         args.fmt,
-        violations,
-        context,
-        linter.rules,
+        all_violations,
+        merged_context,
+        unique_rules,
         cli_version,
         verbose=args.verbose,
-        baseline_suppressed=linter.baseline_suppressed_count,
+        baseline_suppressed=baseline_suppressed,
     )
     print(stdout_output)
 
@@ -643,20 +781,20 @@ def _run_lint(args):
         if fmt not in report_cache:
             report_cache[fmt] = format_report(
                 fmt,
-                violations,
-                context,
-                linter.rules,
+                all_violations,
+                merged_context,
+                unique_rules,
                 cli_version,
                 verbose=args.verbose,
-                baseline_suppressed=linter.baseline_suppressed_count,
+                baseline_suppressed=baseline_suppressed,
             )
         out_path = Path(output_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(report_cache[fmt], encoding="utf-8")
 
-    errors, warnings_count, info = get_counts(violations)
+    errors, warnings_count, info = get_counts(all_violations)
 
-    if errors > 0:
+    if missing_count > 0 or errors > 0:
         sys.exit(1)
     elif config.strict and warnings_count > 0:
         sys.exit(1)
@@ -850,17 +988,19 @@ def _run_llm_fix_inline(args, linter, config):
 
 
 def _run_fix(args):
-    if not args.path.exists():
-        print(f"Error: Path not found: {args.path}", file=sys.stderr)
-        sys.exit(1)
+    paths = _resolve_lint_paths(args.path)
+    paths = _dedup_discovered_paths(paths)
+
+    for p in paths:
+        if not p.exists():
+            print(f"Error: Path not found: {p}", file=sys.stderr)
+            sys.exit(1)
 
     if getattr(args, "apply_patch", False):
-        root_path = args.path.resolve()
+        root_path = paths[0].resolve()
         patch_path = _resolve_patch_path(args, root_path)
         _apply_llm_patch(patch_path, root_path)
         sys.exit(0)
-
-    context = RepositoryContext(args.path)
 
     if args.config:
         config_path = args.config
@@ -868,7 +1008,7 @@ def _run_fix(args):
             print(f"Error: Config file not found: {config_path}", file=sys.stderr)
             sys.exit(1)
     else:
-        config_path = find_config(args.path)
+        config_path = find_config(paths[0])
 
     if config_path:
         try:
@@ -884,17 +1024,21 @@ def _run_fix(args):
     if rule_ids and skip_rule_ids:
         print("Error: --rule and --skip-rule cannot be combined", file=sys.stderr)
         sys.exit(1)
-    try:
-        linter = Linter(
-            context,
-            config,
-            rule_ids=rule_ids,
-            skip_rule_ids=skip_rule_ids,
-            no_custom_rules=args.no_custom_rules,
-        )
-    except ValueError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+
+    for fix_path in paths:
+        context = RepositoryContext(fix_path)
+
+        try:
+            linter = Linter(
+                context,
+                config,
+                rule_ids=rule_ids,
+                skip_rule_ids=skip_rule_ids,
+                no_custom_rules=args.no_custom_rules,
+            )
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
 
     if not args.use_llm:
         import difflib
@@ -904,7 +1048,7 @@ def _run_fix(args):
         applied, suggested = linter.fix_and_apply(confidence, dry_run=dry_run)
 
         if not dry_run and any(f.rule_id == "agentskill-name" for f in applied):
-            context = RepositoryContext(args.path)
+            context = RepositoryContext(fix_path)
             linter = Linter(
                 context,
                 config,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -337,6 +337,377 @@ class TestAgentskills:
         assert len(stats["skills"]) == 4
 
 
+# ── File Path Argument ──────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestFilePathArgument:
+
+    def test_lint_skill_md_file_directly(self, tmp_path):
+        """Passing a SKILL.md file path should lint its parent directory."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        skill_file = repo / "code-review" / "SKILL.md"
+        r = run_lint(skill_file)
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_broken_skill_md_file_directly(self, tmp_path):
+        """Passing a broken SKILL.md file should report violations."""
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        skill_file = repo / "Bad_Formatter" / "SKILL.md"
+        r = run_lint(skill_file)
+        assert r["rc"] == 1
+        ids = rule_ids(r)
+        assert len(ids) > 0
+
+    def test_lint_nonexistent_file_errors(self, tmp_path):
+        """Passing a nonexistent file should error."""
+        bad = tmp_path / "nonexistent.md"
+        r = run_lint(bad)
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_dir_errors(self, tmp_path):
+        """Passing a nonexistent directory should error."""
+        bad = tmp_path / "no-such-dir"
+        r = run_lint(bad)
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+
+# ── Multiple Paths ─────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestMultiplePaths:
+
+    def test_lint_two_directories(self, tmp_path):
+        """Linting two directories should produce a merged report."""
+        repo1 = copy_fixture("agentskills/clean", tmp_path)
+        repo2 = copy_fixture("single-plugin/clean", tmp_path)
+        r = run_lint(repo1, str(repo2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        repo_types = stats["repo_types"]
+        assert len(repo_types) >= 2
+
+    def test_lint_mixed_clean_and_broken(self, tmp_path):
+        """If any path has errors, exit code should be 1."""
+        repo_clean = copy_fixture("agentskills/clean", tmp_path)
+        repo_broken = copy_fixture("agentskills/broken", tmp_path)
+        r = run_lint(repo_clean, str(repo_broken))
+        assert r["rc"] == 1
+
+    def test_lint_two_skill_files_directly(self, tmp_path):
+        """Passing two SKILL.md files should lint both parents."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        file2 = repo / "deploy-service" / "SKILL.md"
+        r = run_lint(file1, str(file2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_one_dir_one_file(self, tmp_path):
+        """dir then file should lint both."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir_path = repo / "code-review"
+        file_path = repo / "deploy-service" / "SKILL.md"
+        r = run_lint(dir_path, str(file_path))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_one_file_one_dir(self, tmp_path):
+        """file then dir should lint both."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file_path = repo / "code-review" / "SKILL.md"
+        dir_path = repo / "deploy-service"
+        r = run_lint(file_path, str(dir_path))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_dir_file_dir(self, tmp_path):
+        """dir, file, dir ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        file1 = repo / "deploy-service" / "SKILL.md"
+        dir2 = repo / "run-tests"
+        r = run_lint(dir1, str(file1), str(dir2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_file_dir_file(self, tmp_path):
+        """file, dir, file ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        dir1 = repo / "deploy-service"
+        file2 = repo / "run-tests" / "SKILL.md"
+        r = run_lint(file1, str(dir1), str(file2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_three_files(self, tmp_path):
+        """Three SKILL.md files should all lint."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        file2 = repo / "deploy-service" / "SKILL.md"
+        file3 = repo / "run-tests" / "SKILL.md"
+        r = run_lint(file1, str(file2), str(file3))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_three_files_and_dir(self, tmp_path):
+        """Three files plus a directory should lint all four."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        file2 = repo / "deploy-service" / "SKILL.md"
+        file3 = repo / "run-tests" / "SKILL.md"
+        dir1 = repo / "database-migrate"
+        r = run_lint(file1, str(file2), str(file3), str(dir1))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_three_directories(self, tmp_path):
+        """Three directories should all lint."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        dir2 = repo / "deploy-service"
+        dir3 = repo / "run-tests"
+        r = run_lint(dir1, str(dir2), str(dir3))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_dir_dir_file(self, tmp_path):
+        """dir, dir, file ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        dir2 = repo / "deploy-service"
+        file1 = repo / "run-tests" / "SKILL.md"
+        r = run_lint(dir1, str(dir2), str(file1))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_dir_file_file(self, tmp_path):
+        """dir, file, file ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        file1 = repo / "deploy-service" / "SKILL.md"
+        file2 = repo / "run-tests" / "SKILL.md"
+        r = run_lint(dir1, str(file1), str(file2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_file_file_dir(self, tmp_path):
+        """file, file, dir ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        file2 = repo / "deploy-service" / "SKILL.md"
+        dir1 = repo / "run-tests"
+        r = run_lint(file1, str(file2), str(dir1))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_file_dir_dir(self, tmp_path):
+        """file, dir, dir ordering should lint all three."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        dir1 = repo / "deploy-service"
+        dir2 = repo / "run-tests"
+        r = run_lint(file1, str(dir1), str(dir2))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_three_dirs_and_file(self, tmp_path):
+        """Three directories plus a file should lint all four."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        dir2 = repo / "deploy-service"
+        dir3 = repo / "run-tests"
+        file1 = repo / "database-migrate" / "SKILL.md"
+        r = run_lint(dir1, str(dir2), str(dir3), str(file1))
+        assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert "agentskills" in stats["repo_types"]
+
+    def test_lint_same_file_repeated(self, tmp_path):
+        """Passing the same file multiple times should not produce duplicate violations."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        f = repo / "code-review" / "SKILL.md"
+        r = run_lint(f, str(f), str(f))
+        assert r["rc"] == 0
+
+    def test_lint_dir_and_file_within_it(self, tmp_path):
+        """Passing a dir and a file inside that dir should not duplicate violations."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir_path = repo / "code-review"
+        file_path = repo / "code-review" / "SKILL.md"
+        r = run_lint(dir_path, str(file_path))
+        assert r["rc"] == 0
+
+    def test_lint_file_within_dir_and_dir(self, tmp_path):
+        """Passing a file then its parent dir should not duplicate violations."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file_path = repo / "code-review" / "SKILL.md"
+        dir_path = repo / "code-review"
+        r = run_lint(file_path, str(dir_path))
+        assert r["rc"] == 0
+
+    def test_lint_same_dir_repeated(self, tmp_path):
+        """Passing the same directory twice should not duplicate violations."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir_path = repo / "code-review"
+        r = run_lint(dir_path, str(dir_path))
+        assert r["rc"] == 0
+
+    def test_lint_broken_file_and_clean_dir(self, tmp_path):
+        """A broken file and a clean dir should exit 1."""
+        repo_broken = copy_fixture("agentskills/broken", tmp_path)
+        repo_clean = copy_fixture("agentskills/clean", tmp_path)
+        broken_file = repo_broken / "Bad_Formatter" / "SKILL.md"
+        r = run_lint(broken_file, str(repo_clean))
+        assert r["rc"] == 1
+
+    def test_lint_clean_dir_and_broken_file(self, tmp_path):
+        """A clean dir and a broken file should exit 1."""
+        repo_clean = copy_fixture("agentskills/clean", tmp_path)
+        repo_broken = copy_fixture("agentskills/broken", tmp_path)
+        broken_file = repo_broken / "Bad_Formatter" / "SKILL.md"
+        r = run_lint(repo_clean, str(broken_file))
+        assert r["rc"] == 1
+
+    def test_lint_valid_dir_and_nonexistent_dir(self, tmp_path):
+        """valid dir, nonexistent dir should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        bad = tmp_path / "no-such-dir"
+        r = run_lint(repo, str(bad))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_dir_and_valid_dir(self, tmp_path):
+        """nonexistent dir, valid dir should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        bad = tmp_path / "no-such-dir"
+        r = run_lint(bad, str(repo))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_valid_file_and_nonexistent_file(self, tmp_path):
+        """valid file, nonexistent file should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        valid_file = repo / "code-review" / "SKILL.md"
+        bad = tmp_path / "nonexistent.md"
+        r = run_lint(valid_file, str(bad))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_file_and_valid_file(self, tmp_path):
+        """nonexistent file, valid file should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        valid_file = repo / "code-review" / "SKILL.md"
+        bad = tmp_path / "nonexistent.md"
+        r = run_lint(bad, str(valid_file))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_valid_dir_and_nonexistent_file(self, tmp_path):
+        """valid dir, nonexistent file should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        bad = tmp_path / "nonexistent.md"
+        r = run_lint(repo, str(bad))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_file_and_valid_dir(self, tmp_path):
+        """nonexistent file, valid dir should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        bad = tmp_path / "nonexistent.md"
+        r = run_lint(bad, str(repo))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_valid_file_and_nonexistent_dir(self, tmp_path):
+        """valid file, nonexistent dir should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        valid_file = repo / "code-review" / "SKILL.md"
+        bad = tmp_path / "no-such-dir"
+        r = run_lint(valid_file, str(bad))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_dir_and_valid_file(self, tmp_path):
+        """nonexistent dir, valid file should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        valid_file = repo / "code-review" / "SKILL.md"
+        bad = tmp_path / "no-such-dir"
+        r = run_lint(bad, str(valid_file))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_among_dir_file_dir(self, tmp_path):
+        """dir, nonexistent, file should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        dir1 = repo / "code-review"
+        file1 = repo / "deploy-service" / "SKILL.md"
+        bad = tmp_path / "ghost"
+        r = run_lint(dir1, str(bad), str(file1))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_among_file_dir_file(self, tmp_path):
+        """file, nonexistent, dir should warn, lint valid, exit 3."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        file1 = repo / "code-review" / "SKILL.md"
+        dir1 = repo / "deploy-service"
+        bad = tmp_path / "ghost"
+        r = run_lint(file1, str(bad), str(dir1))
+        assert r["rc"] == 1
+        assert f"Path not found: {bad}" in r["stderr"]
+
+    def test_lint_nonexistent_file_with_existing_parent(self, tmp_path):
+        """A nonexistent file whose parent exists should warn, lint valid paths, exit 1."""
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        real = repo / "Bad_Formatter" / "SKILL.md"
+        fake = repo / "Bad_Formatter" / "SKILL2.md"
+        r = run_lint(real, str(fake))
+        assert r["rc"] == 1
+        assert f"Path not found: {fake}" in r["stderr"]
+        assert "1 path(s) not found" in r["stderr"]
+        # Valid path was still linted — violations present in output
+        assert len(violations(r)) > 0
+
+    def test_lint_nonexistent_sibling_file(self, tmp_path):
+        """Two files in same dir, one nonexistent, should warn, lint valid paths, exit 1."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        real = repo / "code-review" / "SKILL.md"
+        fake = repo / "code-review" / "NOPE.md"
+        r = run_lint(real, str(fake))
+        assert r["rc"] == 1
+        assert f"Path not found: {fake}" in r["stderr"]
+        assert "1 path(s) not found" in r["stderr"]
+
+    def test_lint_two_nonexistent_among_valid_shows_count(self, tmp_path):
+        """Two missing paths should report count of 2."""
+        repo = copy_fixture("agentskills/clean", tmp_path)
+        real = repo / "code-review" / "SKILL.md"
+        fake1 = tmp_path / "ghost1"
+        fake2 = tmp_path / "ghost2"
+        r = run_lint(real, str(fake1), str(fake2))
+        assert r["rc"] == 1
+        assert "2 path(s) not found" in r["stderr"]
+
+
 # ── Dot-Claude ───────────────────────────────────────────────────
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,8 +44,10 @@ def run_lint(path, *extra_args, config=None, verbose=True, fmt="json"):
         args.append("-v")
     if config:
         args.extend(["-c", str(config)])
-    args.extend(extra_args)
+    # path goes before extra_args so multi-path tests exercise the
+    # CLI argument order their names describe (extra paths follow it)
     args.append(str(path))
+    args.extend(extra_args)
     result = subprocess.run(args, capture_output=True, text=True, timeout=60)
     output = None
     if fmt == "json" and result.stdout.strip():
@@ -408,6 +410,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 2
 
     def test_lint_one_dir_one_file(self, tmp_path):
         """dir then file should lint both."""
@@ -418,6 +421,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 2
 
     def test_lint_one_file_one_dir(self, tmp_path):
         """file then dir should lint both."""
@@ -428,6 +432,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 2
 
     def test_lint_dir_file_dir(self, tmp_path):
         """dir, file, dir ordering should lint all three."""
@@ -439,6 +444,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_file_dir_file(self, tmp_path):
         """file, dir, file ordering should lint all three."""
@@ -450,6 +456,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_three_files(self, tmp_path):
         """Three SKILL.md files should all lint."""
@@ -461,6 +468,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_three_files_and_dir(self, tmp_path):
         """Three files plus a directory should lint all four."""
@@ -473,6 +481,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 4
 
     def test_lint_three_directories(self, tmp_path):
         """Three directories should all lint."""
@@ -484,6 +493,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_dir_dir_file(self, tmp_path):
         """dir, dir, file ordering should lint all three."""
@@ -495,6 +505,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_dir_file_file(self, tmp_path):
         """dir, file, file ordering should lint all three."""
@@ -506,6 +517,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_file_file_dir(self, tmp_path):
         """file, file, dir ordering should lint all three."""
@@ -517,6 +529,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_file_dir_dir(self, tmp_path):
         """file, dir, dir ordering should lint all three."""
@@ -528,6 +541,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 3
 
     def test_lint_three_dirs_and_file(self, tmp_path):
         """Three directories plus a file should lint all four."""
@@ -540,6 +554,7 @@ class TestMultiplePaths:
         assert r["rc"] == 0
         stats = r["out"]["stats"]
         assert "agentskills" in stats["repo_types"]
+        assert len(stats["skills"]) == 4
 
     def test_lint_same_file_repeated(self, tmp_path):
         """Passing the same file multiple times should not produce duplicate violations."""
@@ -547,6 +562,8 @@ class TestMultiplePaths:
         f = repo / "code-review" / "SKILL.md"
         r = run_lint(f, str(f), str(f))
         assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert len(stats["skills"]) == 1
 
     def test_lint_dir_and_file_within_it(self, tmp_path):
         """Passing a dir and a file inside that dir should not duplicate violations."""
@@ -555,6 +572,8 @@ class TestMultiplePaths:
         file_path = repo / "code-review" / "SKILL.md"
         r = run_lint(dir_path, str(file_path))
         assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert len(stats["skills"]) == 1
 
     def test_lint_file_within_dir_and_dir(self, tmp_path):
         """Passing a file then its parent dir should not duplicate violations."""
@@ -563,6 +582,8 @@ class TestMultiplePaths:
         dir_path = repo / "code-review"
         r = run_lint(file_path, str(dir_path))
         assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert len(stats["skills"]) == 1
 
     def test_lint_same_dir_repeated(self, tmp_path):
         """Passing the same directory twice should not duplicate violations."""
@@ -570,6 +591,8 @@ class TestMultiplePaths:
         dir_path = repo / "code-review"
         r = run_lint(dir_path, str(dir_path))
         assert r["rc"] == 0
+        stats = r["out"]["stats"]
+        assert len(stats["skills"]) == 1
 
     def test_lint_broken_file_and_clean_dir(self, tmp_path):
         """A broken file and a clean dir should exit 1."""
@@ -588,7 +611,7 @@ class TestMultiplePaths:
         assert r["rc"] == 1
 
     def test_lint_valid_dir_and_nonexistent_dir(self, tmp_path):
-        """valid dir, nonexistent dir should warn, lint valid, exit 3."""
+        """valid dir, nonexistent dir should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         bad = tmp_path / "no-such-dir"
         r = run_lint(repo, str(bad))
@@ -596,7 +619,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_dir_and_valid_dir(self, tmp_path):
-        """nonexistent dir, valid dir should warn, lint valid, exit 3."""
+        """nonexistent dir, valid dir should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         bad = tmp_path / "no-such-dir"
         r = run_lint(bad, str(repo))
@@ -604,7 +627,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_valid_file_and_nonexistent_file(self, tmp_path):
-        """valid file, nonexistent file should warn, lint valid, exit 3."""
+        """valid file, nonexistent file should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         valid_file = repo / "code-review" / "SKILL.md"
         bad = tmp_path / "nonexistent.md"
@@ -613,7 +636,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_file_and_valid_file(self, tmp_path):
-        """nonexistent file, valid file should warn, lint valid, exit 3."""
+        """nonexistent file, valid file should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         valid_file = repo / "code-review" / "SKILL.md"
         bad = tmp_path / "nonexistent.md"
@@ -622,7 +645,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_valid_dir_and_nonexistent_file(self, tmp_path):
-        """valid dir, nonexistent file should warn, lint valid, exit 3."""
+        """valid dir, nonexistent file should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         bad = tmp_path / "nonexistent.md"
         r = run_lint(repo, str(bad))
@@ -630,7 +653,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_file_and_valid_dir(self, tmp_path):
-        """nonexistent file, valid dir should warn, lint valid, exit 3."""
+        """nonexistent file, valid dir should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         bad = tmp_path / "nonexistent.md"
         r = run_lint(bad, str(repo))
@@ -638,7 +661,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_valid_file_and_nonexistent_dir(self, tmp_path):
-        """valid file, nonexistent dir should warn, lint valid, exit 3."""
+        """valid file, nonexistent dir should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         valid_file = repo / "code-review" / "SKILL.md"
         bad = tmp_path / "no-such-dir"
@@ -647,7 +670,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_dir_and_valid_file(self, tmp_path):
-        """nonexistent dir, valid file should warn, lint valid, exit 3."""
+        """nonexistent dir, valid file should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         valid_file = repo / "code-review" / "SKILL.md"
         bad = tmp_path / "no-such-dir"
@@ -656,7 +679,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_among_dir_file_dir(self, tmp_path):
-        """dir, nonexistent, file should warn, lint valid, exit 3."""
+        """dir, nonexistent, file should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         dir1 = repo / "code-review"
         file1 = repo / "deploy-service" / "SKILL.md"
@@ -666,7 +689,7 @@ class TestMultiplePaths:
         assert f"Path not found: {bad}" in r["stderr"]
 
     def test_lint_nonexistent_among_file_dir_file(self, tmp_path):
-        """file, nonexistent, dir should warn, lint valid, exit 3."""
+        """file, nonexistent, dir should warn, lint valid, exit 1."""
         repo = copy_fixture("agentskills/clean", tmp_path)
         file1 = repo / "code-review" / "SKILL.md"
         dir1 = repo / "deploy-service"
@@ -706,6 +729,83 @@ class TestMultiplePaths:
         r = run_lint(real, str(fake1), str(fake2))
         assert r["rc"] == 1
         assert "2 path(s) not found" in r["stderr"]
+
+
+# ── Multiple Paths: fix ────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestFixMultiplePaths:
+    """Regression tests for `skillsaw fix` with multiple paths.
+
+    The original multi-path implementation built a linter per path in a
+    loop but ran the fix only on the last one, silently skipping the rest.
+    """
+
+    def _run_fix(self, *cli_args):
+        args = [sys.executable, "-m", "skillsaw", "fix"]
+        args.extend(str(a) for a in cli_args)
+        return subprocess.run(args, capture_output=True, text=True, timeout=60)
+
+    def test_fix_two_repos_fixes_both(self, tmp_path):
+        """Every path passed to fix gets fixed, not just the last one."""
+        repo1 = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path)
+        repo2 = copy_fixture("autofix/unlinked-ref-duplicate-paths", tmp_path)
+        before1 = (repo1 / "CLAUDE.md").read_text()
+        before2 = (repo2 / "CLAUDE.md").read_text()
+
+        result = self._run_fix(repo1, repo2)
+        assert result.returncode == 0
+        assert (repo1 / "CLAUDE.md").read_text() != before1
+        assert (repo2 / "CLAUDE.md").read_text() != before2
+
+        for repo in (repo1, repo2):
+            r = run_lint(repo)
+            remaining = [
+                v for v in violations(r) if v["rule_id"] == "content-unlinked-internal-reference"
+            ]
+            assert remaining == []
+
+    def test_fix_dry_run_two_repos_reports_both(self, tmp_path):
+        """Dry-run over two repos reports fixes for both and modifies neither."""
+        repo1 = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path)
+        repo2 = copy_fixture("autofix/unlinked-ref-duplicate-paths", tmp_path)
+        before1 = (repo1 / "CLAUDE.md").read_text()
+        before2 = (repo2 / "CLAUDE.md").read_text()
+
+        result = self._run_fix("--dry-run", repo1, repo2)
+        assert result.returncode == 0
+        assert str(repo1) in result.stdout
+        assert str(repo2) in result.stdout
+        assert (repo1 / "CLAUDE.md").read_text() == before1
+        assert (repo2 / "CLAUDE.md").read_text() == before2
+
+    def test_fix_nonexistent_path_fails_before_fixing(self, tmp_path):
+        """A missing path aborts the whole fix — valid paths stay untouched."""
+        repo = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path)
+        before = (repo / "CLAUDE.md").read_text()
+
+        result = self._run_fix(repo, tmp_path / "ghost")
+        assert result.returncode == 1
+        assert "Path not found" in result.stderr
+        assert (repo / "CLAUDE.md").read_text() == before
+
+    def test_fix_llm_rejects_multiple_paths(self, tmp_path):
+        """--llm runs an interactive session against a single repository."""
+        repo1 = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path)
+        repo2 = copy_fixture("autofix/unlinked-ref-duplicate-paths", tmp_path)
+
+        result = self._run_fix("--llm", repo1, repo2)
+        assert result.returncode == 1
+        assert "--llm accepts a single path" in result.stderr
+
+    def test_fix_apply_patch_rejects_multiple_paths(self, tmp_path):
+        repo1 = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path)
+        repo2 = copy_fixture("autofix/unlinked-ref-duplicate-paths", tmp_path)
+
+        result = self._run_fix("--apply-patch", repo1, repo2)
+        assert result.returncode == 1
+        assert "--apply-patch accepts a single path" in result.stderr
 
 
 # ── Dot-Claude ───────────────────────────────────────────────────

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -544,7 +544,7 @@ class TestMaxIterationsCLIOverride:
 
         config = LinterConfig.default()
         args = Namespace(
-            path=Path("."),
+            path=[Path(".")],
             config=None,
             use_llm=True,
             model=None,
@@ -582,7 +582,7 @@ class TestMaxIterationsCLIOverride:
         config = LinterConfig.default()
         default_value = config.llm.max_iterations
         args = Namespace(
-            path=Path("."),
+            path=[Path(".")],
             config=None,
             use_llm=True,
             model=None,

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,0 +1,483 @@
+"""
+Unit tests for CLI path resolution and deduplication logic.
+
+Two passes of deduplication:
+
+Pass 1 — _resolve_lint_paths (CLI input normalization):
+  - Files resolve to their parent directory
+  - Exact duplicate resolved paths are removed
+  - Order of first appearance is preserved
+  - Does NOT drop children when a parent is present (that's pass 2)
+
+Pass 2 — _dedup_discovered_files (after RepositoryContext discovery):
+  - Removes duplicate files discovered by overlapping RepositoryContexts
+  - Operates on the merged violation/file lists, not on input paths
+"""
+
+from pathlib import Path
+
+import pytest
+
+from skillsaw.__main__ import _resolve_lint_paths
+
+# ── Pass 1: _resolve_lint_paths ────────────────────────────────
+
+
+class TestResolveSinglePaths:
+    """File-to-parent resolution for individual paths."""
+
+    def test_file_resolves_to_parent(self, tmp_path):
+        f = tmp_path / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f])
+        assert result == [tmp_path]
+
+    def test_directory_stays_unchanged(self, tmp_path):
+        d = tmp_path / "my-skill"
+        d.mkdir()
+        result = _resolve_lint_paths([d])
+        assert result == [d]
+
+    def test_nested_file_resolves_to_immediate_parent(self, tmp_path):
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        f = nested / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f])
+        assert result == [nested]
+
+
+class TestDeduplicateExactPaths:
+    """Exact duplicates after resolution are collapsed."""
+
+    def test_same_dir_twice(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        result = _resolve_lint_paths([d, d])
+        assert result == [d]
+
+    def test_same_dir_three_times(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        result = _resolve_lint_paths([d, d, d])
+        assert result == [d]
+
+    def test_same_file_twice(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        f = d / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f, f])
+        assert result == [d]
+
+    def test_same_file_three_times(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        f = d / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f, f, f])
+        assert result == [d]
+
+    def test_file_and_its_parent_dir(self, tmp_path):
+        """A file and its parent resolve to the same directory — deduped."""
+        d = tmp_path / "skill"
+        d.mkdir()
+        f = d / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f, d])
+        assert result == [d]
+
+    def test_parent_dir_and_file_in_it(self, tmp_path):
+        """Order reversed: dir first, then file inside it — same result."""
+        d = tmp_path / "skill"
+        d.mkdir()
+        f = d / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([d, f])
+        assert result == [d]
+
+
+class TestOverlappingPathsKept:
+    """Pass 1 does NOT drop children when a parent is present.
+
+    Parent/child overlap is handled by pass 2 after file discovery.
+    """
+
+    def test_parent_and_child_dir_both_kept(self, tmp_path):
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        result = _resolve_lint_paths([parent, child])
+        assert result == [parent, child]
+
+    def test_child_dir_then_parent_both_kept(self, tmp_path):
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        result = _resolve_lint_paths([child, parent])
+        assert result == [child, parent]
+
+
+class TestPreservesOrder:
+    """First-seen order is preserved after dedup."""
+
+    def test_distinct_dirs_preserve_order(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        c = tmp_path / "c"
+        a.mkdir()
+        b.mkdir()
+        c.mkdir()
+        result = _resolve_lint_paths([a, b, c])
+        assert result == [a, b, c]
+
+    def test_distinct_files_preserve_order(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "SKILL.md").touch()
+        (b / "SKILL.md").touch()
+        result = _resolve_lint_paths([a / "SKILL.md", b / "SKILL.md"])
+        assert result == [a, b]
+
+    def test_mixed_with_dupes_preserves_first_seen(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "SKILL.md").touch()
+        result = _resolve_lint_paths([a / "SKILL.md", b, a / "SKILL.md"])
+        assert result == [a, b]
+
+
+class TestMixedFilesAndDirs:
+    """Various combinations of files and directories."""
+
+    def test_dir_then_file(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (b / "SKILL.md").touch()
+        result = _resolve_lint_paths([a, b / "SKILL.md"])
+        assert result == [a, b]
+
+    def test_file_then_dir(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "SKILL.md").touch()
+        result = _resolve_lint_paths([a / "SKILL.md", b])
+        assert result == [a, b]
+
+    def test_dir_file_dir(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        c = tmp_path / "c"
+        a.mkdir()
+        b.mkdir()
+        c.mkdir()
+        (b / "SKILL.md").touch()
+        result = _resolve_lint_paths([a, b / "SKILL.md", c])
+        assert result == [a, b, c]
+
+    def test_file_dir_file(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        c = tmp_path / "c"
+        a.mkdir()
+        b.mkdir()
+        c.mkdir()
+        (a / "SKILL.md").touch()
+        (c / "SKILL.md").touch()
+        result = _resolve_lint_paths([a / "SKILL.md", b, c / "SKILL.md"])
+        assert result == [a, b, c]
+
+
+class TestEmptyAndSingleInput:
+    """Edge cases for empty and single-element inputs."""
+
+    def test_empty_list(self):
+        result = _resolve_lint_paths([])
+        assert result == []
+
+    def test_single_dir(self, tmp_path):
+        result = _resolve_lint_paths([tmp_path])
+        assert result == [tmp_path]
+
+    def test_single_file(self, tmp_path):
+        f = tmp_path / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([f])
+        assert result == [tmp_path]
+
+
+# ── _is_subpath ────────────────────────────────────────────────
+
+
+from skillsaw.__main__ import _is_subpath
+
+
+class TestIsSubpath:
+    """Unit tests for the _is_subpath helper."""
+
+    def test_child_is_subpath_of_parent(self, tmp_path):
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        assert _is_subpath(child, parent) is True
+
+    def test_deeply_nested_is_subpath(self, tmp_path):
+        parent = tmp_path / "repo"
+        deep = parent / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        assert _is_subpath(deep, parent) is True
+
+    def test_parent_is_not_subpath_of_child(self, tmp_path):
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        assert _is_subpath(parent, child) is False
+
+    def test_same_path_is_not_subpath(self, tmp_path):
+        d = tmp_path / "repo"
+        d.mkdir()
+        assert _is_subpath(d, d) is False
+
+    def test_siblings_are_not_subpaths(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        assert _is_subpath(a, b) is False
+        assert _is_subpath(b, a) is False
+
+    def test_unrelated_paths_are_not_subpaths(self, tmp_path):
+        x = tmp_path / "x"
+        y = tmp_path / "completely" / "different"
+        x.mkdir()
+        y.mkdir(parents=True)
+        assert _is_subpath(x, y) is False
+        assert _is_subpath(y, x) is False
+
+    def test_similar_name_prefix_not_subpath(self, tmp_path):
+        """'repo-extra' is not a child of 'repo' even though the name starts with it."""
+        repo = tmp_path / "repo"
+        repo_extra = tmp_path / "repo-extra"
+        repo.mkdir()
+        repo_extra.mkdir()
+        assert _is_subpath(repo_extra, repo) is False
+
+
+# ── Pass 2: _dedup_discovered_paths ────────────────────────────
+
+
+from skillsaw.__main__ import _dedup_discovered_paths
+
+
+class TestDedupDiscoveredPaths:
+    """After multiple RepositoryContexts discover files, duplicates are removed
+    before passing to the linter. This prevents the same file being linted twice
+    when overlapping paths are given (e.g. dir/ and dir/subdir/).
+    """
+
+    def test_identical_paths_deduped(self, tmp_path):
+        a = tmp_path / "a"
+        a.mkdir()
+        result = _dedup_discovered_paths([a, a, a])
+        assert result == [a]
+
+    def test_distinct_paths_kept(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        result = _dedup_discovered_paths([a, b])
+        assert result == [a, b]
+
+    def test_child_dropped_when_parent_present(self, tmp_path):
+        """If parent/ and parent/child/ are both discovered, drop the child."""
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        result = _dedup_discovered_paths([parent, child])
+        assert result == [parent]
+
+    def test_child_first_then_parent_drops_child(self, tmp_path):
+        """Order shouldn't matter — child is still redundant."""
+        parent = tmp_path / "repo"
+        child = parent / "subdir"
+        child.mkdir(parents=True)
+        result = _dedup_discovered_paths([child, parent])
+        assert child not in result
+        assert parent in result
+
+    def test_deeply_nested_child_dropped(self, tmp_path):
+        parent = tmp_path / "repo"
+        deep = parent / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        result = _dedup_discovered_paths([parent, deep])
+        assert result == [parent]
+
+    def test_siblings_both_kept(self, tmp_path):
+        """Two siblings under the same parent are not overlapping."""
+        parent = tmp_path / "repo"
+        a = parent / "skill-a"
+        b = parent / "skill-b"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        result = _dedup_discovered_paths([a, b])
+        assert result == [a, b]
+
+    def test_empty_list(self):
+        result = _dedup_discovered_paths([])
+        assert result == []
+
+    def test_single_path(self, tmp_path):
+        result = _dedup_discovered_paths([tmp_path])
+        assert result == [tmp_path]
+
+    def test_preserves_order(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        c = tmp_path / "c"
+        a.mkdir()
+        b.mkdir()
+        c.mkdir()
+        result = _dedup_discovered_paths([c, a, b])
+        assert result == [c, a, b]
+
+    def test_complex_overlap(self, tmp_path):
+        """Mix of overlapping and distinct paths."""
+        repo1 = tmp_path / "repo1"
+        repo1_sub = repo1 / "skills" / "deploy"
+        repo2 = tmp_path / "repo2"
+        repo1_sub.mkdir(parents=True)
+        repo2.mkdir()
+        result = _dedup_discovered_paths([repo1, repo1_sub, repo2])
+        assert repo1 in result
+        assert repo2 in result
+        assert repo1_sub not in result
+        assert len(result) == 2
+
+
+# ── _build_merged_context ──────────────────────────────────────
+
+
+from skillsaw.__main__ import _build_merged_context, _MergedContext
+from skillsaw.context import RepositoryContext, RepositoryType
+
+
+class TestBuildMergedContext:
+    """Tests for merging multiple RepositoryContexts into one for formatters."""
+
+    def test_single_context_returned_as_is(self, tmp_path):
+        d = tmp_path / "skill"
+        d.mkdir()
+        (d / "SKILL.md").touch()
+        ctx = RepositoryContext(d)
+        result = _build_merged_context([ctx])
+        assert result is ctx
+
+    def test_two_contexts_merged(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "SKILL.md").touch()
+        (b / "SKILL.md").touch()
+        ctx_a = RepositoryContext(a)
+        ctx_b = RepositoryContext(b)
+        result = _build_merged_context([ctx_a, ctx_b])
+        assert isinstance(result, _MergedContext)
+        assert result.root_path == tmp_path
+        assert ctx_a.repo_types | ctx_b.repo_types == result.repo_types
+
+    def test_merged_root_is_common_ancestor(self, tmp_path):
+        a = tmp_path / "projects" / "alpha"
+        b = tmp_path / "projects" / "beta"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        ctx_a = RepositoryContext(a)
+        ctx_b = RepositoryContext(b)
+        result = _build_merged_context([ctx_a, ctx_b])
+        assert result.root_path == tmp_path / "projects"
+
+    def test_merged_repo_types_is_union(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "SKILL.md").touch()
+        (b / ".claude-plugin").mkdir()
+        (b / ".claude-plugin" / "plugin.json").write_text("{}")
+        ctx_a = RepositoryContext(a)
+        ctx_b = RepositoryContext(b)
+        result = _build_merged_context([ctx_a, ctx_b])
+        assert RepositoryType.AGENTSKILLS in result.repo_types
+        assert RepositoryType.SINGLE_PLUGIN in result.repo_types
+
+
+class TestMergedContextRepoType:
+    """The repo_type property should return the primary type by priority."""
+
+    def test_unknown_when_empty(self):
+        ctx = _MergedContext(
+            root_path=Path("/tmp"),
+            repo_types={RepositoryType.UNKNOWN},
+            plugins=[],
+            skills=[],
+        )
+        assert ctx.repo_type == RepositoryType.UNKNOWN
+
+    def test_returns_highest_priority(self):
+        ctx = _MergedContext(
+            root_path=Path("/tmp"),
+            repo_types={RepositoryType.AGENTSKILLS, RepositoryType.DOT_CLAUDE},
+            plugins=[],
+            skills=[],
+        )
+        assert ctx.repo_type != RepositoryType.UNKNOWN
+
+
+# ── _dedup_rules ───────────────────────────────────────────────
+
+
+from skillsaw.__main__ import _dedup_rules
+from skillsaw.rule import Rule, Severity
+
+
+class _FakeRule:
+    """Minimal rule-like object for testing _dedup_rules."""
+
+    def __init__(self, rule_id):
+        self.rule_id = rule_id
+
+
+class TestDedupRules:
+
+    def test_no_dupes_unchanged(self):
+        rules = [_FakeRule("a"), _FakeRule("b"), _FakeRule("c")]
+        result = _dedup_rules(rules)
+        assert [r.rule_id for r in result] == ["a", "b", "c"]
+
+    def test_duplicates_collapsed(self):
+        rules = [_FakeRule("a"), _FakeRule("b"), _FakeRule("a")]
+        result = _dedup_rules(rules)
+        assert [r.rule_id for r in result] == ["a", "b"]
+
+    def test_all_same_collapses_to_one(self):
+        rules = [_FakeRule("x"), _FakeRule("x"), _FakeRule("x")]
+        result = _dedup_rules(rules)
+        assert [r.rule_id for r in result] == ["x"]
+
+    def test_empty_list(self):
+        assert _dedup_rules([]) == []
+
+    def test_preserves_first_occurrence(self):
+        r1 = _FakeRule("a")
+        r2 = _FakeRule("a")
+        result = _dedup_rules([r1, r2])
+        assert result[0] is r1

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,22 +1,13 @@
 """
 Unit tests for CLI path resolution and deduplication logic.
 
-Two passes of deduplication:
-
-Pass 1 — _resolve_lint_paths (CLI input normalization):
+_resolve_lint_paths normalizes CLI input in a single pass:
   - Files resolve to their parent directory
   - Exact duplicate resolved paths are removed
+  - Paths nested inside another entry are dropped (the parent's
+    RepositoryContext already discovers everything beneath it)
   - Order of first appearance is preserved
-  - Does NOT drop children when a parent is present (that's pass 2)
-
-Pass 2 — _dedup_discovered_files (after RepositoryContext discovery):
-  - Removes duplicate files discovered by overlapping RepositoryContexts
-  - Operates on the merged violation/file lists, not on input paths
 """
-
-from pathlib import Path
-
-import pytest
 
 from skillsaw.__main__ import _resolve_lint_paths
 
@@ -97,25 +88,62 @@ class TestDeduplicateExactPaths:
         assert result == [d]
 
 
-class TestOverlappingPathsKept:
-    """Pass 1 does NOT drop children when a parent is present.
-
-    Parent/child overlap is handled by pass 2 after file discovery.
+class TestOverlappingPathsDropped:
+    """Paths nested inside another entry are redundant — the parent's
+    RepositoryContext already discovers everything beneath it.
     """
 
-    def test_parent_and_child_dir_both_kept(self, tmp_path):
+    def test_child_dropped_when_parent_present(self, tmp_path):
         parent = tmp_path / "repo"
         child = parent / "subdir"
         child.mkdir(parents=True)
         result = _resolve_lint_paths([parent, child])
-        assert result == [parent, child]
+        assert result == [parent]
 
-    def test_child_dir_then_parent_both_kept(self, tmp_path):
+    def test_child_first_then_parent_drops_child(self, tmp_path):
+        """Order shouldn't matter — child is still redundant."""
         parent = tmp_path / "repo"
         child = parent / "subdir"
         child.mkdir(parents=True)
         result = _resolve_lint_paths([child, parent])
-        assert result == [child, parent]
+        assert result == [parent]
+
+    def test_deeply_nested_child_dropped(self, tmp_path):
+        parent = tmp_path / "repo"
+        deep = parent / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        result = _resolve_lint_paths([parent, deep])
+        assert result == [parent]
+
+    def test_nested_file_dropped_when_parent_present(self, tmp_path):
+        """A SKILL.md under a passed directory dedups against that directory."""
+        parent = tmp_path / "repo"
+        skill = parent / "skills" / "deploy"
+        skill.mkdir(parents=True)
+        f = skill / "SKILL.md"
+        f.touch()
+        result = _resolve_lint_paths([parent, f])
+        assert result == [parent]
+
+    def test_siblings_both_kept(self, tmp_path):
+        """Two siblings under the same parent are not overlapping."""
+        parent = tmp_path / "repo"
+        a = parent / "skill-a"
+        b = parent / "skill-b"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        result = _resolve_lint_paths([a, b])
+        assert result == [a, b]
+
+    def test_complex_overlap(self, tmp_path):
+        """Mix of overlapping and distinct paths."""
+        repo1 = tmp_path / "repo1"
+        repo1_sub = repo1 / "skills" / "deploy"
+        repo2 = tmp_path / "repo2"
+        repo1_sub.mkdir(parents=True)
+        repo2.mkdir()
+        result = _resolve_lint_paths([repo1, repo1_sub, repo2])
+        assert result == [repo1, repo2]
 
 
 class TestPreservesOrder:
@@ -271,98 +299,6 @@ class TestIsSubpath:
         assert _is_subpath(repo_extra, repo) is False
 
 
-# ── Pass 2: _dedup_discovered_paths ────────────────────────────
-
-
-from skillsaw.__main__ import _dedup_discovered_paths
-
-
-class TestDedupDiscoveredPaths:
-    """After multiple RepositoryContexts discover files, duplicates are removed
-    before passing to the linter. This prevents the same file being linted twice
-    when overlapping paths are given (e.g. dir/ and dir/subdir/).
-    """
-
-    def test_identical_paths_deduped(self, tmp_path):
-        a = tmp_path / "a"
-        a.mkdir()
-        result = _dedup_discovered_paths([a, a, a])
-        assert result == [a]
-
-    def test_distinct_paths_kept(self, tmp_path):
-        a = tmp_path / "a"
-        b = tmp_path / "b"
-        a.mkdir()
-        b.mkdir()
-        result = _dedup_discovered_paths([a, b])
-        assert result == [a, b]
-
-    def test_child_dropped_when_parent_present(self, tmp_path):
-        """If parent/ and parent/child/ are both discovered, drop the child."""
-        parent = tmp_path / "repo"
-        child = parent / "subdir"
-        child.mkdir(parents=True)
-        result = _dedup_discovered_paths([parent, child])
-        assert result == [parent]
-
-    def test_child_first_then_parent_drops_child(self, tmp_path):
-        """Order shouldn't matter — child is still redundant."""
-        parent = tmp_path / "repo"
-        child = parent / "subdir"
-        child.mkdir(parents=True)
-        result = _dedup_discovered_paths([child, parent])
-        assert child not in result
-        assert parent in result
-
-    def test_deeply_nested_child_dropped(self, tmp_path):
-        parent = tmp_path / "repo"
-        deep = parent / "a" / "b" / "c"
-        deep.mkdir(parents=True)
-        result = _dedup_discovered_paths([parent, deep])
-        assert result == [parent]
-
-    def test_siblings_both_kept(self, tmp_path):
-        """Two siblings under the same parent are not overlapping."""
-        parent = tmp_path / "repo"
-        a = parent / "skill-a"
-        b = parent / "skill-b"
-        a.mkdir(parents=True)
-        b.mkdir(parents=True)
-        result = _dedup_discovered_paths([a, b])
-        assert result == [a, b]
-
-    def test_empty_list(self):
-        result = _dedup_discovered_paths([])
-        assert result == []
-
-    def test_single_path(self, tmp_path):
-        result = _dedup_discovered_paths([tmp_path])
-        assert result == [tmp_path]
-
-    def test_preserves_order(self, tmp_path):
-        a = tmp_path / "a"
-        b = tmp_path / "b"
-        c = tmp_path / "c"
-        a.mkdir()
-        b.mkdir()
-        c.mkdir()
-        result = _dedup_discovered_paths([c, a, b])
-        assert result == [c, a, b]
-
-    def test_complex_overlap(self, tmp_path):
-        """Mix of overlapping and distinct paths."""
-        repo1 = tmp_path / "repo1"
-        repo1_sub = repo1 / "skills" / "deploy"
-        repo2 = tmp_path / "repo2"
-        repo1_sub.mkdir(parents=True)
-        repo2.mkdir()
-        result = _dedup_discovered_paths([repo1, repo1_sub, repo2])
-        assert repo1 in result
-        assert repo2 in result
-        assert repo1_sub not in result
-        assert len(result) == 2
-
-
 # ── _build_merged_context ──────────────────────────────────────
 
 
@@ -423,18 +359,18 @@ class TestBuildMergedContext:
 class TestMergedContextRepoType:
     """The repo_type property should return the primary type by priority."""
 
-    def test_unknown_when_empty(self):
+    def test_unknown_when_empty(self, tmp_path):
         ctx = _MergedContext(
-            root_path=Path("/tmp"),
+            root_path=tmp_path,
             repo_types={RepositoryType.UNKNOWN},
             plugins=[],
             skills=[],
         )
         assert ctx.repo_type == RepositoryType.UNKNOWN
 
-    def test_returns_highest_priority(self):
+    def test_returns_highest_priority(self, tmp_path):
         ctx = _MergedContext(
-            root_path=Path("/tmp"),
+            root_path=tmp_path,
             repo_types={RepositoryType.AGENTSKILLS, RepositoryType.DOT_CLAUDE},
             plugins=[],
             skills=[],
@@ -446,7 +382,6 @@ class TestMergedContextRepoType:
 
 
 from skillsaw.__main__ import _dedup_rules
-from skillsaw.rule import Rule, Severity
 
 
 class _FakeRule:


### PR DESCRIPTION
## Summary
  
- Adds support for passing SKILL.md files directly as CLI arguments (resolves to parent directory for linting)
- Accepts multiple directories and/or files in a single invocation: `skillsaw dir1/ dir2/SKILL.md dir3/`
- Two-pass deduplication prevents double-linting: pass 1 normalizes CLI args (file→parent, exact dedup), pass 2 removes child paths already covered by a parent
- Merges results across all paths into a single combined report
- Validates paths before resolution so nonexistent files can't silently resolve to an existing parent directory — missing paths are warned, valid paths still lint, exit 1 if any not found

Closes #288
Closes #289

## Test plan

### New Tests
- [ ] 49 unit tests covering `_resolve_lint_paths`, `_dedup_discovered_paths`, `_is_subpath`, `_build_merged_context`, `_MergedContext`, and `_dedup_rules`
- [ ] 35 integration tests covering all file/dir permutations (D/F pairs, triples, quads), dedup/overlap edge cases, mixed clean/broken exit codes, and nonexistent path error handling

### Automated Testing 
- [ ] `make test` passes with no regressions (1974 passed)

### Manual Testing
- [ ] `.venv/bin/skillsaw` — no args, backward compatibility lints CWD
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/clean/ tests/fixtures/single-plugin/clean/` — single directory backward compatibility
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/clean/code-review/SKILL.md` — single file detects agentskills
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/clean/ tests/fixtures/single-plugin/clean/` — two directories merged
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/clean/code-review/SKILL.md tests/fixtures/single-plugin/clean/` — mixed file + dir
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/broken/Bad_Formatter/SKILL.md` — broken file exits 1
- [ ] `.venv/bin/skillsaw tests/fixtures/agentskills/broken/Bad_Formatter/SKILL.md tests/fixtures/agentskills/broken/Bad_Formatter/SKILL2.md` — nonexistent sibling warns and exits 1


🤖 PR Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `skillsaw lint` and `skillsaw fix` accept multiple paths, normalize file inputs to parent dirs, merge results across resolved roots, and aggregate reporting across all paths.
  * `fix` enforces single-path behavior for interactive LLM/patch application.

* **Bug Fixes**
  * Fail-fast on missing paths and clearer "N path(s) not found" reporting with correct exit codes.

* **Tests**
  * Added end-to-end and unit tests covering multi-path handling and path-resolution behavior.

* **Documentation**
  * CLI and Quick Start docs updated to describe multi-path defaults and config auto-discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->