### PR TITLE
Add autofix and malformed-input test coverage

### DIFF
--- a/src/skillsaw/rules/builtin/marketplace/registration.py
+++ b/src/skillsaw/rules/builtin/marketplace/registration.py
@@ -73,8 +73,16 @@ class MarketplaceRegistrationRule(Rule):
         except json.JSONDecodeError:
             return results
 
+        # marketplace-json-valid reports malformed shapes; mutating a
+        # non-object document or non-list plugins would crash, so leave
+        # those for manual repair.
+        if not isinstance(data, dict):
+            return results
+
         if "plugins" not in data:
             data["plugins"] = []
+        if not isinstance(data["plugins"], list):
+            return results
 
         fixed_violations = []
         for v in violations:
@@ -84,7 +92,7 @@ class MarketplaceRegistrationRule(Rule):
             if len(name_match) < 2:
                 continue
             plugin_name = name_match[1]
-            if any(p.get("name") == plugin_name for p in data["plugins"]):
+            if any(p.get("name") == plugin_name for p in data["plugins"] if isinstance(p, dict)):
                 continue
             rel_source = plugin_name
             for plugin_node in context.lint_tree.find(PluginNode):

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -20,7 +20,8 @@ from skillsaw.config import LinterConfig
 from skillsaw.linter import Linter
 from skillsaw.rules.builtin.skills import SkillFrontmatterRule
 from skillsaw.rules.builtin.agents import AgentFrontmatterRule
-from skillsaw.rules.builtin.command_format import CommandNamingRule
+from skillsaw.rules.builtin.command_format import CommandNamingRule, CommandFrontmatterRule
+from skillsaw.rules.builtin.utils import invalidate_read_caches
 
 
 class NoFixRule(Rule):
@@ -890,3 +891,135 @@ class TestSkillRenameRefsEndToEnd:
         rename_violations = [v for v in violations3 if v.rule_id == "agentskill-rename-refs"]
         assert len(rename_violations) == 0
         assert not manifest_path.exists()
