### PR TITLE
Fix badge JSON rejected by shields.io endpoint schema validation

### DIFF
--- a/.skillsaw-badge.json
+++ b/.skillsaw-badge.json
@@ -3,12 +3,5 @@
   "label": "skillsaw",
   "message": "A-",
   "color": "brightgreen",
-  "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill-rule=\"evenodd\" fill=\"#fff\" d=\"M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z\"/></svg>",
-  "grade": "A-",
-  "density": 2.37,
-  "errors": 0,
-  "warnings": 0,
-  "info": 44,
-  "contentTokens": 18534,
-  "skillsawVersion": "0.13.1"
+  "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill-rule=\"evenodd\" fill=\"#fff\" d=\"M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z\"/></svg>"
 }

--- a/README.md
+++ b/README.md
@@ -533,8 +533,8 @@ README. The file works with both shields.io styles:
   (recommended — color tracks the grade automatically):
   `https://img.shields.io/endpoint?url=<raw-url-to-.skillsaw-badge.json>`
 - **[Dynamic JSON badge](https://shields.io/badges/dynamic-json-badge)**
-  (query `$.grade` from the same file):
-  `https://img.shields.io/badge/dynamic/json?url=<raw-url>&query=%24.grade&label=skillsaw`
+  (query `$.message` from the same file):
+  `https://img.shields.io/badge/dynamic/json?url=<raw-url>&query=%24.message&label=skillsaw`
 
 When the repository has a GitHub remote, the printed markdown already
 contains the correct `raw.githubusercontent.com` URL. Regenerate the

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -1555,9 +1555,7 @@ def _run_badge(args):
 
     badge_path = args.output or (context.root_path / _BADGE_FILENAME)
     badge_path.parent.mkdir(parents=True, exist_ok=True)
-    badge_path.write_text(
-        json.dumps(grade.badge_json(_get_version()), indent=2) + "\n", encoding="utf-8"
-    )
+    badge_path.write_text(json.dumps(grade.badge_json(), indent=2) + "\n", encoding="utf-8")
 
     c = _ansi_colors()
     grade_color = (
@@ -1590,7 +1588,7 @@ def _run_badge(args):
     print(f"\n  Dynamic JSON badge (https://shields.io/badges/dynamic-json-badge):")
     print(
         f"  [![skillsaw grade](https://img.shields.io/badge/dynamic/json"
-        f"?url={encoded}&query=%24.grade&label={label}&color={grade.color}"
+        f"?url={encoded}&query=%24.message&label={label}&color={grade.color}"
         f"&logo={logo})](https://skillsaw.org/)"
     )
     print(f"\n  Endpoint badge (color updates with the grade automatically):")

--- a/src/skillsaw/grade.py
+++ b/src/skillsaw/grade.py
@@ -115,22 +115,16 @@ class Grade:
             "content_tokens": self.content_tokens,
         }
 
-    def badge_json(self, version: str) -> dict:
-        """shields.io endpoint-schema payload, with extra fields for
-        dynamic-json badges (query ``$.message`` or ``$.grade``)."""
+    def badge_json(self) -> dict:
+        """shields.io endpoint-schema payload. The schema rejects unknown
+        properties, so only spec'd keys may appear here; dynamic-json
+        badges read the grade via ``query=$.message``."""
         return {
             "schemaVersion": 1,
             "label": self.settings.label,
             "message": self.letter,
             "color": self.color,
             "logoSvg": LOGO_SVG,
-            "grade": self.letter,
-            "density": round(self.density, 2),
-            "errors": self.errors,
-            "warnings": self.warnings,
-            "info": self.info,
-            "contentTokens": self.content_tokens,
-            "skillsawVersion": version,
         }
 
 

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -124,19 +124,34 @@ def test_invalid_grade_settings_rejected(bad):
         GradeSettings.from_dict(bad)
 
 
+# Every property the shields.io endpoint schema accepts — it rejects
+# payloads containing anything else, so badge_json() must never grow a
+# key outside this set.
+_SHIELDS_ENDPOINT_KEYS = {
+    "schemaVersion",
+    "label",
+    "message",
+    "color",
+    "labelColor",
+    "isError",
+    "namedLogo",
+    "logoSvg",
+    "logoColor",
+    "logoSize",
+    "style",
+    "cacheSeconds",
+}
+
+
 def test_badge_json_shape():
     grade = compute_grade(_violations(warnings=2, info=3), content_tokens=20_000)
-    payload = grade.badge_json("1.2.3")
+    payload = grade.badge_json()
     assert payload["schemaVersion"] == 1
     assert payload["label"] == "skillsaw"
-    assert payload["message"] == payload["grade"] == grade.letter
+    assert payload["message"] == grade.letter
     assert payload["color"] == grade.color
-    assert payload["errors"] == 0
-    assert payload["warnings"] == 2
-    assert payload["info"] == 3
-    assert payload["contentTokens"] == 20_000
-    assert payload["skillsawVersion"] == "1.2.3"
     assert payload["logoSvg"].startswith("<svg")
+    assert set(payload) <= _SHIELDS_ENDPOINT_KEYS
 
 
 # ── CLI integration ──────────────────────────────────────────────
@@ -192,11 +207,11 @@ def test_badge_writes_shields_json(tmp_path):
     assert payload["schemaVersion"] == 1
     assert payload["message"] == "A+"
     assert payload["color"] == "brightgreen"
-    assert payload["grade"] == "A+"
+    assert set(payload) <= _SHIELDS_ENDPOINT_KEYS
 
     # README markdown for both shields.io badge styles, linking to skillsaw.org
     assert "img.shields.io/badge/dynamic/json" in result.stdout
-    assert "query=%24.grade" in result.stdout
+    assert "query=%24.message" in result.stdout
     assert "img.shields.io/endpoint" in result.stdout
     assert "(https://skillsaw.org/)" in result.stdout
     # Saw-blade logo: embedded in the dynamic badge URL (endpoint badges get
@@ -255,12 +270,12 @@ def test_badge_ignores_baseline(tmp_path):
     r = run_lint(repo)
     assert summary(r)["errors"] == 0
 
-    # ...but the published badge still reflects the real state.
+    # ...but the published badge still reflects the real state. The repo
+    # has errors, so the error knockdown caps it at B+ or worse.
     result = run_badge(repo)
     assert result.returncode == 0, result.stderr
     payload = json.loads((repo / ".skillsaw-badge.json").read_text())
-    assert payload["errors"] > 0
-    assert payload["grade"] != "A+"
+    assert payload["message"][0] != "A"
 
 
 def test_badge_missing_path_errors():


### PR DESCRIPTION
## Summary

Follow-up to #296. shields.io strictly validates endpoint-badge payloads and rejects unknown properties, so the extra metadata in `.skillsaw-badge.json` (`grade`, `density`, `errors`, `warnings`, `info`, `contentTokens`, `skillsawVersion`) broke the badge: it rendered as **"custom badge: invalid properties"** instead of the grade.

- `badge_json()` now emits only spec'd endpoint keys: `schemaVersion`, `label`, `message`, `color`, `logoSvg`.
- Dynamic-JSON badge markdown queries `$.message` (the letter grade) instead of the removed `$.grade`; README docs updated to match.
- The detailed numbers are still available in `skillsaw lint --format json` under `summary.grade` — the badge file is now purely a badge.
- A schema-pinning test (`set(payload) <= _SHIELDS_ENDPOINT_KEYS`) prevents future fields from silently breaking the badge again.
- Regenerated the dogfooded `.skillsaw-badge.json`, so the README badge renders correctly once merged.

## Test plan

- Updated `tests/test_grade.py` (badge shape, CLI markdown, baseline-bypass assertions); full suite 2089 passed, 15 skipped.
- `make lint` / `make update` clean; `openshift-eng/ai-helpers` canary exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)