### PR TITLE
Add repository quality grade and shields.io badge support

### DIFF
--- a/.skillsaw-badge.json
+++ b/.skillsaw-badge.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "label": "skillsaw",
+  "message": "A-",
+  "color": "brightgreen",
+  "grade": "A-",
+  "density": 2.37,
+  "errors": 0,
+  "warnings": 0,
+  "info": 44,
+  "contentTokens": 18534,
+  "skillsawVersion": "0.13.1"
+}

--- a/.skillsaw-badge.json
+++ b/.skillsaw-badge.json
@@ -3,6 +3,7 @@
   "label": "skillsaw",
   "message": "A-",
   "color": "brightgreen",
+  "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill-rule=\"evenodd\" fill=\"#fff\" d=\"M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z\"/></svg>",
   "grade": "A-",
   "density": 2.37,
   "errors": 0,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VENV := .venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 
-.PHONY: help venv format lint test clean update apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile
+.PHONY: help venv format lint test clean update apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile badge self-lint
 
 help:
 	@echo "Available targets:"
@@ -49,7 +49,10 @@ generate-example: $(VENV)/bin/activate
 generate-docs: $(VENV)/bin/activate
 	$(PYTHON) scripts/generate-docs.py
 
-self-lint: $(VENV)/bin/activate
+badge: $(VENV)/bin/activate
+	$(VENV)/bin/skillsaw badge .
+
+self-lint: $(VENV)/bin/activate badge
 	$(VENV)/bin/skillsaw lint .
 
 update: apm generate-example generate-docs generate-site-content format self-lint

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Keep your skills sharp. 40+ rules catch weak language, contradictions, attention dead zones, and structural issues — then auto-fix them.
 
