### PR TITLE
[Auto] Bump version to 0.13.1

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.13.0"
+version: "0.13.1"
 
 rules:
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.12.1"). Defaults to the version this action was released with.'
     required: false
-    default: '0.13.0'
+    default: '0.13.1'
   strict:
     description: 'Treat warnings as errors'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.13.0"
+version = "0.13.1"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext


### PR DESCRIPTION
## Summary

- Version bump to 0.13.1
- Follows hotfix: Settings/hooks/MCP JSON blocks are config, not content

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.13.1

* **Chores**
  * Version bumped to 0.13.1 across all package manifests and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->