### PR TITLE
[Auto] Bump version to 0.14.0

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.13.1"
+version: "0.14.0"
 
 rules:
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.12.1"). Defaults to the version this action was released with.'
     required: false
-    default: '0.13.1'
+    default: '0.14.0'
   strict:
     description: 'Treat warnings as errors'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.13.1"
+version = "0.14.0"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext


### PR DESCRIPTION
## Summary
- Bump skillsaw version from 0.13.1 to 0.14.0 for release

## Test plan
- [x] All 2089 tests pass
- [x] Lint is clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->