### PR TITLE
Recalibrate grade scoring against real-world repositories

### DIFF
--- a/.skillsaw-badge.json
+++ b/.skillsaw-badge.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "skillsaw",
-  "message": "A-",
+  "message": "A",
   "color": "brightgreen",
   "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill-rule=\"evenodd\" fill=\"#fff\" d=\"M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z\"/></svg>"
 }

--- a/README.md
+++ b/README.md
@@ -493,28 +493,26 @@ Every lint run computes a letter grade (A+ through F) summarizing
 repository quality, shown in the text summary and in the JSON report
 under `summary.grade`.
 
-**How it's calculated:** weighted warning-and-info density sets your
-letter; errors knock letters off.
+**How it's calculated:** weighted violation density sets your letter;
+errors additionally knock letters off.
 
-- **Density sets the letter.** Warnings (weight 1.0) and info-level
-  violations (weight 0.1) are counted per 10,000 estimated content
-  tokens, so a large marketplace isn't penalized for having more
-  surface area than a single skill. Each density unit costs one notch
-  (A+ → A → A- → …). Repositories smaller than 10K tokens are graded
-  as one unit.
-- **Errors knock off whole letters** regardless of repository size:
-  one error costs a letter, five or more cost two, twenty-five or more
-  cost three. A broken manifest can't be diluted by prose volume.
+- **Density sets the letter.** Errors (weight 1.0), warnings (weight
+  0.75), and info-level violations (weight 0.1) are counted per 10,000
+  estimated content tokens, so a large marketplace isn't penalized for
+  having more surface area than a single skill. A+ requires density
+  below 1.0; after that every 2.0 density units cost one notch (A < 3,
+  A- < 5, B+ < 7, … F ≥ 21 — calibrated against real-world community
+  marketplaces). Repositories smaller than 10K tokens are graded as
+  one unit.
+- **Errors also knock off whole letters** regardless of repository
+  size: one error costs a letter, five or more cost two, twenty-five
+  or more cost three. A broken manifest can't be diluted by prose
+  volume.
 - **Zero violations is an A+.**
 
-The weights are tunable in `.skillsaw.yaml`:
-
-```yaml
-grade:
-  warning-weight: 1.0
-  info-weight: 0.1
-  label: skillsaw   # badge label text
-```
+The weights and bands are deliberately **not configurable** — a
+skillsaw badge means the same thing on every repository, so a repo
+can't grade itself on a friendlier curve.
 
 ### README badge
 

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -850,7 +850,7 @@ def _run_lint(args):
     content_tokens = sum(
         block.estimate_tokens() for ctx in contexts for block in ctx.lint_tree.content_blocks()
     )