+
+
+class TestCommandFrontmatterFix:
+    """CommandFrontmatterRule.fix(): prepend a frontmatter block when none
+    exists, or insert a description field into an existing block. The applied
+    fix must resolve the violation on re-lint (convergence) — a fix that
+    leaves the violation in place would make `skillsaw fix` loop forever."""
+
+    def test_missing_frontmatter_prepended(self, temp_dir):
+        body = "Run the deployment steps.\n"
+        plugin_dir = _make_plugin(temp_dir, "my-plugin", {"deploy.md": body})
+        context = RepositoryContext(plugin_dir)
+        rule = CommandFrontmatterRule()
+
+        violations = rule.check(context)
+        assert [v.message for v in violations] == ["Missing frontmatter"]
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        fix = fixes[0]
+        assert fix.confidence == AutofixConfidence.SAFE
+        assert fix.fixed_content == f"---\ndescription: \n---\n{body}"
+
+        fix.file_path.write_text(fix.fixed_content)
+        invalidate_read_caches()
+        assert rule.check(RepositoryContext(plugin_dir)) == []
+
+    def test_missing_description_inserted_into_existing_block(self, temp_dir):
+        content = "---\nargument-hint: <env>\n---\nDeploy to the given environment.\n"
+        plugin_dir = _make_plugin(temp_dir, "my-plugin", {"deploy.md": content})
+        context = RepositoryContext(plugin_dir)
+        rule = CommandFrontmatterRule()
+
+        violations = rule.check(context)
+        assert [v.message for v in violations] == ["Missing 'description' in frontmatter"]
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        fixed = fixes[0].fixed_content
+        # Field goes inside the existing block: other keys preserved, body
+        # untouched, exactly one line added.
+        assert "argument-hint: <env>" in fixed
+        assert "description: " in fixed
+        assert fixed.endswith("Deploy to the given environment.\n")
+        assert len(fixed.splitlines()) == len(content.splitlines()) + 1
+
+        fixes[0].file_path.write_text(fixed)
+        invalidate_read_caches()
+        assert rule.check(RepositoryContext(plugin_dir)) == []
+
+    def test_fix_idempotent(self, temp_dir):
+        """A second fix pass after applying must not stack frontmatter blocks."""
+        plugin_dir = _make_plugin(temp_dir, "my-plugin", {"deploy.md": "Body.\n"})
+        rule = CommandFrontmatterRule()
+
+        context = RepositoryContext(plugin_dir)
+        fixes = rule.fix(context, rule.check(context))
+        target = fixes[0].file_path
+        target.write_text(fixes[0].fixed_content)
+        first_pass = target.read_text()
+
+        invalidate_read_caches()
+        context2 = RepositoryContext(plugin_dir)
+        violations2 = rule.check(context2)
+        assert violations2 == []
+        assert rule.fix(context2, violations2) == []
+        assert target.read_text() == first_pass
+
+
+class TestSkillFixMissingFrontmatterBlock:
+    """SkillFrontmatterRule.fix(): a SKILL.md without any frontmatter gets a
+    full block prepended, deriving the name from the skill directory and
+    preserving the body byte-for-byte."""
+
+    def test_adds_block_and_preserves_body(self, temp_dir):
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        skill_dir = plugin_dir / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        body = "# My Skill\n\nDo the thing.\n"
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(body)
+
+        context = RepositoryContext(plugin_dir)
+        rule = SkillFrontmatterRule()
+
+        violations = rule.check(context)
+        assert [v.message for v in violations] == ["Missing frontmatter (recommended for SKILL.md)"]
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert fixes[0].fixed_content == f"---\nname: my-skill\ndescription: \n---\n{body}"
+
+        skill_md.write_text(fixes[0].fixed_content)
+        invalidate_read_caches()
+        assert rule.check(RepositoryContext(plugin_dir)) == []
+
+
+class TestAgentFixMissingFrontmatterBlock:
+    """AgentFrontmatterRule.fix(): an agent file without any frontmatter gets
+    a full block prepended, deriving the name from the file stem."""
+
+    def test_adds_block_and_preserves_body(self, temp_dir):
+        plugin_dir = temp_dir / "test-plugin"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+
+        agents_dir = plugin_dir / "agents"
+        agents_dir.mkdir()
+        body = "You are a helpful code reviewer.\n"
+        agent_md = agents_dir / "my-agent.md"
+        agent_md.write_text(body)
+
+        context = RepositoryContext(plugin_dir)
+        rule = AgentFrontmatterRule()
+
+        violations = rule.check(context)
+        assert [v.message for v in violations] == ["Missing frontmatter"]
+
+        fixes = rule.fix(context, violations)
+        assert len(fixes) == 1
+        assert fixes[0].fixed_content == f"---\nname: my-agent\ndescription: \n---\n{body}"
+
+        agent_md.write_text(fixes[0].fixed_content)
+        invalidate_read_caches()
+        assert rule.check(RepositoryContext(plugin_dir)) == []