-[![PyPI version](https://badge.fury.io/py/skillsaw.svg)](https://badge.fury.io/py/skillsaw) [![PyPI Downloads](https://img.shields.io/pypi/dm/skillsaw)](https://pypi.org/project/skillsaw/) [![Tests](https://github.com/stbenjam/skillsaw/workflows/Tests/badge.svg)](https://github.com/stbenjam/skillsaw/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/stbenjam/skillsaw/branch/main/graph/badge.svg)](https://codecov.io/gh/stbenjam/skillsaw) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![PyPI version](https://badge.fury.io/py/skillsaw.svg)](https://badge.fury.io/py/skillsaw) [![PyPI Downloads](https://img.shields.io/pypi/dm/skillsaw)](https://pypi.org/project/skillsaw/) [![Tests](https://github.com/stbenjam/skillsaw/workflows/Tests/badge.svg)](https://github.com/stbenjam/skillsaw/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/stbenjam/skillsaw/branch/main/graph/badge.svg)](https://codecov.io/gh/stbenjam/skillsaw) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![skillsaw grade](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fstbenjam%2Fskillsaw%2Fmain%2F.skillsaw-badge.json)](https://skillsaw.org/)
 
 </td>
 </tr></table>

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Keep your skills sharp. 40+ rules catch weak language, contradictions, attention
   - [Ignoring the baseline](#ignoring-the-baseline)
   - [Stale entries](#stale-entries)
   - [Baseline and fix](#baseline-and-fix)
+- [Quality Grade & Badge](#quality-grade-badge)
+  - [README badge](#readme-badge)
 - [Supply Chain Protection](#supply-chain-protection)
 - [Builtin Rules](#builtin-rules)
 - [Autofixing](#autofixing)
@@ -484,6 +486,63 @@ resolved violations.
 The `skillsaw fix` command operates on all violations regardless of the
 baseline. The baseline only affects `lint` reporting and exit codes — if
 you explicitly ask to fix, everything is eligible.
+
+## Quality Grade & Badge
+
+Every lint run computes a letter grade (A+ through F) summarizing
+repository quality, shown in the text summary and in the JSON report
+under `summary.grade`.
+
+**How it's calculated:** weighted warning-and-info density sets your
+letter; errors knock letters off.
+
+- **Density sets the letter.** Warnings (weight 1.0) and info-level
+  violations (weight 0.1) are counted per 10,000 estimated content
+  tokens, so a large marketplace isn't penalized for having more
+  surface area than a single skill. Each density unit costs one notch
+  (A+ → A → A- → …). Repositories smaller than 10K tokens are graded
+  as one unit.
+- **Errors knock off whole letters** regardless of repository size:
+  one error costs a letter, five or more cost two, twenty-five or more
+  cost three. A broken manifest can't be diluted by prose volume.
+- **Zero violations is an A+.**
+
+The weights are tunable in `.skillsaw.yaml`:
+
+```yaml
+grade:
+  warning-weight: 1.0
+  info-weight: 0.1
+  label: skillsaw   # badge label text
+```
+
+### README badge
+
+`skillsaw badge` grades the repository, writes `.skillsaw-badge.json`
+(a [shields.io](https://shields.io) compatible payload), and prints the
+markdown to embed the badge:
+
+```bash
+skillsaw badge
+```
+
+Commit `.skillsaw-badge.json` and add the printed markdown to your
+README. The file works with both shields.io styles:
+
+- **[Endpoint badge](https://shields.io/badges/endpoint-badge)**
+  (recommended — color tracks the grade automatically):
+  `https://img.shields.io/endpoint?url=<raw-url-to-.skillsaw-badge.json>`
+- **[Dynamic JSON badge](https://shields.io/badges/dynamic-json-badge)**
+  (query `$.grade` from the same file):
+  `https://img.shields.io/badge/dynamic/json?url=<raw-url>&query=%24.grade&label=skillsaw`
+
+When the repository has a GitHub remote, the printed markdown already
+contains the correct `raw.githubusercontent.com` URL. Regenerate the
+badge file in CI (or a pre-push hook) so it stays current.
+
+Unlike `lint`, the badge **ignores any baseline** — the published grade
+reflects every violation, so a baselined repository can't advertise a
+clean bill of health it doesn't have.
 
 ## Supply Chain Protection
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,6 +91,15 @@ Generate or update the baseline file from current violations
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file |  |
 
+## `skillsaw badge`
+
+Grade the repository and write a shields.io badge JSON file
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
+| `-o`, `--output` | Badge JSON output path (default: .skillsaw-badge.json in the repository root) |  |
+
 ## `skillsaw add`
 
 Scaffold marketplaces, plugins, skills, commands, agents, and hooks

--- a/skills/skillsaw-onboard/SKILL.md
+++ b/skills/skillsaw-onboard/SKILL.md
@@ -250,7 +250,52 @@ If a `Makefile` already exists, append the targets. If not, create one. In
 either case, do not overwrite existing `lint` or `lint-fix` targets — if they
 already exist, ask the user what names to use instead (e.g. `skillsaw-lint`).
 
-## Step 9: Final verification
+## Step 9: README badge
+
+Ask the user if they want a skillsaw grade badge in their README. The badge
+shows the repository's letter grade (A+ through F) and updates whenever the
+badge file is regenerated. If they decline, skip to Step 10.
+
+If they agree:
+
+1. Run `skillsaw badge`. This writes `.skillsaw-badge.json` to the repo root
+   and prints ready-to-paste markdown for two shields.io badge styles.
+2. Add the **endpoint badge** markdown (the variant whose color tracks the
+   grade automatically) to `README.md`:
+   - If the README already has badges (look for `img.shields.io`,
+     `badge.svg`, or similar image links near the top), add the skillsaw
+     badge on the same line or block as the existing badges.
+   - If there are no badges yet, add it on its own line directly under the
+     top-level heading.
+3. The badge must link to `https://skillsaw.org/` — the markdown printed by
+   `skillsaw badge` already does this; keep that link when placing it.
+4. If `skillsaw badge` printed a URL placeholder (no GitHub remote detected),
+   tell the user the badge will render once `.skillsaw-badge.json` is
+   published at a URL shields.io can fetch, and leave the placeholder for
+   them to fill in.
+
+If Makefile targets were set up in Step 8, wire badge regeneration into them:
+add a `badge` target using the same command prefix as the other targets, and
+make `lint` depend on it so every lint run refreshes the badge file. The
+`badge` target runs first and always succeeds, so the file is regenerated even
+when the lint fails:
+
+```makefile
+.PHONY: badge
+badge:
+	uvx skillsaw==$(SKILLSAW_VERSION) badge
+
+lint: badge
+	uvx skillsaw==$(SKILLSAW_VERSION) --strict
+```
+
+Tell the user the badge reflects the committed `.skillsaw-badge.json`, so it
+should be regenerated when content changes — run `make lint` (or `skillsaw
+badge` directly), or add it to CI (e.g. a workflow step that runs `skillsaw
+badge` and commits the file if it changed). The badge ignores any baseline:
+it always reflects the repository's true grade.
+
+## Step 10: Final verification
 
 Run `skillsaw` one final time and confirm the repo passes (exit 0). Summarize
 what was done:
@@ -261,11 +306,13 @@ what was done:
 - Number baselined
 - CI setup (if any)
 - Makefile targets (if any)
+- README badge (if added)
 - Files created or modified
 
 Remind the user to commit all new/changed files:
 - `.skillsaw.yaml` (if created)
 - `.skillsaw-baseline.json` (if created)
+- `.skillsaw-badge.json` and `README.md` (if the badge was set up)
 - `.github/workflows/lint.yml` (if created)
 - `.github/workflows/lint-review.yml` (if created)
 - `.gitlab-ci.yml` (if modified)

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -25,7 +25,18 @@ from .formatters import (
 )
 from . import __version__
 
-_SUBCOMMANDS = {"lint", "init", "list-rules", "docs", "add", "fix", "tree", "baseline", "explain"}
+_SUBCOMMANDS = {
+    "lint",
+    "init",
+    "list-rules",
+    "docs",
+    "add",
+    "fix",
+    "tree",
+    "baseline",
+    "explain",
+    "badge",
+}
 
 
 def _get_version() -> str:
@@ -394,6 +405,36 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         type=Path,
         help="Path to .skillsaw.yaml config file",
     )
+    # --- badge ---
+    badge_parser = subparsers.add_parser(
+        "badge",
+        help="Grade the repository and write a shields.io badge JSON file",
+        description="Lint the repository, compute its letter grade, write a "
+        "shields.io-compatible badge file, and print the markdown to embed it. "
+        "Ignores any baseline so the published grade reflects all violations.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    badge_parser.add_argument(
+        "path",
+        nargs="?",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to repository (default: current directory)",
+    )
+    badge_parser.add_argument(
+        "-c",
+        "--config",
+        type=Path,
+        help="Path to .skillsaw.yaml config file (default: auto-discover)",
+    )
+    badge_parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Badge JSON output path (default: .skillsaw-badge.json in the repository root)",
+    )
+
     # --- add ---
     subparsers.add_parser(
         "add",
@@ -433,6 +474,8 @@ def main():
         _run_docs(args)
     elif args.command == "baseline":
         _run_baseline(args)
+    elif args.command == "badge":
+        _run_badge(args)
     elif args.command == "tree":
         _run_tree(args)
 
@@ -802,6 +845,13 @@ def _run_lint(args):
     unique_rules = _dedup_rules(all_rules)
     lint_duration = time.perf_counter() - lint_started
 
+    from .grade import compute_grade
+
+    content_tokens = sum(
+        block.estimate_tokens() for ctx in contexts for block in ctx.lint_tree.content_blocks()
+    )
+    grade = compute_grade(all_violations, content_tokens, config.grade)
+
     stdout_output = format_report(
         args.fmt,
         all_violations,
@@ -811,6 +861,7 @@ def _run_lint(args):
         verbose=args.verbose,
         baseline_suppressed=baseline_suppressed,
         duration=lint_duration,
+        grade=grade,
     )
     print(stdout_output)
 
@@ -826,6 +877,7 @@ def _run_lint(args):
                 verbose=args.verbose,
                 baseline_suppressed=baseline_suppressed,
                 duration=lint_duration,
+                grade=grade,
             )
         out_path = Path(output_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1409,6 +1461,141 @@ def _run_baseline(args):
 
     save_baseline(output_path, baseline)
     print(f"Baselined {len(baseline.violations)} violation(s) to {output_path}")
+    sys.exit(0)
+
+
+_BADGE_FILENAME = ".skillsaw-badge.json"
+
+
+def _github_raw_url(root_path: Path, badge_path: Path):
+    """Best-effort raw.githubusercontent.com URL for the badge file.
+
+    Returns None when the repo has no recognizable GitHub remote.
+    """
+    import re
+    import subprocess
+
+    def _git(*argv):
+        result = subprocess.run(
+            ["git", "-C", str(root_path), *argv],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    remote = _git("config", "--get", "remote.origin.url")
+    if not remote:
+        return None
+    m = re.search(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?/?$", remote)
+    if not m:
+        return None
+    owner, repo = m.group(1), m.group(2)
+
+    branch = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    if branch and branch.startswith("origin/"):
+        branch = branch[len("origin/") :]
+    if not branch:
+        branch = _git("rev-parse", "--abbrev-ref", "HEAD") or "main"
+
+    try:
+        rel = badge_path.resolve().relative_to(root_path.resolve())
+    except ValueError:
+        rel = Path(badge_path.name)
+    return f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{rel.as_posix()}"
+
+
+def _run_badge(args):
+    import json
+    from urllib.parse import quote
+
+    if not args.path.exists():
+        print(f"Error: Path not found: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    context = RepositoryContext(args.path)
+
+    if args.config:
+        config_path = args.config
+        if not config_path.exists():
+            print(f"Error: Config file not found: {config_path}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        config_path = find_config(args.path)
+
+    if config_path:
+        try:
+            config = LinterConfig.from_file(config_path)
+        except ValueError as e:
+            print(f"Error loading config: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        config = LinterConfig.default()
+
+    # No baseline on purpose — the published grade must reflect every
+    # violation, not just the ones newer than the baseline.
+    try:
+        linter = Linter(context, config)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    rule_progress = _RuleProgress(args)
+    try:
+        violations = linter.run(progress=rule_progress)
+    finally:
+        rule_progress.clear()
+
+    from .grade import compute_grade
+
+    content_tokens = sum(b.estimate_tokens() for b in context.lint_tree.content_blocks())
+    grade = compute_grade(violations, content_tokens, config.grade)
+
+    badge_path = args.output or (context.root_path / _BADGE_FILENAME)
+    badge_path.parent.mkdir(parents=True, exist_ok=True)
+    badge_path.write_text(
+        json.dumps(grade.badge_json(_get_version()), indent=2) + "\n", encoding="utf-8"
+    )
+
+    c = _ansi_colors()
+    grade_color = (
+        c["green"]
+        if grade.letter[0] in "AB"
+        else (c["yellow"] if grade.letter[0] == "C" else c["red"])
+    )
+    print(f"Grade: {grade_color}{c['bold']}{grade.letter}{c['reset']}")
+    print(
+        f"  {grade.errors} error(s), {grade.warnings} warning(s), {grade.info} info"
+        f" across ~{grade.content_tokens:,} content tokens"
+        f" ({grade.density:.2f} weighted violations per 10k tokens)"
+    )
+    print(f"\nBadge written to {badge_path}")
+
+    raw_url = _github_raw_url(context.root_path, badge_path)
+    if raw_url is None:
+        raw_url = "<RAW_URL_TO_YOUR_BADGE_JSON>"
+        print(
+            "\nNo GitHub remote detected — replace the URL placeholder after"
+            " publishing the badge file somewhere shields.io can fetch it."
+        )
+    encoded = quote(raw_url, safe="")
+    label = quote(grade.settings.label, safe="")
+
+    print(f"\n{c['bold']}Markdown for your README:{c['reset']}")
+    print(f"\n  Dynamic JSON badge (https://shields.io/badges/dynamic-json-badge):")
+    print(
+        f"  [![skillsaw grade](https://img.shields.io/badge/dynamic/json"
+        f"?url={encoded}&query=%24.grade&label={label}&color={grade.color})]"
+        f"(https://github.com/stbenjam/skillsaw)"
+    )
+    print(f"\n  Endpoint badge (color updates with the grade automatically):")
+    print(
+        f"  [![skillsaw grade](https://img.shields.io/endpoint?url={encoded})]"
+        f"(https://github.com/stbenjam/skillsaw)"
+    )
+    print(
+        f"\nCommit {badge_path.name} and regenerate it (e.g. in CI) whenever"
+        " the repository changes."
+    )
     sys.exit(0)
 
 

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -1476,11 +1476,14 @@ def _github_raw_url(root_path: Path, badge_path: Path):
     import subprocess
 
     def _git(*argv):
-        result = subprocess.run(
-            ["git", "-C", str(root_path), *argv],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(root_path), *argv],
+                capture_output=True,
+                text=True,
+            )
+        except OSError:
+            return None
         return result.stdout.strip() if result.returncode == 0 else None
 
     remote = _git("config", "--get", "remote.origin.url")
@@ -1577,15 +1580,18 @@ def _run_badge(args):
             "\nNo GitHub remote detected — replace the URL placeholder after"
             " publishing the badge file somewhere shields.io can fetch it."
         )
+    from .grade import logo_data_uri
+
     encoded = quote(raw_url, safe="")
     label = quote(grade.settings.label, safe="")
+    logo = quote(logo_data_uri(), safe="")
 
     print(f"\n{c['bold']}Markdown for your README:{c['reset']}")
     print(f"\n  Dynamic JSON badge (https://shields.io/badges/dynamic-json-badge):")
     print(
         f"  [![skillsaw grade](https://img.shields.io/badge/dynamic/json"
-        f"?url={encoded}&query=%24.grade&label={label}&color={grade.color})]"
-        f"(https://skillsaw.org/)"
+        f"?url={encoded}&query=%24.grade&label={label}&color={grade.color}"
+        f"&logo={logo})](https://skillsaw.org/)"
     )
     print(f"\n  Endpoint badge (color updates with the grade automatically):")
     print(

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -1585,12 +1585,12 @@ def _run_badge(args):
     print(
         f"  [![skillsaw grade](https://img.shields.io/badge/dynamic/json"
         f"?url={encoded}&query=%24.grade&label={label}&color={grade.color})]"
-        f"(https://github.com/stbenjam/skillsaw)"
+        f"(https://skillsaw.org/)"
     )
     print(f"\n  Endpoint badge (color updates with the grade automatically):")
     print(
         f"  [![skillsaw grade](https://img.shields.io/endpoint?url={encoded})]"
-        f"(https://github.com/stbenjam/skillsaw)"
+        f"(https://skillsaw.org/)"
     )
     print(
         f"\nCommit {badge_path.name} and regenerate it (e.g. in CI) whenever"

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Set, Tuple, TYPE_CHECKING
 from dataclasses import dataclass, field
 
+from .grade import GradeSettings
+
 if TYPE_CHECKING:
     from .context import RepositoryContext
 
@@ -69,6 +71,7 @@ class LinterConfig:
     content_paths: List[str] = field(default_factory=list)
     strict: bool = False
     llm: LLMSettings = field(default_factory=LLMSettings)
+    grade: GradeSettings = field(default_factory=GradeSettings)
     config_dir: Optional[Path] = None
 
     @classmethod
@@ -149,6 +152,11 @@ class LinterConfig:
         else:
             raise ValueError(f"'strict' must be a boolean, got {type(raw_strict).__name__}")
 
+        raw_grade = data.get("grade")
+        grade_settings = (
+            GradeSettings.from_dict(raw_grade) if raw_grade is not None else GradeSettings()
+        )
+
         llm_data = data.get("llm", {})
         llm_settings = LLMSettings(
             model=llm_data.get("model", LLMSettings.model),
@@ -166,6 +174,7 @@ class LinterConfig:
             content_paths=data.get("content-paths", []),
             strict=strict,
             llm=llm_settings,
+            grade=grade_settings,
             config_dir=config_path.resolve().parent,
         )
 

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -85,6 +85,7 @@ def format_report(
     verbose: bool = False,
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
+    grade=None,
 ) -> str:
     """
     Format lint results in the specified format.
@@ -99,18 +100,19 @@ def format_report(
         baseline_suppressed: Number of violations suppressed by baseline
         duration: Wall-clock lint time in seconds (text and json formats only;
             sarif/code-climate schemas have no place for it)
+        grade: Optional Grade for the run (text and json formats only)
     """
     if fmt == "text":
         from .text import format_text
 
         return format_text(
-            violations, context, rules, version, verbose, baseline_suppressed, duration
+            violations, context, rules, version, verbose, baseline_suppressed, duration, grade
         )
     elif fmt == "json":
         from .json_fmt import format_json
 
         return format_json(
-            violations, context, rules, version, verbose, baseline_suppressed, duration
+            violations, context, rules, version, verbose, baseline_suppressed, duration, grade
         )
     elif fmt == "sarif":
         from .sarif import format_sarif

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -15,6 +15,7 @@ def format_json(
     verbose: bool = False,
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
+    grade=None,
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
@@ -62,5 +63,8 @@ def format_json(
             "baseline_suppressed": baseline_suppressed,
         },
     }
+
+    if grade is not None:
+        report["summary"]["grade"] = grade.to_dict()
 
     return json.dumps(report, indent=2)

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -28,6 +28,7 @@ def format_text(
     verbose: bool = False,
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
+    grade=None,
 ) -> str:
     no_color = "NO_COLOR" in os.environ
     red = "" if no_color else "\033[91m"
@@ -95,6 +96,12 @@ def format_text(
     if baseline_suppressed:
         dim = "" if no_color else "\033[2m"
         output.append(f"  {dim}Baseline: {baseline_suppressed} suppressed{reset}")
+    if grade is not None:
+        grade_color = {"A": green, "B": green, "C": yellow, "D": red, "F": red}[grade.letter[0]]
+        output.append(
+            f"  Grade:    {grade_color}{bold}{grade.letter}{reset} "
+            f"({grade.density:.2f} weighted violations per 10k tokens)"
+        )
 
     if errors == 0 and warnings == 0:
         output.append(f"\n{green}{bold}✓ All checks passed!{reset}")

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -102,6 +102,12 @@ def format_text(
             f"  Grade:    {grade_color}{bold}{grade.letter}{reset} "
             f"({grade.density:.2f} weighted violations per 10k tokens)"
         )
+        if grade.info and not verbose:
+            dim = "" if no_color else "\033[2m"
+            output.append(
+                f"  {dim}{grade.info} info-level violation(s) count toward"
+                f" the grade — run with -v to see them{reset}"
+            )
 
     if errors == 0 and warnings == 0:
         output.append(f"\n{green}{bold}✓ All checks passed!{reset}")

--- a/src/skillsaw/grade.py
+++ b/src/skillsaw/grade.py
@@ -35,6 +35,26 @@ TOKENS_PER_UNIT = 10_000
 # Error-count brackets -> whole letters knocked off.
 _ERROR_BRACKETS = ((25, 3), (5, 2), (1, 1))
 
+# Minimal circular-saw-blade logo (8 hooked teeth, arbor hole), white so it
+# reads on the dark label half of the badge. Endpoint badges take the raw
+# SVG via logoSvg; dynamic-json badges need it base64-encoded in the URL.
+LOGO_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+    '<path fill-rule="evenodd" fill="#fff" d="M20.0 12.0L22.3 15.8L19.3 15.3'
+    "L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7"
+    "L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5"
+    "L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2Z"
+    'M15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z"/></svg>'
+)
+
+
+def logo_data_uri() -> str:
+    """data: URI for the logo, for shields.io URL ``logo=`` parameters."""
+    import base64
+
+    return "data:image/svg+xml;base64," + base64.b64encode(LOGO_SVG.encode()).decode()
+
+
 # shields.io named colors per letter.
 _LETTER_COLORS = {
     "A": "brightgreen",
@@ -103,6 +123,7 @@ class Grade:
             "label": self.settings.label,
             "message": self.letter,
             "color": self.color,
+            "logoSvg": LOGO_SVG,
             "grade": self.letter,
             "density": round(self.density, 2),
             "errors": self.errors,

--- a/src/skillsaw/grade.py
+++ b/src/skillsaw/grade.py
@@ -1,0 +1,151 @@
+"""
+Repository quality grade.
+
+The grade condenses a lint run into a letter (A+ .. F) suitable for a
+README badge:
+
+- **Warning/info density sets the letter.** Weighted violations
+  (warnings at full weight, info lightly) are normalized per 10,000
+  estimated content tokens, so a large marketplace is not penalized for
+  having more surface area than a single skill. One density unit costs
+  one notch (A+ -> A -> A- -> ...).
+- **Errors knock off whole letters.** Errors are rare and structural —
+  a broken manifest is not diluted by prose volume, so any error drops
+  the grade a full letter regardless of repository size.
+- Repositories smaller than one 10K-token unit are graded as one unit,
+  so a tiny skill with one warning loses one notch rather than the
+  whole scale.
+
+Token estimates come from ``ContentBlock.estimate_tokens()`` (prose
+blocks only); structured JSON config blocks are not content an agent
+reads linearly and are excluded from the denominator.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .rule import RuleViolation, Severity
+
+# One density unit per notch; a whole letter is three notches.
+LETTER_NOTCHES = ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "F"]
+_NOTCHES_PER_LETTER = 3
+
+TOKENS_PER_UNIT = 10_000
+
+# Error-count brackets -> whole letters knocked off.
+_ERROR_BRACKETS = ((25, 3), (5, 2), (1, 1))
+
+# shields.io named colors per letter.
+_LETTER_COLORS = {
+    "A": "brightgreen",
+    "B": "green",
+    "C": "yellow",
+    "D": "orange",
+    "F": "red",
+}
+
+
+@dataclass
+class GradeSettings:
+    """Tunable grade parameters (``grade:`` section of .skillsaw.yaml)."""
+
+    warning_weight: float = 1.0
+    info_weight: float = 0.1
+    label: str = "skillsaw"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GradeSettings":
+        if not isinstance(data, dict):
+            raise ValueError(f"'grade' must be a mapping, got {type(data).__name__}")
+        settings = cls()
+        for yaml_key, attr in (
+            ("warning-weight", "warning_weight"),
+            ("info-weight", "info_weight"),
+        ):
+            if yaml_key in data:
+                value = data[yaml_key]
+                if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+                    raise ValueError(f"'grade.{yaml_key}' must be a non-negative number")
+                setattr(settings, attr, float(value))
+        if "label" in data:
+            if not isinstance(data["label"], str) or not data["label"].strip():
+                raise ValueError("'grade.label' must be a non-empty string")
+            settings.label = data["label"].strip()
+        return settings
+
+
+@dataclass
+class Grade:
+    letter: str
+    density: float
+    errors: int
+    warnings: int
+    info: int
+    content_tokens: int
+    settings: GradeSettings = field(default_factory=GradeSettings)
+
+    @property
+    def color(self) -> str:
+        return _LETTER_COLORS[self.letter[0]]
+
+    def to_dict(self) -> dict:
+        return {
+            "letter": self.letter,
+            "density": round(self.density, 2),
+            "content_tokens": self.content_tokens,
+        }
+
+    def badge_json(self, version: str) -> dict:
+        """shields.io endpoint-schema payload, with extra fields for
+        dynamic-json badges (query ``$.message`` or ``$.grade``)."""
+        return {
+            "schemaVersion": 1,
+            "label": self.settings.label,
+            "message": self.letter,
+            "color": self.color,
+            "grade": self.letter,
+            "density": round(self.density, 2),
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "info": self.info,
+            "contentTokens": self.content_tokens,
+            "skillsawVersion": version,
+        }
+
+
+def _error_letters(errors: int) -> int:
+    for threshold, letters in _ERROR_BRACKETS:
+        if errors >= threshold:
+            return letters
+    return 0
+
+
+def compute_grade(
+    violations: List[RuleViolation],
+    content_tokens: int,
+    settings: Optional[GradeSettings] = None,
+) -> Grade:
+    """Grade a lint run. ``content_tokens`` is the summed token estimate
+    of every ContentBlock in the lint tree(s)."""
+    settings = settings or GradeSettings()
+
+    errors = sum(1 for v in violations if v.severity == Severity.ERROR)
+    warnings = sum(1 for v in violations if v.severity == Severity.WARNING)
+    info = sum(1 for v in violations if v.severity == Severity.INFO)
+
+    units = max(content_tokens / TOKENS_PER_UNIT, 1.0)
+    density = (settings.warning_weight * warnings + settings.info_weight * info) / units
+
+    last = len(LETTER_NOTCHES) - 1
+    notch = min(int(density), last)
+    notch = min(notch + _NOTCHES_PER_LETTER * _error_letters(errors), last)
+
+    return Grade(
+        letter=LETTER_NOTCHES[notch],
+        density=density,
+        errors=errors,
+        warnings=warnings,
+        info=info,
+        content_tokens=content_tokens,
+        settings=settings,
+    )

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -136,6 +136,7 @@ def test_badge_json_shape():
     assert payload["info"] == 3
     assert payload["contentTokens"] == 20_000
     assert payload["skillsawVersion"] == "1.2.3"
+    assert payload["logoSvg"].startswith("<svg")
 
 
 # ── CLI integration ──────────────────────────────────────────────
@@ -198,6 +199,9 @@ def test_badge_writes_shields_json(tmp_path):
     assert "query=%24.grade" in result.stdout
     assert "img.shields.io/endpoint" in result.stdout
     assert "(https://skillsaw.org/)" in result.stdout
+    # Saw-blade logo: embedded in the dynamic badge URL (endpoint badges get
+    # it from the logoSvg field in the JSON payload instead)
+    assert "logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2C" in result.stdout
 
 
 def test_badge_uses_github_remote_for_url(tmp_path):

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -157,6 +157,19 @@ def test_lint_text_shows_grade(tmp_path):
     assert "A+" in r["stdout"]
 
 
+def test_lint_text_hints_at_hidden_info_violations(tmp_path):
+    # The clean fixture has info-level violations that affect the grade
+    # but are hidden without -v — the summary must say so.
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    quiet = run_lint(repo, fmt="text", verbose=False)
+    assert "count toward the grade" in quiet["stdout"]
+    assert "run with -v" in quiet["stdout"]
+
+    # With -v the info list is already shown; no hint needed.
+    loud = run_lint(repo, fmt="text", verbose=True)
+    assert "run with -v" not in loud["stdout"]
+
+
 def run_badge(path, *extra_args):
     result = subprocess.run(
         [sys.executable, "-m", "skillsaw", "badge", str(path), *extra_args],

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,0 +1,251 @@
+"""
+Tests for the repository quality grade (skillsaw.grade) and the
+`skillsaw badge` subcommand.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from skillsaw.grade import Grade, GradeSettings, compute_grade, LETTER_NOTCHES
+from skillsaw.rule import RuleViolation, Severity
+
+from .test_integration import FIXTURES, copy_fixture, run_lint, summary
+
+
+def _violations(errors=0, warnings=0, info=0):
+    out = []
+    for i in range(errors):
+        out.append(RuleViolation("test-error", Severity.ERROR, f"error {i}"))
+    for i in range(warnings):
+        out.append(RuleViolation("test-warning", Severity.WARNING, f"warning {i}"))
+    for i in range(info):
+        out.append(RuleViolation("test-info", Severity.INFO, f"info {i}"))
+    return out
+
+
+# ── compute_grade ────────────────────────────────────────────────
+
+
+def test_zero_violations_is_a_plus():
+    grade = compute_grade([], content_tokens=100)
+    assert grade.letter == "A+"
+    assert grade.density == 0.0
+    assert grade.color == "brightgreen"
+
+
+def test_density_normalizes_by_tokens():
+    # 17 warnings in a huge marketplace is near-pristine...
+    big = compute_grade(_violations(warnings=17), content_tokens=5_000_000)
+    assert big.letter == "A+"
+    # ...but 17 warnings in one small skill is a mess.
+    small = compute_grade(_violations(warnings=17), content_tokens=2_000)
+    assert small.letter == "F"
+
+
+def test_small_repos_floor_at_one_unit():
+    # A tiny skill with one warning loses one notch, not the whole scale.
+    grade = compute_grade(_violations(warnings=1), content_tokens=500)
+    assert grade.letter == "A"
+    assert grade.density == 1.0
+
+
+def test_one_density_unit_per_notch():
+    for units, letter in [(0, "A+"), (1, "A"), (2, "A-"), (3, "B+"), (11, "F"), (50, "F")]:
+        grade = compute_grade(_violations(warnings=units), content_tokens=10_000)
+        assert grade.letter == letter, f"{units} warnings/10k tokens -> {grade.letter}"
+
+
+def test_info_calibration_anchor():
+    # 1 info per 10k tokens must not dent the score.
+    assert compute_grade(_violations(info=1), content_tokens=10_000).letter == "A+"
+    # ~10 info per 10k tokens takes A+ to A.
+    assert compute_grade(_violations(info=10), content_tokens=10_000).letter == "A"
+
+
+def test_errors_knock_off_whole_letters():
+    # Errors are not diluted by repository size.
+    tokens = 5_000_000
+    assert compute_grade(_violations(errors=1), content_tokens=tokens).letter == "B+"
+    assert compute_grade(_violations(errors=5), content_tokens=tokens).letter == "C+"
+    assert compute_grade(_violations(errors=25), content_tokens=tokens).letter == "D+"
+
+
+def test_errors_stack_with_density():
+    # One warning unit (A) plus one error letter (3 notches) -> B.
+    grade = compute_grade(_violations(errors=1, warnings=1), content_tokens=10_000)
+    assert grade.letter == "B"
+
+
+def test_grade_floors_at_f():
+    grade = compute_grade(_violations(errors=100, warnings=100), content_tokens=100)
+    assert grade.letter == "F"
+    assert grade.color == "red"
+
+
+def test_letter_notches_are_well_formed():
+    assert LETTER_NOTCHES[0] == "A+"
+    assert LETTER_NOTCHES[-1] == "F"
+    for letter in LETTER_NOTCHES:
+        assert Grade(letter, 0, 0, 0, 0, 0).color  # every notch has a color
+
+
+# ── GradeSettings ────────────────────────────────────────────────
+
+
+def test_custom_weights():
+    settings = GradeSettings.from_dict({"warning-weight": 2.0, "info-weight": 0.5})
+    grade = compute_grade(_violations(warnings=1, info=2), content_tokens=10_000, settings=settings)
+    assert grade.density == 3.0
+    assert grade.letter == "B+"
+
+
+def test_zero_info_weight_ignores_info():
+    settings = GradeSettings.from_dict({"info-weight": 0})
+    grade = compute_grade(_violations(info=500), content_tokens=10_000, settings=settings)
+    assert grade.letter == "A+"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"warning-weight": -1},
+        {"warning-weight": "heavy"},
+        {"info-weight": True},
+        {"label": ""},
+        {"label": 7},
+        "not-a-mapping",
+    ],
+)
+def test_invalid_grade_settings_rejected(bad):
+    with pytest.raises(ValueError):
+        GradeSettings.from_dict(bad)
+
+
+def test_badge_json_shape():
+    grade = compute_grade(_violations(warnings=2, info=3), content_tokens=20_000)
+    payload = grade.badge_json("1.2.3")
+    assert payload["schemaVersion"] == 1
+    assert payload["label"] == "skillsaw"
+    assert payload["message"] == payload["grade"] == grade.letter
+    assert payload["color"] == grade.color
+    assert payload["errors"] == 0
+    assert payload["warnings"] == 2
+    assert payload["info"] == 3
+    assert payload["contentTokens"] == 20_000
+    assert payload["skillsawVersion"] == "1.2.3"
+
+
+# ── CLI integration ──────────────────────────────────────────────
+
+
+def test_lint_json_includes_grade(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    r = run_lint(repo)
+    grade = summary(r)["grade"]
+    assert grade["letter"] == "A+"
+    assert grade["content_tokens"] > 0
+    assert grade["density"] >= 0
+
+
+def test_lint_text_shows_grade(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    r = run_lint(repo, fmt="text")
+    assert "Grade:" in r["stdout"]
+    assert "A+" in r["stdout"]
+
+
+def run_badge(path, *extra_args):
+    result = subprocess.run(
+        [sys.executable, "-m", "skillsaw", "badge", str(path), *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result
+
+
+def test_badge_writes_shields_json(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    result = run_badge(repo)
+    assert result.returncode == 0, result.stderr
+
+    badge_file = repo / ".skillsaw-badge.json"
+    assert badge_file.exists()
+    payload = json.loads(badge_file.read_text())
+    assert payload["schemaVersion"] == 1
+    assert payload["message"] == "A+"
+    assert payload["color"] == "brightgreen"
+    assert payload["grade"] == "A+"
+
+    # README markdown for both shields.io badge styles
+    assert "img.shields.io/badge/dynamic/json" in result.stdout
+    assert "query=%24.grade" in result.stdout
+    assert "img.shields.io/endpoint" in result.stdout
+
+
+def test_badge_uses_github_remote_for_url(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:example/clean-plugin.git",
+        ],
+        check=True,
+    )
+    result = run_badge(repo)
+    assert result.returncode == 0, result.stderr
+    assert (
+        "raw.githubusercontent.com%2Fexample%2Fclean-plugin%2Fmain%2F.skillsaw-badge.json"
+        in result.stdout
+    )
+
+
+def test_badge_without_remote_prints_placeholder(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    result = run_badge(repo)
+    assert result.returncode == 0, result.stderr
+    assert "RAW_URL_TO_YOUR_BADGE_JSON" in result.stdout
+
+
+def test_badge_custom_output_path(tmp_path):
+    repo = copy_fixture("single-plugin/clean", tmp_path)
+    out = tmp_path / "out" / "badge.json"
+    result = run_badge(repo, "-o", str(out))
+    assert result.returncode == 0, result.stderr
+    assert json.loads(out.read_text())["schemaVersion"] == 1
+
+
+def test_badge_ignores_baseline(tmp_path):
+    repo = copy_fixture("single-plugin/broken", tmp_path)
+
+    # Baseline away every violation: lint goes green...
+    subprocess.run(
+        [sys.executable, "-m", "skillsaw", "baseline", str(repo)],
+        capture_output=True,
+        check=True,
+        timeout=60,
+    )
+    r = run_lint(repo)
+    assert summary(r)["errors"] == 0
+
+    # ...but the published badge still reflects the real state.
+    result = run_badge(repo)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads((repo / ".skillsaw-badge.json").read_text())
+    assert payload["errors"] > 0
+    assert payload["grade"] != "A+"
+
+
+def test_badge_missing_path_errors():
+    result = run_badge("/nonexistent/path")
+    assert result.returncode == 1
+    assert "Path not found" in result.stderr

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -180,10 +180,11 @@ def test_badge_writes_shields_json(tmp_path):
     assert payload["color"] == "brightgreen"
     assert payload["grade"] == "A+"
 
-    # README markdown for both shields.io badge styles
+    # README markdown for both shields.io badge styles, linking to skillsaw.org
     assert "img.shields.io/badge/dynamic/json" in result.stdout
     assert "query=%24.grade" in result.stdout
     assert "img.shields.io/endpoint" in result.stdout
+    assert "(https://skillsaw.org/)" in result.stdout
 
 
 def test_badge_uses_github_remote_for_url(tmp_path):


### PR DESCRIPTION
## Summary

Every lint run now computes a **letter grade (A+ through F)** summarizing repository quality, and a new `skillsaw badge` subcommand publishes it as a README badge via shields.io.

## Preview

What the badge looks like (static-badge mockups with the embedded saw-blade logo):

![A-](https://img.shields.io/badge/skillsaw-A---brightgreen.svg?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjZmZmIiBkPSJNMjAuMCAxMi4wTDIyLjMgMTUuOEwxOS4zIDE1LjNMMTcuNyAxNy43TDE2LjYgMjIuMEwxNC44IDE5LjVMMTIuMCAyMC4wTDguMiAyMi4zTDguNyAxOS4zTDYuMyAxNy43TDIuMCAxNi42TDQuNSAxNC44TDQuMCAxMi4wTDEuNyA4LjJMNC43IDguN0w2LjMgNi4zTDcuNCAyLjBMOS4yIDQuNUwxMi4wIDQuMEwxNS44IDEuN0wxNS4zIDQuN0wxNy43IDYuM0wyMi4wIDcuNEwxOS41IDkuMlpNMTUuMCAxMi4wQTMuMCAzLjAgMCAxIDAgOS4wIDEyLjBBMy4wIDMuMCAwIDEgMCAxNS4wIDEyLjBaIi8+PC9zdmc+) ![C](https://img.shields.io/badge/skillsaw-C-yellow.svg?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjZmZmIiBkPSJNMjAuMCAxMi4wTDIyLjMgMTUuOEwxOS4zIDE1LjNMMTcuNyAxNy43TDE2LjYgMjIuMEwxNC44IDE5LjVMMTIuMCAyMC4wTDguMiAyMi4zTDguNyAxOS4zTDYuMyAxNy43TDIuMCAxNi42TDQuNSAxNC44TDQuMCAxMi4wTDEuNyA4LjJMNC43IDguN0w2LjMgNi4zTDcuNCAyLjBMOS4yIDQuNUwxMi4wIDQuMEwxNS44IDEuN0wxNS4zIDQuN0wxNy43IDYuM0wyMi4wIDcuNEwxOS41IDkuMlpNMTUuMCAxMi4wQTMuMCAzLjAgMCAxIDAgOS4wIDEyLjBBMy4wIDMuMCAwIDEgMCAxNS4wIDEyLjBaIi8+PC9zdmc+) ![F](https://img.shields.io/badge/skillsaw-F-red.svg?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjZmZmIiBkPSJNMjAuMCAxMi4wTDIyLjMgMTUuOEwxOS4zIDE1LjNMMTcuNyAxNy43TDE2LjYgMjIuMEwxNC44IDE5LjVMMTIuMCAyMC4wTDguMiAyMi4zTDguNyAxOS4zTDYuMyAxNy43TDIuMCAxNi42TDQuNSAxNC44TDQuMCAxMi4wTDEuNyA4LjJMNC43IDguN0w2LjMgNi4zTDcuNCAyLjBMOS4yIDQuNUwxMi4wIDQuMEwxNS44IDEuN0wxNS4zIDQuN0wxNy43IDYuM0wyMi4wIDcuNEwxOS41IDkuMlpNMTUuMCAxMi4wQTMuMCAzLjAgMCAxIDAgOS4wIDEyLjBBMy4wIDMuMCAwIDEgMCAxNS4wIDEyLjBaIi8+PC9zdmc+)

**Scoring model** — one sentence: *weighted warning-and-info density sets your letter; errors knock letters off.*

- **Density sets the letter**: warnings (weight 1.0) and info violations (weight 0.1) per 10K estimated content tokens, one density unit per notch. Normalizing by content volume means a 5M-token marketplace with 17 warnings grades A+ while a single skill with 17 warnings grades F. Repos under 10K tokens are graded as one unit.
- **Errors knock off whole letters** regardless of size (1 → −1 letter, 5+ → −2, 25+ → −3), so a broken manifest can't be diluted by prose volume.
- **Zero violations = A+.** Weights and badge label are tunable via a new `grade:` config section.
- Token estimates come from `ContentBlock.estimate_tokens()` — prose only, JSON config blocks excluded from the denominator.

**Surfaces:**

- `Grade:` line in the text summary (with a hint when hidden info-level violations affected it), `summary.grade` in JSON output.
- `skillsaw badge` writes `.skillsaw-badge.json` — compatible with both [shields.io endpoint badges](https://shields.io/badges/endpoint-badge) (color tracks the grade, logo via `logoSvg`) and [dynamic JSON badges](https://shields.io/badges/dynamic-json-badge) (`query=$.grade`, logo embedded as a base64 data URI) — and prints paste-ready README markdown with the raw.githubusercontent.com URL derived from the git remote. The badge image links to https://skillsaw.org/.
- **The badge ignores baselines** so a baselined repo can't advertise a clean grade it doesn't have (regression-tested).
- The onboarding skill now offers badge setup: places the badge alongside existing README badges and wires a `badge` Makefile target as a `lint` dependency.
- Dogfooded: skillsaw's own badge (currently **A-**, 2.37 density, all info-level) is in the README badge row, regenerated by `make update` via the new `make badge` target.

## Test plan

- 27 new tests in `tests/test_grade.py`: density banding, the calibration anchors (1 info/10K tokens → no dent, 10 → A+ becomes A), error knockdown brackets, token floor, config validation, badge JSON shape (incl. logo), GitHub remote URL derivation, missing-git fallback, baseline-bypass regression, info-hint output.
- Full suite: 2089 passed, 15 skipped. `make lint` and `make update` clean.
- Canary: `openshift-eng/ai-helpers` lints exit 0 (grades A+ at 0.94 density).

🤖 Generated with [Claude Code](https://claude.com/claude-code)