-    grade = compute_grade(all_violations, content_tokens, config.grade)
+    grade = compute_grade(all_violations, content_tokens)
 
     stdout_output = format_report(
         args.fmt,
@@ -1551,7 +1551,7 @@ def _run_badge(args):
     from .grade import compute_grade
 
     content_tokens = sum(b.estimate_tokens() for b in context.lint_tree.content_blocks())
-    grade = compute_grade(violations, content_tokens, config.grade)
+    grade = compute_grade(violations, content_tokens)
 
     badge_path = args.output or (context.root_path / _BADGE_FILENAME)
     badge_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1581,7 +1581,7 @@ def _run_badge(args):
     from .grade import logo_data_uri
 
     encoded = quote(raw_url, safe="")
-    label = quote(grade.settings.label, safe="")
+    label = "skillsaw"
     logo = quote(logo_data_uri(), safe="")
 
     print(f"\n{c['bold']}Markdown for your README:{c['reset']}")

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Set, Tuple, TYPE_CHECKING
 from dataclasses import dataclass, field
 
-from .grade import GradeSettings
-
 if TYPE_CHECKING:
     from .context import RepositoryContext
 
@@ -71,7 +69,6 @@ class LinterConfig:
     content_paths: List[str] = field(default_factory=list)
     strict: bool = False
     llm: LLMSettings = field(default_factory=LLMSettings)
-    grade: GradeSettings = field(default_factory=GradeSettings)
     config_dir: Optional[Path] = None
 
     @classmethod
@@ -152,11 +149,6 @@ class LinterConfig:
         else:
             raise ValueError(f"'strict' must be a boolean, got {type(raw_strict).__name__}")
 
-        raw_grade = data.get("grade")
-        grade_settings = (
-            GradeSettings.from_dict(raw_grade) if raw_grade is not None else GradeSettings()
-        )
-
         llm_data = data.get("llm", {})
         llm_settings = LLMSettings(
             model=llm_data.get("model", LLMSettings.model),
@@ -174,7 +166,6 @@ class LinterConfig:
             content_paths=data.get("content-paths", []),
             strict=strict,
             llm=llm_settings,
-            grade=grade_settings,
             config_dir=config_path.resolve().parent,
         )
 

--- a/src/skillsaw/grade.py
+++ b/src/skillsaw/grade.py
@@ -4,16 +4,17 @@ Repository quality grade.
 The grade condenses a lint run into a letter (A+ .. F) suitable for a
 README badge:
 
-- **Warning/info density sets the letter.** Weighted violations
-  (warnings at full weight, info lightly) are normalized per 10,000
-  estimated content tokens, so a large marketplace is not penalized for
-  having more surface area than a single skill. One density unit costs
-  one notch (A+ -> A -> A- -> ...).
-- **Errors knock off whole letters.** Errors are rare and structural —
-  a broken manifest is not diluted by prose volume, so any error drops
-  the grade a full letter regardless of repository size.
+- **Violation density sets the letter.** Weighted violations (errors
+  1.0, warnings 0.75, info 0.1) are normalized per 10,000 estimated
+  content tokens, so a large marketplace is not penalized for having
+  more surface area than a single skill. A+ requires density below
+  1.0; after that every DENSITY_PER_NOTCH units cost a notch
+  (A+ -> A -> A- -> ...).
+- **Errors additionally knock off whole letters.** Errors are rare and
+  structural — a broken manifest is not diluted by prose volume, so any
+  error drops the grade a full letter regardless of repository size.
 - Repositories smaller than one 10K-token unit are graded as one unit,
-  so a tiny skill with one warning loses one notch rather than the
+  so a tiny skill with a few warnings loses a notch rather than the
   whole scale.
 
 Token estimates come from ``ContentBlock.estimate_tokens()`` (prose
@@ -21,14 +22,27 @@ blocks only); structured JSON config blocks are not content an agent
 reads linearly and are excluded from the denominator.
 """
 
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import List
 
 from .rule import RuleViolation, Severity
 
-# One density unit per notch; a whole letter is three notches.
+# The scoring constants are deliberately NOT configurable: a skillsaw
+# badge must mean the same thing on every repository, and tunable
+# weights would let a repo grade itself on a friendlier curve.
+#
+# A+ is exclusive (density < 1.0); after that each notch spans
+# DENSITY_PER_NOTCH units. A whole letter is three notches.
+# Calibrated against real repositories (June 2026): well-maintained
+# community marketplaces run ~12-14 weighted violations per 10K tokens
+# and should land around C+, not F.
 LETTER_NOTCHES = ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D+", "D", "F"]
 _NOTCHES_PER_LETTER = 3
+A_PLUS_THRESHOLD = 1.0
+DENSITY_PER_NOTCH = 2.0
+ERROR_WEIGHT = 1.0
+WARNING_WEIGHT = 0.75
+INFO_WEIGHT = 0.1
 
 TOKENS_PER_UNIT = 10_000
 
@@ -66,35 +80,6 @@ _LETTER_COLORS = {
 
 
 @dataclass
-class GradeSettings:
-    """Tunable grade parameters (``grade:`` section of .skillsaw.yaml)."""
-
-    warning_weight: float = 1.0
-    info_weight: float = 0.1
-    label: str = "skillsaw"
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "GradeSettings":
-        if not isinstance(data, dict):
-            raise ValueError(f"'grade' must be a mapping, got {type(data).__name__}")
-        settings = cls()
-        for yaml_key, attr in (
-            ("warning-weight", "warning_weight"),
-            ("info-weight", "info_weight"),
-        ):
-            if yaml_key in data:
-                value = data[yaml_key]
-                if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
-                    raise ValueError(f"'grade.{yaml_key}' must be a non-negative number")
-                setattr(settings, attr, float(value))
-        if "label" in data:
-            if not isinstance(data["label"], str) or not data["label"].strip():
-                raise ValueError("'grade.label' must be a non-empty string")
-            settings.label = data["label"].strip()
-        return settings
-
-
-@dataclass
 class Grade:
     letter: str
     density: float
@@ -102,7 +87,6 @@ class Grade:
     warnings: int
     info: int
     content_tokens: int
-    settings: GradeSettings = field(default_factory=GradeSettings)
 
     @property
     def color(self) -> str:
@@ -121,7 +105,7 @@ class Grade:
         badges read the grade via ``query=$.message``."""
         return {
             "schemaVersion": 1,
-            "label": self.settings.label,
+            "label": "skillsaw",
             "message": self.letter,
             "color": self.color,
             "logoSvg": LOGO_SVG,
@@ -135,24 +119,21 @@ def _error_letters(errors: int) -> int:
     return 0
 
 
-def compute_grade(
-    violations: List[RuleViolation],
-    content_tokens: int,
-    settings: Optional[GradeSettings] = None,
-) -> Grade:
+def compute_grade(violations: List[RuleViolation], content_tokens: int) -> Grade:
     """Grade a lint run. ``content_tokens`` is the summed token estimate
     of every ContentBlock in the lint tree(s)."""
-    settings = settings or GradeSettings()
-
     errors = sum(1 for v in violations if v.severity == Severity.ERROR)
     warnings = sum(1 for v in violations if v.severity == Severity.WARNING)
     info = sum(1 for v in violations if v.severity == Severity.INFO)
 
     units = max(content_tokens / TOKENS_PER_UNIT, 1.0)
-    density = (settings.warning_weight * warnings + settings.info_weight * info) / units
+    density = (ERROR_WEIGHT * errors + WARNING_WEIGHT * warnings + INFO_WEIGHT * info) / units
 
     last = len(LETTER_NOTCHES) - 1
-    notch = min(int(density), last)
+    if density < A_PLUS_THRESHOLD:
+        notch = 0
+    else:
+        notch = min(1 + int((density - A_PLUS_THRESHOLD) / DENSITY_PER_NOTCH), last)
     notch = min(notch + _NOTCHES_PER_LETTER * _error_letters(errors), last)
 
     return Grade(
@@ -162,5 +143,4 @@ def compute_grade(
         warnings=warnings,
         info=info,
         content_tokens=content_tokens,
-        settings=settings,
     )

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -7,9 +7,8 @@ import json
 import subprocess
 import sys
 
-import pytest
-
-from skillsaw.grade import Grade, GradeSettings, compute_grade, LETTER_NOTCHES
+import skillsaw.grade as grade_mod
+from skillsaw.grade import Grade, compute_grade, LETTER_NOTCHES
 from skillsaw.rule import RuleViolation, Severity
 
 from .test_integration import FIXTURES, copy_fixture, run_lint, summary
@@ -40,22 +39,38 @@ def test_density_normalizes_by_tokens():
     # 17 warnings in a huge marketplace is near-pristine...
     big = compute_grade(_violations(warnings=17), content_tokens=5_000_000)
     assert big.letter == "A+"
-    # ...but 17 warnings in one small skill is a mess.
+    # ...but 17 warnings in one small skill drops it six notches.
     small = compute_grade(_violations(warnings=17), content_tokens=2_000)
-    assert small.letter == "F"
+    assert small.letter == "C+"
 
 
 def test_small_repos_floor_at_one_unit():
-    # A tiny skill with one warning loses one notch, not the whole scale.
-    grade = compute_grade(_violations(warnings=1), content_tokens=500)
+    # A tiny skill with a couple of warnings loses one notch, not the
+    # whole scale (one warning at weight 0.75 stays under the A+ line).
+    assert compute_grade(_violations(warnings=1), content_tokens=500).letter == "A+"
+    grade = compute_grade(_violations(warnings=2), content_tokens=500)
     assert grade.letter == "A"
-    assert grade.density == 1.0
+    assert grade.density == 1.5
 
 
-def test_one_density_unit_per_notch():
-    for units, letter in [(0, "A+"), (1, "A"), (2, "A-"), (3, "B+"), (11, "F"), (50, "F")]:
-        grade = compute_grade(_violations(warnings=units), content_tokens=10_000)
-        assert grade.letter == letter, f"{units} warnings/10k tokens -> {grade.letter}"
+def test_density_bands():
+    # A+ is exclusive (< 1.0); after that every 2.0 density units cost a
+    # notch. Calibrated so real-world community marketplaces (~10-14
+    # density) land around B-/C+, not F. 10 info = 1.0 density unit.
+    for info, letter in [
+        (0, "A+"),
+        (9, "A+"),
+        (10, "A"),
+        (29, "A"),
+        (30, "A-"),
+        (50, "B+"),
+        (110, "C+"),
+        (130, "C"),
+        (210, "F"),
+        (500, "F"),
+    ]:
+        grade = compute_grade(_violations(info=info), content_tokens=10_000)
+        assert grade.letter == letter, f"{info} info/10k tokens -> {grade.letter}"
 
 
 def test_info_calibration_anchor():
@@ -74,7 +89,8 @@ def test_errors_knock_off_whole_letters():
 
 
 def test_errors_stack_with_density():
-    # One warning unit (A) plus one error letter (3 notches) -> B.
+    # Density 1.75 (error 1.0 + warning 0.75) lands A; the error's
+    # letter knockdown (3 notches) takes it to B.
     grade = compute_grade(_violations(errors=1, warnings=1), content_tokens=10_000)
     assert grade.letter == "B"
 
@@ -92,36 +108,19 @@ def test_letter_notches_are_well_formed():
         assert Grade(letter, 0, 0, 0, 0, 0).color  # every notch has a color
 
 
-# ── GradeSettings ────────────────────────────────────────────────
+# ── Fixed scoring constants ──────────────────────────────────────
 
 
-def test_custom_weights():
-    settings = GradeSettings.from_dict({"warning-weight": 2.0, "info-weight": 0.5})
-    grade = compute_grade(_violations(warnings=1, info=2), content_tokens=10_000, settings=settings)
-    assert grade.density == 3.0
-    assert grade.letter == "B+"
-
-
-def test_zero_info_weight_ignores_info():
-    settings = GradeSettings.from_dict({"info-weight": 0})
-    grade = compute_grade(_violations(info=500), content_tokens=10_000, settings=settings)
-    assert grade.letter == "A+"
-
-
-@pytest.mark.parametrize(
-    "bad",
-    [
-        {"warning-weight": -1},
-        {"warning-weight": "heavy"},
-        {"info-weight": True},
-        {"label": ""},
-        {"label": 7},
-        "not-a-mapping",
-    ],
-)
-def test_invalid_grade_settings_rejected(bad):
-    with pytest.raises(ValueError):
-        GradeSettings.from_dict(bad)
+def test_weights_are_fixed_constants():
+    # The grade is deliberately NOT configurable — a skillsaw badge must
+    # mean the same thing on every repository. These values changing is
+    # a breaking change to every published badge; bump knowingly.
+    assert grade_mod.ERROR_WEIGHT == 1.0
+    assert grade_mod.WARNING_WEIGHT == 0.75
+    assert grade_mod.INFO_WEIGHT == 0.1
+    assert grade_mod.DENSITY_PER_NOTCH == 2.0
+    assert grade_mod.A_PLUS_THRESHOLD == 1.0
+    assert not hasattr(grade_mod, "GradeSettings")
 
 
 # Every property the shields.io endpoint schema accepts — it rejects


### PR DESCRIPTION
## Summary

The grade scale shipped in #296 was calibrated only on intuition and turned out far too strict: graded against real repositories, well-maintained community marketplaces landed **F**. This PR recalibrates the bands against real-world data and locks the scoring down.

**New scale:**

- Weights: **errors 1.0, warnings 0.75, info 0.1**, per 10K content tokens.
- **A+ stays exclusive** (density < 1.0); after that every **2.0 density units cost one notch**: A < 3, A- < 5, B+ < 7, … F ≥ 21.
- Error letter-knockdown unchanged (1+/5+/25+ errors → −1/−2/−3 letters) on top of their density weight.

**Calibration results:**

| Repo | Density | Before | After |
|---|---|---|---|
| openshift-eng/ai-helpers | 0.94 | A+ | A+ |
| stbenjam/skillsaw | 2.37 | A- | A |
| obra/superpowers | 9.85 | F | **B-** |
| anthropics/claude-plugins-official | 11.50 + 6 errors | F | F (C+ on density; the 6 errors are genuinely broken files) |

**Scoring is no longer configurable.** The `grade:` config section is removed entirely — tunable weights would let a repository grade itself on a friendlier curve and publish an unearned A+. Weights and bands are fixed constants in `grade.py`, pinned by a test so changing them is a deliberate, visible act. The badge label is likewise hardcoded.

## Test plan

- `tests/test_grade.py` updated for the new bands and weights, including a constants-pinning test and `assert not hasattr(grade_mod, "GradeSettings")`.
- Full suite: 2082 passed, 15 skipped (count down from removed configurability tests). `make lint` / `make update` clean.
- Canary: `openshift-eng/ai-helpers` exits 0, grades A+.
- Dogfooded badge regenerated: skillsaw now wears an **A**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM configuration support added for model and worker settings

* **Documentation**
  * Quality grade calculation explained with fixed density-based letter thresholds and error knockoff behavior

* **Bug Fixes**
  * Grading system now enforces fixed, non-configurable scoring standards
  * Badge label standardized to "skillsaw"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->