--- a/tests/test_hook_rules.py
+++ b/tests/test_hook_rules.py
@@ -1398,3 +1398,62 @@ def test_prohibited_rule_metadata():
     rule = HooksProhibitedRule()
     assert rule.rule_id == "hooks-prohibited"
     assert rule.default_severity().value == "error"
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        pytest.param(
+            [{"type": "command", "command": "echo hi"}],
+            "hooks.json must be a JSON object",
+            id="top-level-array",
+        ),
+        pytest.param(
+            {"hooks": []},
+            "'hooks' must be a JSON object",
+            id="hooks-key-not-object",
+        ),
+        pytest.param(
+            {"hooks": {"PreToolUse": "echo hi"}},
+            "Event 'PreToolUse' must have an array of hook configurations",
+            id="event-not-array",
+        ),
+        pytest.param(
+            {"hooks": {"PreToolUse": ["echo hi"]}},
+            "Event 'PreToolUse[0]' configuration must be an object",
+            id="config-not-object",
+        ),
+        pytest.param(
+            {"hooks": {"PreToolUse": [{"matcher": ".*"}]}},
+            "Event 'PreToolUse[0]' must have a 'hooks' array",
+            id="config-missing-hooks",
+        ),
+        pytest.param(
+            {"hooks": {"PreToolUse": [{"hooks": {"type": "command"}}]}},
+            "Event 'PreToolUse[0].hooks' must be an array",
+            id="hooks-list-not-array",
+        ),
+        pytest.param(
+            {"hooks": {"PreToolUse": [{"hooks": ["echo hi"]}]}},
+            "Event 'PreToolUse[0].hooks[0]' must be an object",
+            id="hook-entry-not-object",
+        ),
+    ],
+)
+def test_malformed_hooks_structure(temp_dir, payload, expected):
+    """Each malformed hooks.json shape produces a single clear error rather
+    than a crash or a misleading cascade of follow-on violations."""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "test-plugin"}')
+    hooks_dir = plugin_dir / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text(json.dumps(payload))
+
+    rule = HooksJsonValidRule()
+    violations = rule.check(RepositoryContext(plugin_dir))
+    assert len(violations) == 1
+    assert expected in violations[0].message
+    assert violations[0].severity == Severity.ERROR

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -17,6 +17,7 @@ from skillsaw.rules.builtin.command_format import (
     CommandNamingRule,
     CommandFrontmatterRule,
     CommandNameFormatRule,
+    CommandSectionsRule,
 )
 from skillsaw.rules.builtin.marketplace import (
     MarketplaceJsonValidRule,
@@ -580,3 +581,249 @@ def test_skill_frontmatter_malformed_yaml_reports_line(temp_dir):
     assert len(fm_violations) == 1
     assert fm_violations[0].line is not None
     assert fm_violations[0].line == 5
+
+
+# --- marketplace-registration autofix ---
+
+
+def _add_unregistered_plugin(repo, name):
+    """Create a plugin directory under repo/plugins that is not registered."""
+    import json
+
+    plugin_dir = repo / "plugins" / name
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "description": "Test plugin",
+                "version": "1.0.0",
+                "author": {"name": "Test"},
+            }
+        )
+    )
+    (plugin_dir / "commands").mkdir()
+    return plugin_dir
+
+
+def _marketplace_with_raw_json(temp_dir, marketplace_text):
+    """Marketplace repo with raw marketplace.json text and one unregistered plugin."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text(marketplace_text)
+    _add_unregistered_plugin(temp_dir, "plugin-one")
+    return temp_dir
+
+
+def test_marketplace_registration_fix_registers_plugin(marketplace_repo):
+    """fix() appends an entry using the plugin's repo-relative path as source,
+    preserves existing registrations, and resolves the violation on re-lint."""
+    import json
+
+    from skillsaw.rules.builtin.utils import invalidate_read_caches
+
+    _add_unregistered_plugin(marketplace_repo, "plugin-three")
+    context = RepositoryContext(marketplace_repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+
+    fixes = rule.fix(context, violations)
+    assert len(fixes) == 1
+    fix = fixes[0]
+    assert fix.violations_fixed == violations
+
+    data = json.loads(fix.fixed_content)
+    entries = [p for p in data["plugins"] if p.get("name") == "plugin-three"]
+    assert entries == [{"name": "plugin-three", "source": "plugins/plugin-three"}]
+    assert {p["name"] for p in data["plugins"]} == {
+        "plugin-one",
+        "plugin-two",
+        "plugin-three",
+    }
+
+    fix.file_path.write_text(fix.fixed_content)
+    invalidate_read_caches()
+    assert rule.check(RepositoryContext(marketplace_repo)) == []
+
+
+def test_marketplace_registration_fix_plugins_not_list(temp_dir):
+    """Regression: fix() crashed with AttributeError when 'plugins' was a JSON
+    object instead of an array. The malformed document is reported by
+    marketplace-json-valid; fix() must skip it, not crash."""
+    import json
+
+    repo = _marketplace_with_raw_json(
+        temp_dir, json.dumps({"name": "m", "owner": {"name": "o"}, "plugins": {}})
+    )
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert rule.fix(context, violations) == []
+
+
+def test_marketplace_registration_fix_top_level_array(temp_dir):
+    """Regression: fix() crashed with TypeError when marketplace.json held a
+    top-level JSON array instead of an object."""
+    repo = _marketplace_with_raw_json(temp_dir, "[]")
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert rule.fix(context, violations) == []
+
+
+def test_marketplace_registration_fix_skips_non_dict_entries(temp_dir):
+    """Regression: string entries in 'plugins' crashed the duplicate scan with
+    AttributeError. They must be skipped while still registering the plugin."""
+    import json
+
+    repo = _marketplace_with_raw_json(
+        temp_dir,
+        json.dumps({"name": "m", "owner": {"name": "o"}, "plugins": ["plugin-zero"]}),
+    )
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+
+    fixes = rule.fix(context, violations)
+    assert len(fixes) == 1
+    data = json.loads(fixes[0].fixed_content)
+    assert {"name": "plugin-one", "source": "plugins/plugin-one"} in data["plugins"]
+    assert "plugin-zero" in data["plugins"]
+
+
+def test_marketplace_registration_fix_invalid_json(temp_dir):
+    """Unparseable marketplace.json yields no fixes rather than a crash."""
+    repo = _marketplace_with_raw_json(temp_dir, '{"name": broken')
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert rule.fix(context, violations) == []
+
+
+# --- marketplace-json-valid: malformed documents ---
+
+
+def test_marketplace_json_invalid_json(temp_dir):
+    """Unparseable marketplace.json reports a single Invalid JSON error."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text('{"name": broken')
+
+    context = RepositoryContext(temp_dir)
+    rule = MarketplaceJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "Invalid JSON" in violations[0].message
+    assert violations[0].severity == Severity.ERROR
+
+
+def test_marketplace_json_top_level_not_object(temp_dir):
+    """A top-level JSON array is rejected with a clear message."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text("[]")
+
+    context = RepositoryContext(temp_dir)
+    rule = MarketplaceJsonValidRule()
+    violations = rule.check(context)
+    assert [v.message for v in violations] == ["Marketplace file must contain a JSON object"]
+
+
+def test_marketplace_json_missing_required_fields(temp_dir):
+    """An empty object reports all three missing required fields."""
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text("{}")
+
+    context = RepositoryContext(temp_dir)
+    rule = MarketplaceJsonValidRule()
+    violations = rule.check(context)
+    assert {v.message for v in violations} == {
+        "Missing 'name' field",
+        "Missing 'owner' field",
+        "Missing 'plugins' array",
+    }
+
+
+def test_marketplace_json_plugins_not_array(temp_dir):
+    """A non-array 'plugins' value is rejected."""
+    import json
+
+    claude_dir = temp_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "marketplace.json").write_text(
+        json.dumps({"name": "m", "owner": {"name": "o"}, "plugins": "nope"})
+    )
+
+    context = RepositoryContext(temp_dir)
+    rule = MarketplaceJsonValidRule()
+    violations = rule.check(context)
+    assert [v.message for v in violations] == ["'plugins' must be an array"]
+
+
+# --- command-sections ---
+
+
+def test_command_sections_all_present(valid_plugin):
+    """The valid plugin fixture command has all four recommended sections."""
+    context = RepositoryContext(valid_plugin)
+    rule = CommandSectionsRule()
+    assert rule.check(context) == []
+
+
+def test_command_sections_missing_all(temp_dir):
+    """A command with no section headings reports one warning per section."""
+    import json
+
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+    commands_dir = plugin_dir / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "deploy.md").write_text("---\ndescription: Deploy\n---\nJust prose.\n")
+
+    context = RepositoryContext(plugin_dir)
+    rule = CommandSectionsRule()
+    violations = rule.check(context)
+    assert {v.message for v in violations} == {
+        "Missing recommended section '## Name'",
+        "Missing recommended section '## Synopsis'",
+        "Missing recommended section '## Description'",
+        "Missing recommended section '## Implementation'",
+    }
+    assert all(v.severity == Severity.WARNING for v in violations)
+
+
+def test_command_sections_partial(temp_dir):
+    """Only the absent sections are reported."""
+    import json
+
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text(json.dumps({"name": "test-plugin"}))
+    commands_dir = plugin_dir / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "deploy.md").write_text(
+        "---\ndescription: Deploy\n---\n"
+        "## Name\ndeploy\n\n## Synopsis\n/deploy\n\n## Description\nDeploys.\n"
+    )
+
+    context = RepositoryContext(plugin_dir)
+    rule = CommandSectionsRule()
+    violations = rule.check(context)
+    assert [v.message for v in violations] == ["Missing recommended section '## Implementation'"]


### PR DESCRIPTION
# Test coverage audit: autofix paths and malformed-input handling

## Summary of coverage analysis

Ran the full suite with coverage (`pytest --cov=src`): 2038 passed, 15 skipped, 82% total. Most low-coverage numbers in `__main__.py` (14%) and `marketplace/cli.py` (36%) are artifacts — those paths are exercised end-to-end by `tests/test_integration.py` via subprocess, which coverage doesn't instrument. After discounting those, the real gaps clustered in two areas:

1. **Autofix (`fix()`) implementations with no direct tests.** Integration tests run `skillsaw fix` against fixtures, but several rules' fix paths were never executed by any test, in-process or via CLI:
   - `commands/frontmatter.py` — 56% (both fix branches untested)
   - `marketplace/registration.py` — 43% (entire `fix()` untested)
   - `skills/frontmatter.py` / `agents/frontmatter.py` — the missing-whole-frontmatter-block branches untested (only field insertion was covered)

2. **Malformed-input branches in JSON validation rules.** The branches that handle structurally wrong user files were never exercised:
   - `hooks/json_valid.py` — 84%; all seven structure-shape error branches uncovered
   - `marketplace/json_valid.py` — 83%; invalid JSON, non-object document, missing required fields, non-array `plugins` uncovered
   - `commands/sections.py` — 54%; the rule had no direct tests at all (it is opt-in, so integration runs never enable it)

The remaining sizable gap, `linter.py` 69%, is LLM-fix orchestration already covered by mocked tests in `test_llm.py`/`test_llm_integration.py` at the level that matters; I left it alone.

## Bug found and fixed

Probing the untested `MarketplaceRegistrationRule.fix()` exposed crashes on malformed-but-plausible `marketplace.json` documents that `check()` (and `marketplace-json-valid`) already handle gracefully:

- `"plugins": {}` (object instead of array) → `AttributeError: 'dict' object has no attribute 'append'`
- top-level JSON array (`[]`) → `TypeError: list indices must be integers or slices, not str`
- string entries in `plugins` (`["plugin-zero"]`) → `AttributeError: 'str' object has no attribute 'get'` in the duplicate scan

The linter isolates fix exceptions into a rule-crash violation, so the CLI didn't die — but `skillsaw fix` on such a repo reported an internal error instead of skipping the unfixable document. The minimal fix in `registration.py` mirrors `check()`'s existing shape guards: bail out of `fix()` when the document isn't an object or `plugins` isn't a list (marketplace-json-valid reports those shapes), and skip non-dict entries when scanning for existing registrations. All three regression tests fail on the previous code and pass with the guard (verified by reverting and re-running).

## Test cases added

**`tests/test_rules.py`**
- `test_marketplace_registration_fix_registers_plugin` — happy path: entry appended with the plugin's repo-relative `source`, existing registrations preserved, `violations_fixed` populated, and re-lint after applying the fix is clean (convergence).
- `test_marketplace_registration_fix_plugins_not_list`, `..._fix_top_level_array`, `..._fix_skips_non_dict_entries` — regressions for the three crashes above.
- `test_marketplace_registration_fix_invalid_json` — unparseable JSON yields no fixes rather than a crash.
- `test_marketplace_json_invalid_json`, `..._top_level_not_object`, `..._missing_required_fields`, `..._plugins_not_array` — the malformed-document branches of `marketplace-json-valid`, asserting exact messages.
- `test_command_sections_all_present`, `..._missing_all`, `..._partial` — first direct tests of `command-sections`: all four headings satisfied, one warning per missing section, and only absent sections reported.

**`tests/test_autofix.py`**
- `TestCommandFrontmatterFix` — the prepend-missing-frontmatter and insert-missing-description branches. Asserts exact fixed content, that insertion preserves other frontmatter keys and the body, adds exactly one line (per the autofix testing rules), that re-lint after applying is clean, and that a second pass is a no-op (a non-convergent fix would make `skillsaw fix` loop).
- `TestSkillFixMissingFrontmatterBlock` / `TestAgentFixMissingFrontmatterBlock` — a SKILL.md/agent file with no frontmatter at all gets a full block prepended (name derived from skill directory / file stem), body preserved byte-for-byte, re-lint clean.

**`tests/test_hook_rules.py`**
- `test_malformed_hooks_structure` — parametrized over all seven malformed `hooks.json` shapes (top-level array, `hooks` not an object, event value not an array, config entry not an object, config missing `hooks`, inner `hooks` not an array, hook entry not an object). Each must produce exactly one clear ERROR, not a crash or a cascade.

## Test cases changed

None. Existing tests were correct; the gaps were omissions, not weaknesses, so I only added tests.

## Risks these tests guard against

- `skillsaw fix` crashing (rule-crash violations) or corrupting `marketplace.json` on malformed documents — now fixed and pinned by regression tests.
- Autofix non-convergence: a frontmatter fix that doesn't resolve its violation on re-lint would make `fix_and_apply`'s fixed-point loop spin through `max_passes` doing nothing. The re-lint-clean assertions pin convergence for the command/skill/agent frontmatter fixes.
- Autofixes silently dropping body content or other frontmatter keys (exact-content and line-count assertions).
- The hooks/marketplace validators regressing from "one clear error per malformed shape" to a traceback when the schema-walking code is refactored — these rules are the first thing users hit when they hand-write config.

## Verification

```
.venv/bin/pytest tests/ -q --cov=src --cov-report=term
# 2062 passed, 15 skipped (was 2038 passed); total coverage 82% -> 83%
#   commands/frontmatter.py     56% -> 93%
#   commands/sections.py        54% -> 96%
#   hooks/json_valid.py         84% -> 100%
#   marketplace/json_valid.py   83% -> 98%
#   marketplace/registration.py 43% -> 88%
#   agents/frontmatter.py       90% -> 96%

.venv/bin/black --check src/ tests/   # clean
.venv/bin/skillsaw lint .             # exit 0, all checks passed

# Regression value check: with the registration.py guard reverted,
# the three new regression tests fail with the original AttributeError/
# TypeError; with the guard they pass.
```

Pre-push checklist:

```
make update                          # completed; zero changes to tracked files
                                     # (apm compile, example config, docs, site
                                     # content all regenerate identically)
skillsaw lint <ai-helpers clone>     # exit 0, 0 errors / 0 warnings
                                     # (41 plugins, 106 skills, 45 rules)
```

Note: the ai-helpers run needs the skillsaw venv `bin/` on PATH — the repo's
`plugins-doc-up-to-date` rule re-invokes `skillsaw` by name and reports a
spurious error if only the absolute venv binary is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened marketplace configuration validation with defensive checks to gracefully handle malformed plugin data and prevent unexpected crashes during plugin registration and autofix operations
  * Enhanced plugin detection and registration logic to safely handle corrupted or non-standard data structures in configuration files, ensuring system stability and reliable autofix behavior in edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->