### PR TITLE
Fix confirmed bugs from the architecture/quality review

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ unless you bump the version or explicitly enable them. Repos **without** a
 `.skillsaw.yaml` run all rules at the latest version — you get new rules
 automatically but may occasionally fail after a skillsaw upgrade.
 
+A hand-written config that omits `version` defaults to an early version (so
+newer rules are skipped) and prints a warning on each run — set `version`
+explicitly to silence it and control which rules apply.
+
 ### Exclude Patterns
 
 Skip files and directories using glob patterns:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--strict` | Treat warnings as errors (exit with error code if warnings exist) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
-| `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit. |  |
+| `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo. |  |
 | `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |
 | `--skip-rule` | Skip these rules (repeatable). Cannot be combined with --rule. |  |
 | `--no-baseline` | Ignore baseline file even if .skillsaw-baseline.json exists |  |

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -46,6 +46,12 @@ def _get_version() -> str:
         return __version__
 
 
+def _emit_config_warnings(config) -> None:
+    """Print non-fatal config-load warnings (missing version, unknown keys)."""
+    for warning in getattr(config, "warnings", []):
+        print(f"Warning: {warning}", file=sys.stderr)
+
+
 def _build_parser():
     """Build the main argument parser with all subcommands.
 
@@ -501,6 +507,7 @@ def _run_tree(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
 
@@ -668,6 +675,13 @@ def _run_lint(args):
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
+        if filepath in output_formats and output_formats[filepath] != fmt:
+            print(
+                f"Error: --output targets '{filepath}' with conflicting formats "
+                f"'{output_formats[filepath]}' and '{fmt}'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         output_formats[filepath] = fmt
 
     _handle_apply_patch_for_lint(args)
@@ -726,6 +740,7 @@ def _run_lint(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
 
@@ -733,10 +748,13 @@ def _run_lint(args):
         config.strict = True
 
     baseline = None
+    baseline_root = None
     if not args.no_baseline:
         from .baseline import find_baseline, load_baseline
 
         baseline_path = find_baseline(config.config_dir or paths[0])
+        if baseline_path:
+            baseline_root = baseline_path.resolve().parent
 
         if baseline_path:
             try:
@@ -785,6 +803,7 @@ def _run_lint(args):
                 rule_ids=rule_ids,
                 skip_rule_ids=skip_rule_ids,
                 baseline=baseline,
+                baseline_root=baseline_root,
                 no_custom_rules=args.no_custom_rules,
             )
         except ValueError as e:
@@ -1112,6 +1131,7 @@ def _run_fix(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
 
@@ -1437,6 +1457,7 @@ def _run_baseline(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
 
@@ -1452,12 +1473,15 @@ def _run_baseline(args):
 
     cli_version = _get_version()
     baseline_modes = {r.rule_id: r.baseline_mode for r in linter.rules if r.baseline_mode}
-    baseline = build_baseline(violations, context.root_path, cli_version, baseline_modes)
 
     if config_path:
         output_path = config_path.parent / BASELINE_FILENAME
     else:
         output_path = args.path / BASELINE_FILENAME
+
+    # Fingerprint paths relative to the directory the baseline is written to,
+    # so the baseline still matches when lint is later run from a subdirectory.
+    baseline = build_baseline(violations, output_path.resolve().parent, cli_version, baseline_modes)
 
     save_baseline(output_path, baseline)
     print(f"Baselined {len(baseline.violations)} violation(s) to {output_path}")
@@ -1531,6 +1555,7 @@ def _run_badge(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
 
@@ -1721,6 +1746,7 @@ def _run_explain(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     if config is None:
         config = LinterConfig.default()
         config_label = "builtin defaults"
@@ -1773,6 +1799,7 @@ def _run_docs(args):
         except ValueError as e:
             print(f"Error loading config: {e}", file=sys.stderr)
             sys.exit(1)
+        _emit_config_warnings(config)
     else:
         config = LinterConfig.default()
     context.exclude_patterns = config.exclude_patterns

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -145,7 +145,9 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         default=[],
         metavar="TYPE",
         help="Override auto-detected repository type (repeatable). "
-        "Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit.",
+        "Values: "
+        + ", ".join(t.value for t in RepositoryType if t is not RepositoryType.UNKNOWN)
+        + ".",
     )
     lint_parser.add_argument(
         "--rule",
@@ -715,7 +717,7 @@ def _run_lint(args):
     # Override repo_types if --type was provided
     override_types = None
     if args.repo_types:
-        type_map = {t.value: t for t in RepositoryType}
+        type_map = {t.value: t for t in RepositoryType if t is not RepositoryType.UNKNOWN}
         override_types = set()
         for val in args.repo_types:
             if val not in type_map:
@@ -751,13 +753,10 @@ def _run_lint(args):
         config.strict = True
 
     baseline = None
-    baseline_root = None
     if not args.no_baseline:
         from .baseline import find_baseline, load_baseline
 
         baseline_path = find_baseline(config.config_dir or paths[0])
-        if baseline_path:
-            baseline_root = baseline_path.resolve().parent
 
         if baseline_path:
             try:
@@ -783,9 +782,7 @@ def _run_lint(args):
     contexts = []
     baseline_suppressed = 0
     for lint_path in paths:
-        context = RepositoryContext(lint_path)
-        if override_types:
-            context.repo_types = override_types
+        context = RepositoryContext(lint_path, repo_types=override_types)
         contexts.append(context)
 
         if context.repo_type == RepositoryType.UNKNOWN:
@@ -806,7 +803,6 @@ def _run_lint(args):
                 rule_ids=rule_ids,
                 skip_rule_ids=skip_rule_ids,
                 baseline=baseline,
-                baseline_root=baseline_root,
                 no_custom_rules=args.no_custom_rules,
             )
         except ValueError as e:

--- a/src/skillsaw/__main__.py
+++ b/src/skillsaw/__main__.py
@@ -675,14 +675,17 @@ def _run_lint(args):
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
-        if filepath in output_formats and output_formats[filepath] != fmt:
+        # Key on the resolved path so 'report.json' and './report.json' are
+        # recognised as the same target.
+        resolved_path = Path(filepath).resolve()
+        if resolved_path in output_formats and output_formats[resolved_path] != fmt:
             print(
                 f"Error: --output targets '{filepath}' with conflicting formats "
-                f"'{output_formats[filepath]}' and '{fmt}'",
+                f"'{output_formats[resolved_path]}' and '{fmt}'",
                 file=sys.stderr,
             )
             sys.exit(1)
-        output_formats[filepath] = fmt
+        output_formats[resolved_path] = fmt
 
     _handle_apply_patch_for_lint(args)
 

--- a/src/skillsaw/baseline.py
+++ b/src/skillsaw/baseline.py
@@ -77,10 +77,17 @@ def fingerprint_violation(
     rel_path = relative_path(violation.file_path, root_path)
     file_line = violation.file_line
 
-    # Ratchet violations use rule_id + file_path only so the fingerprint
-    # is stable across value changes (e.g. token count going up or down).
+    # Ratchet violations use rule_id + file_path (+ optional metric) only so
+    # the fingerprint is stable across value changes (e.g. token count going up
+    # or down).  The metric discriminator keeps two ratchet violations for the
+    # same file (e.g. whole-file vs description tokens) from colliding.  When no
+    # metric is set the fingerprint is unchanged, so existing baselines for
+    # single-metric ratchet rules keep matching.
     if violation.value is not None and rel_path is not None:
-        raw = f"{rule_id}\0{rel_path}"
+        if violation.metric:
+            raw = f"{rule_id}\0{rel_path}\0{violation.metric}"
+        else:
+            raw = f"{rule_id}\0{rel_path}"
         return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
     if rel_path is not None and file_line is not None and violation.file_path is not None:
@@ -195,13 +202,17 @@ def load_baseline(path: Path) -> BaselineFile:
 
 
 def find_baseline(start_path: Path) -> Optional[Path]:
-    """Look for a baseline file in *start_path* and its parents."""
+    """Look for a baseline file in *start_path* and its parents.
+
+    The walk includes the start directory itself and the filesystem root, so a
+    baseline placed at ``/`` (containers that mount the repo at the root) is
+    still found.
+    """
     current = start_path.resolve()
-    while current != current.parent:
-        candidate = current / BASELINE_FILENAME
+    for directory in (current, *current.parents):
+        candidate = directory / BASELINE_FILENAME
         if candidate.exists():
             return candidate
-        current = current.parent
     return None
 
 

--- a/src/skillsaw/baseline.py
+++ b/src/skillsaw/baseline.py
@@ -42,6 +42,7 @@ class BaselineFile:
     generated_by: str
     generated_at: str
     violations: List[BaselineEntry] = field(default_factory=list)
+    root_path: Optional[Path] = None
 
 
 def _read_file_lines(path: Path, cache: Dict[Path, Optional[List[str]]]) -> Optional[List[str]]:
@@ -139,6 +140,7 @@ def build_baseline(
         generated_by=f"skillsaw {version_string}",
         generated_at=datetime.now(timezone.utc).isoformat(),
         violations=entries,
+        root_path=root_path.resolve(),
     )
 
 
@@ -198,6 +200,7 @@ def load_baseline(path: Path) -> BaselineFile:
         generated_by=data.get("generated_by", ""),
         generated_at=data.get("generated_at", ""),
         violations=entries,
+        root_path=path.resolve().parent,
     )
 
 
@@ -248,12 +251,13 @@ def filter_baselined_violations(
         else:
             regular_budget[e.fingerprint] += 1
 
+    fingerprint_root = baseline.root_path or root_path
     file_cache: Dict[Path, Optional[List[str]]] = {}
     kept: List[RuleViolation] = []
     consumed_ratchet: set = set()
 
     for v in violations:
-        fp = fingerprint_violation(v, root_path, _file_cache=file_cache)
+        fp = fingerprint_violation(v, fingerprint_root, _file_cache=file_cache)
 
         if fp in ratchet_entries:
             entry = ratchet_entries[fp]

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -120,10 +120,15 @@ class LinterConfig:
 
         try:
             with open(config_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
+                data = yaml.safe_load(f)
         except (yaml.YAMLError, IOError, UnicodeDecodeError) as e:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
 
+        # Only an empty document (None) is an empty config; falsy non-mappings
+        # ([], false, 0, "") are malformed and must reach the type check below
+        # rather than being coerced to {} by ``or {}``.
+        if data is None:
+            data = {}
         if not isinstance(data, dict):
             raise ValueError(
                 f"config root must be a mapping, got {type(data).__name__}. "

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -2,6 +2,7 @@
 Configuration management for skillsaw
 """
 
+import copy
 import functools
 import os
 import re
@@ -138,7 +139,10 @@ class LinterConfig:
                 + ". Known keys: "
                 + ", ".join(sorted(cls._KNOWN_KEYS))
             )
-        if "version" not in data:
+        raw_version = data.get("version")
+        if raw_version is None:
+            # Covers both a missing key and an explicit ``version:`` (None) —
+            # both would otherwise version-gate as 0.0.0 and disable newer rules.
             load_warnings.append(
                 f"config has no 'version' field; defaulting to {_DEFAULT_VERSION}, so rules "
                 "added in later versions are silently disabled. Set 'version' to your "
@@ -183,6 +187,8 @@ class LinterConfig:
         if raw_custom_rules is None:
             custom_rules = []
         elif isinstance(raw_custom_rules, list):
+            if not all(isinstance(p, str) for p in raw_custom_rules):
+                raise ValueError("'custom-rules' must be a list of strings (file paths)")
             custom_rules = raw_custom_rules
         else:
             raise ValueError(
@@ -236,7 +242,7 @@ class LinterConfig:
         )
 
         return cls(
-            version=str(data.get("version", _DEFAULT_VERSION)),
+            version=_DEFAULT_VERSION if raw_version is None else str(raw_version),
             rules=rules,
             custom_rules=custom_rules,
             exclude_patterns=exclude_patterns,
@@ -358,7 +364,10 @@ class LinterConfig:
         Returns:
             Rule configuration dict
         """
-        defaults = _default_rules().get(rule_id, {})
+        # Deep-copy the cached defaults so callers mutating the merged result
+        # (or its nested lists like ``recommended-fields``) cannot corrupt the
+        # shared cache.
+        defaults = copy.deepcopy(_default_rules().get(rule_id, {}))
         overrides = self.rules.get(rule_id)
         if overrides is None:
             overrides = {}

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -2,6 +2,7 @@
 Configuration management for skillsaw
 """
 
+import functools
 import os
 import re
 
@@ -44,6 +45,28 @@ def _parse_version(v: str) -> Tuple[int, ...]:
     return tuple(parts)
 
 
+def _validate_llm_fields(llm_data: Dict[str, Any]) -> None:
+    """Reject mistyped ``llm`` settings before they crash deeper in the engine.
+
+    ``bool`` is a subclass of ``int``, so the integer fields explicitly reject
+    booleans to catch ``max_iterations: true`` mistakes.
+    """
+    int_fields = ("max_iterations", "max_tokens", "max_workers")
+    for name in int_fields:
+        if name in llm_data and (
+            not isinstance(llm_data[name], int) or isinstance(llm_data[name], bool)
+        ):
+            raise ValueError(
+                f"'llm.{name}' must be an integer, got {type(llm_data[name]).__name__}"
+            )
+    if "confirm" in llm_data and not isinstance(llm_data["confirm"], bool):
+        raise ValueError(
+            f"'llm.confirm' must be a boolean, got {type(llm_data['confirm']).__name__}"
+        )
+    if "model" in llm_data and not isinstance(llm_data["model"], str):
+        raise ValueError(f"'llm.model' must be a string, got {type(llm_data['model']).__name__}")
+
+
 @dataclass
 class LLMSettings:
     model: str = ""
@@ -70,6 +93,15 @@ class LinterConfig:
     strict: bool = False
     llm: LLMSettings = field(default_factory=LLMSettings)
     config_dir: Optional[Path] = None
+    # Non-fatal problems found while loading (missing version, unknown keys).
+    # Excluded from equality so two configs loaded the same way still compare
+    # equal regardless of the advisory messages attached.
+    warnings: List[str] = field(default_factory=list, compare=False)
+
+    # Recognised top-level config keys; anything else triggers a load warning.
+    _KNOWN_KEYS = frozenset(
+        {"version", "rules", "custom-rules", "exclude", "content-paths", "strict", "llm"}
+    )
 
     @classmethod
     def from_file(cls, config_path: Path) -> "LinterConfig":
@@ -86,10 +118,32 @@ class LinterConfig:
             return cls()
 
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
-        except (yaml.YAMLError, IOError) as e:
+        except (yaml.YAMLError, IOError, UnicodeDecodeError) as e:
             raise ValueError(f"Failed to load config from {config_path}: {e}")
+
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"config root must be a mapping, got {type(data).__name__}. "
+                "Expected top-level keys like 'rules:', 'exclude:', 'version:'."
+            )
+
+        load_warnings: List[str] = []
+        unknown_keys = set(data) - cls._KNOWN_KEYS
+        if unknown_keys:
+            load_warnings.append(
+                "unknown config key(s) ignored: "
+                + ", ".join(sorted(map(str, unknown_keys)))
+                + ". Known keys: "
+                + ", ".join(sorted(cls._KNOWN_KEYS))
+            )
+        if "version" not in data:
+            load_warnings.append(
+                f"config has no 'version' field; defaulting to {_DEFAULT_VERSION}, so rules "
+                "added in later versions are silently disabled. Set 'version' to your "
+                "skillsaw version to enable them."
+            )
 
         raw_rules = data.get("rules")
         raw_custom_rules = data.get("custom-rules")
@@ -138,9 +192,24 @@ class LinterConfig:
         if raw_exclude is None:
             exclude_patterns = list(_DEFAULT_EXCLUDE_PATTERNS)
         elif isinstance(raw_exclude, list):
+            if not all(isinstance(p, str) for p in raw_exclude):
+                raise ValueError("'exclude' must be a list of strings (glob patterns)")
             exclude_patterns = raw_exclude
         else:
             raise ValueError(f"'exclude' must be a list, got {type(raw_exclude).__name__}")
+
+        raw_content_paths = data.get("content-paths")
+        if raw_content_paths is None:
+            content_paths: List[str] = []
+        elif isinstance(raw_content_paths, list):
+            if not all(isinstance(p, str) for p in raw_content_paths):
+                raise ValueError("'content-paths' must be a list of strings (glob patterns)")
+            content_paths = raw_content_paths
+        else:
+            raise ValueError(
+                "'content-paths' must be a list of strings (glob patterns), "
+                f"got {type(raw_content_paths).__name__}"
+            )
 
         if raw_strict is None:
             strict = False
@@ -150,6 +219,14 @@ class LinterConfig:
             raise ValueError(f"'strict' must be a boolean, got {type(raw_strict).__name__}")
 
         llm_data = data.get("llm", {})
+        if llm_data is None:
+            llm_data = {}
+        if not isinstance(llm_data, dict):
+            raise ValueError(
+                f"'llm' must be a mapping, got {type(llm_data).__name__}. Example:\n"
+                "  llm:\n    model: claude-...\n    max_iterations: 10"
+            )
+        _validate_llm_fields(llm_data)
         llm_settings = LLMSettings(
             model=llm_data.get("model", LLMSettings.model),
             max_iterations=llm_data.get("max_iterations", LLMSettings.max_iterations),
@@ -163,10 +240,11 @@ class LinterConfig:
             rules=rules,
             custom_rules=custom_rules,
             exclude_patterns=exclude_patterns,
-            content_paths=data.get("content-paths", []),
+            content_paths=content_paths,
             strict=strict,
             llm=llm_settings,
             config_dir=config_path.resolve().parent,
+            warnings=load_warnings,
         )
 
     @classmethod
@@ -280,7 +358,7 @@ class LinterConfig:
         Returns:
             Rule configuration dict
         """
-        defaults = self.default().rules.get(rule_id, {})
+        defaults = _default_rules().get(rule_id, {})
         overrides = self.rules.get(rule_id)
         if overrides is None:
             overrides = {}
@@ -346,7 +424,7 @@ class LinterConfig:
             # wants it active.  We must NOT do this for ``enabled: "auto"``
             # rules — those rely on repo-type / format detection.
             if user_overrides:
-                default_enabled = self.default().rules.get(rule_id, {}).get("enabled", True)
+                default_enabled = _default_rules().get(rule_id, {}).get("enabled", True)
                 if default_enabled is False:
                     return True, "configured in config (overrides disabled-by-default)"
                 # For "auto" rules, non-enabled overrides don't change
@@ -406,7 +484,7 @@ class LinterConfig:
             if rule.config_schema:
                 schemas[rule.rule_id] = rule.config_schema
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             f.write("# skillsaw configuration\n")
             f.write("# https://github.com/stbenjam/skillsaw\n\n")
             if self.version:
@@ -517,17 +595,31 @@ def find_config(start_path: Path) -> Optional[Path]:
     """
     current = start_path.resolve()
 
-    while current != current.parent:
+    # Walk up to and *including* the filesystem root, so a config placed at
+    # ``/`` (common in containers where the repo is mounted at the root) is
+    # still found.  ``current.parents`` does not include ``current`` itself.
+    for directory in (current, *current.parents):
         for name in (
             ".skillsaw.yaml",
             ".skillsaw.yml",
             ".claudelint.yaml",
             ".claudelint.yml",
         ):
-            config_file = current / name
+            config_file = directory / name
             if config_file.exists():
                 return config_file
 
-        current = current.parent
-
     return None
+
+
+@functools.lru_cache(maxsize=1)
+def _default_rules() -> Dict[str, Dict[str, Any]]:
+    """Memoised default rule mapping for the hot read path.
+
+    ``LinterConfig.default()`` rebuilds the entire ~60-rule dict on every call,
+    and ``get_rule_config`` / ``rule_enabled_reason`` are invoked per rule and
+    once per violation during filtering.  The defaults are deterministic, so we
+    cache them.  Callers only read this mapping (``get_rule_config`` returns a
+    freshly merged dict), so sharing the instance is safe.
+    """
+    return LinterConfig.default().rules

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -122,7 +122,7 @@ class LinterConfig:
             with open(config_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
         except (yaml.YAMLError, IOError, UnicodeDecodeError) as e:
-            raise ValueError(f"Failed to load config from {config_path}: {e}")
+            raise ValueError(f"Failed to load config from {config_path}: {e}") from e
 
         # Only an empty document (None) is an empty config; falsy non-mappings
         # ([], false, 0, "") are malformed and must reach the type check below

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -74,16 +74,23 @@ class RepositoryContext:
     # When .apm/ is present these are generated artifacts and should not be linted.
     APM_COMPILED_DIRS = frozenset((".claude", ".cursor", ".gemini", ".opencode", ".agents"))
 
-    def __init__(self, root_path: Path):
+    def __init__(
+        self,
+        root_path: Path,
+        repo_types: Optional[Set[RepositoryType]] = None,
+    ):
         """
         Initialize repository context
 
         Args:
             root_path: Root directory of the repository
+            repo_types: Optional explicit repository type override.
         """
         self.root_path = root_path.resolve()
         self.has_apm = self._detect_apm()
-        self.repo_types: Set[RepositoryType] = self._detect_types()
+        self.repo_types: Set[RepositoryType] = (
+            set(repo_types) if repo_types is not None else self._detect_types()
+        )
         logger.info(
             "Detected repo types: %s", ", ".join(t.value for t in self.repo_types) or "none"
         )

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -62,7 +62,13 @@ def parse_output_spec(spec: str) -> tuple:
     if colon > 0:
         prefix = spec[:colon]
         if prefix in _FORMAT_SET:
-            return prefix, spec[colon + 1 :]
+            path = spec[colon + 1 :]
+            if not path:
+                raise ValueError(
+                    f"output file path missing after '{prefix}:' "
+                    f"(use '{prefix}:FILE', or 'FILE' to infer the format)"
+                )
+            return prefix, path
     return infer_format(spec), spec
 
 

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -1,11 +1,11 @@
 """SARIF v2.1.0 output formatter."""
 
 import json
+from pathlib import PurePath
 from typing import List
 
 from ..rule import Rule, RuleViolation, Severity
 from ..rule_docs import rule_doc_url
-from . import relative_path
 
 _SEVERITY_MAP = {
     "error": "error",
@@ -60,16 +60,20 @@ def format_sarif(
             "level": _SEVERITY_MAP.get(v.severity.value, "warning"),
             "message": {"text": v.message},
         }
-        rel = relative_path(v.file_path, context.root_path)
-        if rel is not None:
-            location = {
-                "physicalLocation": {
-                    "artifactLocation": {
-                        "uri": rel,
-                        "uriBaseId": "%SRCROOT%",
-                    },
-                },
-            }
+        if v.file_path is not None:
+            # SARIF URIs must use forward slashes; only paths under the repo
+            # root are root-relative (and may carry uriBaseId).  Paths outside
+            # root are emitted as-is without a misleading %SRCROOT% base.
+            try:
+                uri = v.file_path.relative_to(context.root_path).as_posix()
+                under_root = True
+            except (ValueError, TypeError):
+                uri = PurePath(str(v.file_path)).as_posix()
+                under_root = False
+            artifact_location = {"uri": uri}
+            if under_root:
+                artifact_location["uriBaseId"] = "%SRCROOT%"
+            location = {"physicalLocation": {"artifactLocation": artifact_location}}
             fl = v.file_line
             if fl is not None and fl >= 1:
                 location["physicalLocation"]["region"] = {"startLine": fl}

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -62,14 +62,20 @@ def format_sarif(
         }
         if v.file_path is not None:
             # SARIF URIs must use forward slashes; only paths under the repo
-            # root are root-relative (and may carry uriBaseId).  Paths outside
-            # root are emitted as-is without a misleading %SRCROOT% base.
-            try:
-                uri = v.file_path.relative_to(context.root_path).as_posix()
-                under_root = True
-            except (ValueError, TypeError):
+            # root are root-relative (and may carry uriBaseId).  A relative path
+            # is already root-relative; an absolute path is root-relative only
+            # when it lives under root, otherwise it is emitted as-is without a
+            # misleading %SRCROOT% base.
+            if not v.file_path.is_absolute():
                 uri = PurePath(str(v.file_path)).as_posix()
-                under_root = False
+                under_root = True
+            else:
+                try:
+                    uri = v.file_path.relative_to(context.root_path).as_posix()
+                    under_root = True
+                except (ValueError, TypeError):
+                    uri = PurePath(str(v.file_path)).as_posix()
+                    under_root = False
             artifact_location = {"uri": uri}
             if under_root:
                 artifact_location["uriBaseId"] = "%SRCROOT%"

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -5,6 +5,7 @@ Main linter orchestration
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import importlib.util
 import logging
 import re
@@ -140,7 +141,9 @@ class Linter:
         # Unique module name per file so two custom rule files cannot clobber
         # each other in ``sys.modules`` (they previously all loaded as
         # ``custom_rule``).
-        module_name = "skillsaw_custom_" + re.sub(r"\W", "_", str(path))
+        safe_stem = re.sub(r"\W", "_", path.stem)
+        path_digest = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:16]
+        module_name = f"skillsaw_custom_{safe_stem}_{path_digest}"
         try:
             spec = importlib.util.spec_from_file_location(module_name, path)
             module = importlib.util.module_from_spec(spec)
@@ -158,36 +161,47 @@ class Linter:
             # leaking a SyntaxError/ImportError traceback from the rule file.
             raise ValueError(f"Failed to load custom rule from {path}: {e}") from e
 
-        for name in dir(module):
-            obj = getattr(module, name)
-            if isinstance(obj, type) and issubclass(obj, Rule) and obj is not Rule:
-                rule_instance = obj()
-                self._known_rule_ids.add(rule_instance.rule_id)
-                if self._rule_ids and rule_instance.rule_id not in self._rule_ids:
-                    continue
-                if rule_instance.rule_id in self._skip_rule_ids:
-                    logger.info(
-                        "Rule %-30s skipped (--skip-rule, custom: %s)",
-                        rule_instance.rule_id,
-                        path.name,
-                    )
-                    continue
-                config = self.config.get_rule_config(rule_instance.rule_id)
-                if config:
-                    rule_instance = obj(config)
+        try:
+            for name in dir(module):
+                obj = getattr(module, name)
+                if isinstance(obj, type) and issubclass(obj, Rule) and obj is not Rule:
+                    rule_instance = obj()
+                    self._known_rule_ids.add(rule_instance.rule_id)
+                    if self._rule_ids and rule_instance.rule_id not in self._rule_ids:
+                        continue
+                    if rule_instance.rule_id in self._skip_rule_ids:
+                        logger.info(
+                            "Rule %-30s skipped (--skip-rule, custom: %s)",
+                            rule_instance.rule_id,
+                            path.name,
+                        )
+                        continue
+                    config = self.config.get_rule_config(rule_instance.rule_id)
+                    if config:
+                        rule_instance = obj(config)
 
-                if self._rule_ids or self.config.is_rule_enabled(
-                    rule_instance.rule_id,
-                    self.context,
-                    rule_instance.repo_types,
-                    rule_instance.formats,
-                    since_version=rule_instance.since,
-                ):
-                    rule_instance._source = "custom"
-                    self.rules.append(rule_instance)
-                    logger.info("Rule %-30s enabled (custom: %s)", rule_instance.rule_id, path.name)
-                else:
-                    logger.info("Rule %-30s skipped (custom: %s)", rule_instance.rule_id, path.name)
+                    if self._rule_ids or self.config.is_rule_enabled(
+                        rule_instance.rule_id,
+                        self.context,
+                        rule_instance.repo_types,
+                        rule_instance.formats,
+                        since_version=rule_instance.since,
+                    ):
+                        rule_instance._source = "custom"
+                        self.rules.append(rule_instance)
+                        logger.info(
+                            "Rule %-30s enabled (custom: %s)",
+                            rule_instance.rule_id,
+                            path.name,
+                        )
+                    else:
+                        logger.info(
+                            "Rule %-30s skipped (custom: %s)",
+                            rule_instance.rule_id,
+                            path.name,
+                        )
+        except Exception as e:
+            raise ValueError(f"Failed to load custom rule from {path}: {e}") from e
 
     def _validate_config(self) -> List[RuleViolation]:
         """Check for unknown rule IDs in config"""
@@ -299,7 +313,8 @@ class Linter:
             from .baseline import filter_baselined_violations
 
             before = len(kept)
-            kept, stale = filter_baselined_violations(kept, self._baseline, self.context.root_path)
+            baseline_root = self._baseline.root_path or self.context.root_path
+            kept, stale = filter_baselined_violations(kept, self._baseline, baseline_root)
             if record_baseline:
                 self._stale_baseline_entries = stale
                 self._baseline_suppressed_count = before - len(kept)

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import fnmatch
 import importlib.util
 import logging
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -50,6 +51,7 @@ class Linter:
         rule_ids: Optional[Set[str]] = None,
         skip_rule_ids: Optional[Set[str]] = None,
         baseline: Optional["BaselineFile"] = None,
+        baseline_root: Optional[Path] = None,
         no_custom_rules: bool = False,
     ):
         self.context = context
@@ -57,6 +59,10 @@ class Linter:
         self._rule_ids = rule_ids
         self._skip_rule_ids = skip_rule_ids or set()
         self._baseline = baseline
+        # Fingerprints must be relative to the directory that owns the baseline
+        # file, not the current lint path — otherwise a baseline discovered in
+        # a parent directory never matches when linting a subdirectory.
+        self._baseline_root = baseline_root or context.root_path
         self._no_custom_rules = no_custom_rules
         self._stale_baseline_entries: List["BaselineEntry"] = []
         self._baseline_suppressed_count: int = 0
@@ -71,6 +77,13 @@ class Linter:
             if unknown:
                 formatted = ", ".join(sorted(unknown))
                 raise ValueError(f"Unknown rule(s): {formatted}")
+
+        # A typo in --skip-rule must not silently leave the rule running.
+        if self._skip_rule_ids:
+            unknown = self._skip_rule_ids - self._known_rule_ids
+            if unknown:
+                formatted = ", ".join(sorted(unknown))
+                raise ValueError(f"Unknown rule(s) in --skip-rule: {formatted}")
 
     def _load_rules(self):
         """Load all enabled rules"""
@@ -125,13 +138,22 @@ class Linter:
         path = path.resolve()
 
         if not path.exists():
-            raise FileNotFoundError(f"Custom rule file not found: {path}")
+            raise ValueError(f"Custom rule file not found: {path}")
 
         logger.info("Loading custom rules from %s", path)
 
-        spec = importlib.util.spec_from_file_location("custom_rule", path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        # Unique module name per file so two custom rule files cannot clobber
+        # each other in ``sys.modules`` (they previously all loaded as
+        # ``custom_rule``).
+        module_name = "skillsaw_custom_" + re.sub(r"\W", "_", str(path))
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, path)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        except Exception as e:
+            # Surface a friendly error (the CLI catches ValueError) instead of
+            # leaking a SyntaxError/ImportError traceback from the rule file.
+            raise ValueError(f"Failed to load custom rule from {path}: {e}") from e
 
         for name in dir(module):
             obj = getattr(module, name)
@@ -156,6 +178,7 @@ class Linter:
                     self.context,
                     rule_instance.repo_types,
                     rule_instance.formats,
+                    since_version=rule_instance.since,
                 ):
                     rule_instance._source = "custom"
                     self.rules.append(rule_instance)
@@ -273,7 +296,7 @@ class Linter:
             from .baseline import filter_baselined_violations
 
             before = len(kept)
-            kept, stale = filter_baselined_violations(kept, self._baseline, self.context.root_path)
+            kept, stale = filter_baselined_violations(kept, self._baseline, self._baseline_root)
             if record_baseline:
                 self._stale_baseline_entries = stale
                 self._baseline_suppressed_count = before - len(kept)

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -51,7 +51,6 @@ class Linter:
         rule_ids: Optional[Set[str]] = None,
         skip_rule_ids: Optional[Set[str]] = None,
         baseline: Optional["BaselineFile"] = None,
-        baseline_root: Optional[Path] = None,
         no_custom_rules: bool = False,
     ):
         self.context = context
@@ -59,10 +58,6 @@ class Linter:
         self._rule_ids = rule_ids
         self._skip_rule_ids = skip_rule_ids or set()
         self._baseline = baseline
-        # Fingerprints must be relative to the directory that owns the baseline
-        # file, not the current lint path — otherwise a baseline discovered in
-        # a parent directory never matches when linting a subdirectory.
-        self._baseline_root = baseline_root or context.root_path
         self._no_custom_rules = no_custom_rules
         self._stale_baseline_entries: List["BaselineEntry"] = []
         self._baseline_suppressed_count: int = 0
@@ -304,7 +299,7 @@ class Linter:
             from .baseline import filter_baselined_violations
 
             before = len(kept)
-            kept, stale = filter_baselined_violations(kept, self._baseline, self._baseline_root)
+            kept, stale = filter_baselined_violations(kept, self._baseline, self.context.root_path)
             if record_baseline:
                 self._stale_baseline_entries = stale
                 self._baseline_suppressed_count = before - len(kept)

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -149,7 +149,15 @@ class Linter:
         try:
             spec = importlib.util.spec_from_file_location(module_name, path)
             module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            # Register before exec (the documented module_from_spec pattern) so
+            # the module is importable by name and rule classes carry a distinct
+            # __module__ — this is what keeps two rule files from colliding.
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            except Exception:
+                sys.modules.pop(module_name, None)
+                raise
         except Exception as e:
             # Surface a friendly error (the CLI catches ValueError) instead of
             # leaking a SyntaxError/ImportError traceback from the rule file.

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -39,6 +39,11 @@ class RuleViolation:
     block: Optional["ContentBlock"] = field(default=None, repr=False)
     source: str = "builtin"
     value: Optional[float] = None
+    # Optional discriminator for rules that emit more than one ratchet
+    # (value-carrying) violation per file, so their baseline fingerprints
+    # don't collide. Example: context-budget emits whole-file and
+    # per-description token violations for the same SKILL.md.
+    metric: Optional[str] = None
 
     def __post_init__(self):
         if self.block is None and self.file_path is not None:
@@ -186,16 +191,18 @@ class Rule(ABC):
     def violation(
         self,
         message: str,
-        file_path: Path = None,
-        line: int = None,
-        severity: Severity = None,
-        block: "ContentBlock" = None,
-        value: float = None,
+        file_path: Optional[Path] = None,
+        line: Optional[int] = None,
+        severity: Optional[Severity] = None,
+        block: Optional["ContentBlock"] = None,
+        value: Optional[float] = None,
+        metric: Optional[str] = None,
     ) -> RuleViolation:
         """Create a violation for this rule.
 
         Pass ``block`` for content-based violations.  ``file_path`` is
         accepted for backward compatibility and auto-wraps into a block.
+        ``metric`` disambiguates multiple ratchet violations per file.
         """
         return RuleViolation(
             rule_id=self.rule_id,
@@ -206,4 +213,5 @@ class Rule(ABC):
             block=block,
             source=self._source,
             value=value,
+            metric=metric,
         )

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -25,6 +25,7 @@ import yaml
 from skillsaw.context import RepositoryContext
 from skillsaw.lint_target import LintTarget
 from ruamel.yaml import YAML as _RuamelYAML
+from ruamel.yaml import YAMLError as _RuamelYAMLError
 
 from skillsaw.rules.builtin.utils import (
     _FRONTMATTER_RE,
@@ -39,6 +40,7 @@ from skillsaw.rules.builtin.utils import (
     yaml_key_lines as _yaml_key_lines_util,
     yaml_nth_key_line as _yaml_nth_key_line_util,
     yaml_nth_list_item_key_line as _yaml_nth_list_item_key_line_util,
+    yaml_node_line as _yaml_node_line_util,
 )
 
 # Markdown structure (fences, code spans, HTML comments, links, headings) is
@@ -254,40 +256,45 @@ class CodeRabbitContentBlock(ContentBlock):
         return self.body if self.body is not None else ""
 
     def write_body(self, new_body: str) -> None:
-        ruyaml = _RuamelYAML()
-        ruyaml.preserve_quotes = True
-        raw = self.path.read_text(encoding="utf-8")
-        data = ruyaml.load(raw)
-        if data is None:
-            return
-
-        parts = self.yaml_path.split(".")
-        node = data
-        for i, part in enumerate(parts[:-1]):
-            if "[" in part:
-                key = part[: part.index("[")]
-                node = node.get(key) if isinstance(node, dict) else None
-            else:
-                node = node.get(part) if isinstance(node, dict) else None
-            if node is None:
+        # ``yaml_path`` uses index-based list accessors (e.g.
+        # ``reviews.path_instructions[0].instructions``) so a path glob that
+        # itself contains dots/brackets (``**/*.py``) can never corrupt the
+        # traversal.  Any unexpected structure degrades to a no-op rather than
+        # crashing the fix run.
+        try:
+            ruyaml = _RuamelYAML()
+            ruyaml.preserve_quotes = True
+            raw = self.path.read_text(encoding="utf-8")
+            data = ruyaml.load(raw)
+            if data is None:
                 return
 
-            if isinstance(node, list) and "[" in parts[i]:
-                bracket_val = parts[i][parts[i].index("[") + 1 : parts[i].index("]")]
-                for item in node:
-                    if isinstance(item, dict):
-                        name = item.get("name") or item.get("path")
-                        if str(name) == bracket_val:
-                            node = item
-                            break
+            parts = [p for p in re.split(r"\.|(?=\[)", self.yaml_path) if p]
+            if not parts:
+                return
+            node = data
+            for part in parts[:-1]:
+                idx_match = re.fullmatch(r"\[(\d+)\]", part)
+                if idx_match:
+                    idx = int(idx_match.group(1))
+                    if not isinstance(node, list) or idx >= len(node):
+                        return
+                    node = node[idx]
+                else:
+                    if not isinstance(node, dict) or part not in node:
+                        return
+                    node = node[part]
 
-        last_key = parts[-1]
-        if isinstance(node, dict) and last_key in node:
+            last_key = parts[-1]
+            if not (isinstance(node, dict) and last_key in node):
+                return
             node[last_key] = new_body
 
-        buf = StringIO()
-        ruyaml.dump(data, buf)
-        self.path.write_text(buf.getvalue(), encoding="utf-8")
+            buf = StringIO()
+            ruyaml.dump(data, buf)
+            self.path.write_text(buf.getvalue(), encoding="utf-8")
+        except (OSError, UnicodeDecodeError, _RuamelYAMLError):
+            return
 
     def tree_label(self) -> str:
         return f"{self.yaml_path} ({self.category})"
@@ -386,11 +393,13 @@ class CodeRabbitContentBlock(ContentBlock):
                         continue
                     pi = entry.get("instructions")
                     if isinstance(pi, str) and pi.strip():
-                        path_val = entry.get("path", f"[{idx}]")
-                        line = cls._find_nth_key_line(raw, "instructions", len(results))
-                        results.append(
-                            (f"reviews.path_instructions[{path_val}].instructions", pi, line)
-                        )
+                        # Index-based path: resolves the exact list element by
+                        # position rather than by an nth-"instructions" count
+                        # over the whole document (which mis-attributed lines
+                        # when other 'instructions' keys preceded it).
+                        yaml_path = f"reviews.path_instructions[{idx}].instructions"
+                        line = _yaml_node_line_util(raw, yaml_path)
+                        results.append((yaml_path, pi, line))
 
             tools = reviews.get("tools")
             if isinstance(tools, dict):
@@ -399,36 +408,24 @@ class CodeRabbitContentBlock(ContentBlock):
                         continue
                     ti = tool_cfg.get("instructions")
                     if isinstance(ti, str) and ti.strip():
-                        tool_line = cls._find_yaml_key_line(raw, tool_name)
-                        line = None
-                        if tool_line is not None:
-                            line = cls._find_yaml_key_line_after(raw, "instructions", tool_line)
-                        results.append((f"reviews.tools.{tool_name}.instructions", ti, line))
+                        yaml_path = f"reviews.tools.{tool_name}.instructions"
+                        line = _yaml_node_line_util(raw, yaml_path)
+                        results.append((yaml_path, ti, line))
 
             pre_merge = reviews.get("pre_merge_checks")
             if isinstance(pre_merge, dict):
                 custom_checks = pre_merge.get("custom_checks")
                 if isinstance(custom_checks, list):
-                    custom_checks_line = cls._find_yaml_key_line(raw, "custom_checks") or 0
                     for idx, check in enumerate(custom_checks):
                         if not isinstance(check, dict):
                             continue
                         ci = check.get("instructions")
                         if isinstance(ci, str) and ci.strip():
-                            check_name = check.get("name", f"[{idx}]")
-                            name_line = cls._find_nth_list_item_key_line(
-                                raw, "name", idx, after_line=custom_checks_line
+                            yaml_path = (
+                                f"reviews.pre_merge_checks.custom_checks[{idx}].instructions"
                             )
-                            line = None
-                            if name_line is not None:
-                                line = cls._find_yaml_key_line_after(raw, "instructions", name_line)
-                            results.append(
-                                (
-                                    f"reviews.pre_merge_checks.custom_checks[{check_name}].instructions",
-                                    ci,
-                                    line,
-                                )
-                            )
+                            line = _yaml_node_line_util(raw, yaml_path)
+                            results.append((yaml_path, ci, line))
 
         chat = data.get("chat")
         if isinstance(chat, dict):
@@ -506,17 +503,28 @@ class PromptfooPromptBlock(ContentBlock):
             prompts = data.get("prompts")
             if not isinstance(prompts, list):
                 continue
+            raw_lines = read_text(node.path)
+            raw_lines = raw_lines.splitlines() if raw_lines else []
             for i, prompt in enumerate(prompts):
                 if not isinstance(prompt, str) or not prompt.strip():
                     continue
                 if cls._TEMPLATE_ONLY_RE.match(prompt):
                     continue
                 line = commented_item_line(prompts, i) or 0
+                # A plain one-line item (``- "text"``) has its content on the
+                # same line, so body line 1 maps to ``line`` (offset = line-1).
+                # A block scalar (``- |``) starts content on the *next* line, so
+                # offset = line.  Mirrors CodeRabbitContentBlock.gather.
+                offset = line
+                if line and 1 <= line <= len(raw_lines):
+                    item_text = raw_lines[line - 1]
+                    is_block_scalar = bool(re.search(r"[|>][+-]?\d*\s*$", item_text))
+                    offset = line if is_block_scalar else max(line - 1, 0)
                 blocks.append(
                     cls(
                         path=node.path,
                         body=prompt,
-                        line_offset=line,
+                        line_offset=offset,
                         yaml_path=f"prompts[{i}]",
                     )
                 )

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -520,8 +520,11 @@ class PromptfooPromptBlock(ContentBlock):
                     item_text = raw_lines[line - 1]
                     # Block-scalar header: ``|``/``>`` plus an optional
                     # indentation indicator and chomping indicator in either
-                    # order (``|``, ``|-``, ``|2``, ``|2-``, ``>2+`` ...).
-                    is_block_scalar = bool(re.search(r"[|>](?:\d+[+-]?|[+-]?\d*)\s*$", item_text))
+                    # order (``|``, ``|-``, ``|2``, ``|2-``, ``>2+`` ...), and an
+                    # optional trailing YAML comment (``- | # system prompt``).
+                    is_block_scalar = bool(
+                        re.search(r"[|>](?:\d+[+-]?|[+-]?\d*)\s*(?:#.*)?$", item_text)
+                    )
                     offset = line if is_block_scalar else max(line - 1, 0)
                 blocks.append(
                     cls(

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -518,7 +518,10 @@ class PromptfooPromptBlock(ContentBlock):
                 offset = line
                 if line and 1 <= line <= len(raw_lines):
                     item_text = raw_lines[line - 1]
-                    is_block_scalar = bool(re.search(r"[|>][+-]?\d*\s*$", item_text))
+                    # Block-scalar header: ``|``/``>`` plus an optional
+                    # indentation indicator and chomping indicator in either
+                    # order (``|``, ``|-``, ``|2``, ``|2-``, ``>2+`` ...).
+                    is_block_scalar = bool(re.search(r"[|>](?:\d+[+-]?|[+-]?\d*)\s*$", item_text))
                     offset = line if is_block_scalar else max(line - 1, 0)
                 blocks.append(
                     cls(

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -336,7 +336,9 @@ class CodeRabbitContentBlock(ContentBlock):
             offset = 0
             if line:
                 key_text = cr_lines[line - 1] if line <= len(cr_lines) else ""
-                is_block_scalar = bool(re.search(r":\s*[|>]", key_text))
+                is_block_scalar = bool(
+                    re.search(r":\s*[|>](?:[+-]?[1-9]|[1-9]?[+-])?\s*(?:#.*)?$", key_text)
+                )
                 offset = line if is_block_scalar else (line - 1)
             results.append(
                 CodeRabbitContentBlock(

--- a/src/skillsaw/rules/builtin/context_budget/budget.py
+++ b/src/skillsaw/rules/builtin/context_budget/budget.py
@@ -102,6 +102,10 @@ class ContextBudgetRule(Rule):
             return
         tokens = _estimate_tokens(content)
 
+        # The whole-file budget violation keeps the legacy (metric-less)
+        # fingerprint so existing baselines keep matching after upgrade; only
+        # the per-description violation below carries a metric to break the
+        # collision between the two ratchet violations on one file.
         if error_limit is not None and tokens > error_limit:
             violations.append(
                 self.violation(
@@ -109,7 +113,6 @@ class ContextBudgetRule(Rule):
                     file_path=file_path,
                     severity=Severity.ERROR,
                     value=tokens,
-                    metric=category,
                 )
             )
         elif warn_limit is not None and tokens > warn_limit:
@@ -119,7 +122,6 @@ class ContextBudgetRule(Rule):
                     file_path=file_path,
                     severity=Severity.WARNING,
                     value=tokens,
-                    metric=category,
                 )
             )
 

--- a/src/skillsaw/rules/builtin/context_budget/budget.py
+++ b/src/skillsaw/rules/builtin/context_budget/budget.py
@@ -109,6 +109,7 @@ class ContextBudgetRule(Rule):
                     file_path=file_path,
                     severity=Severity.ERROR,
                     value=tokens,
+                    metric=category,
                 )
             )
         elif warn_limit is not None and tokens > warn_limit:
@@ -118,6 +119,7 @@ class ContextBudgetRule(Rule):
                     file_path=file_path,
                     severity=Severity.WARNING,
                     value=tokens,
+                    metric=category,
                 )
             )
 
@@ -149,6 +151,7 @@ class ContextBudgetRule(Rule):
                             line=block.key_line("description"),
                             severity=Severity.ERROR,
                             value=tokens,
+                            metric=category,
                         )
                     )
                 elif warn_limit is not None and tokens > warn_limit:
@@ -160,6 +163,7 @@ class ContextBudgetRule(Rule):
                             line=block.key_line("description"),
                             severity=Severity.WARNING,
                             value=tokens,
+                            metric=category,
                         )
                     )
 

--- a/src/skillsaw/rules/builtin/utils.py
+++ b/src/skillsaw/rules/builtin/utils.py
@@ -337,8 +337,11 @@ def parse_frontmatter(content: str) -> Tuple[Optional[Dict[str, Any]], str, Opti
 def extract_section(content: str, heading: str, level: int = 2) -> str:
     """Extract content under a markdown heading, up to the next heading of same or higher level."""
     prefix = "#" * level
+    # ``\r?`` must precede ``$``: in MULTILINE mode ``$`` matches before ``\n``,
+    # so on a CRLF line the ``\r`` sits before that position and the heading
+    # would never match if ``\r?`` came after ``$``.
     pattern = re.compile(
-        rf"^{prefix}[ \t]+{re.escape(heading)}[ \t]*$\r?\n?(.*?)(?=^#{{{1},{level}}}[ \t]|\Z)",
+        rf"^{prefix}[ \t]+{re.escape(heading)}[ \t]*\r?$\n?(.*?)(?=^#{{{1},{level}}}[ \t]|\Z)",
         re.MULTILINE | re.DOTALL,
     )
     m = pattern.search(content)

--- a/src/skillsaw/suppression.py
+++ b/src/skillsaw/suppression.py
@@ -50,16 +50,21 @@ from typing import Dict, FrozenSet, List, Optional, Set
 # ``<!-- TODO: document skillsaw-disable -->`` — is inert rather than silently
 # disabling every rule.  The ``(?![\w-])`` boundary stops ``skillsaw-disabled``
 # / ``skillsaw-disablement`` from being read as a bare ``disable`` directive.
+#
+# The patterns are also end-anchored (``\s*$``): the directive plus its
+# optional comma-separated rule list must be the *entire* comment text, so
+# trailing punctuation (``skillsaw-disable.``) or stray suffixes
+# (``skillsaw-disable-next-line:``) are not misread as a bare suppress-all.
 _DISABLE_NEXT_LINE_DIR = re.compile(
-    r"^skillsaw-disable-next-line(?![\w-])(?:\s+([\w,\s-]+))?",
+    r"^skillsaw-disable-next-line(?![\w-])(?:\s+([\w,\s-]+))?\s*$",
     re.IGNORECASE,
 )
 _DISABLE_DIR = re.compile(
-    r"^skillsaw-disable(?!-next-line)(?![\w-])\s*([\w,\s-]*)",
+    r"^skillsaw-disable(?!-next-line)(?![\w-])(?:\s+([\w,\s-]+))?\s*$",
     re.IGNORECASE,
 )
 _ENABLE_DIR = re.compile(
-    r"^skillsaw-enable(?![\w-])\s*([\w,\s-]*)",
+    r"^skillsaw-enable(?![\w-])(?:\s+([\w,\s-]+))?\s*$",
     re.IGNORECASE,
 )
 
@@ -87,15 +92,15 @@ class _Directive:
 
 def _classify_directive(text: str, line: int, **kwargs) -> Optional[_Directive]:
     """Parse a normalised comment text into a directive, if it is one."""
-    m = _DISABLE_NEXT_LINE_DIR.search(text)
+    m = _DISABLE_NEXT_LINE_DIR.match(text)
     if m:
         return _Directive("disable-next-line", _parse_rule_ids(m.group(1) or ""), line, **kwargs)
-    m = _DISABLE_DIR.search(text)
+    m = _DISABLE_DIR.match(text)
     if m:
-        return _Directive("disable", _parse_rule_ids(m.group(1).strip()), line, **kwargs)
-    m = _ENABLE_DIR.search(text)
+        return _Directive("disable", _parse_rule_ids((m.group(1) or "").strip()), line, **kwargs)
+    m = _ENABLE_DIR.match(text)
     if m:
-        return _Directive("enable", _parse_rule_ids(m.group(1).strip()), line, **kwargs)
+        return _Directive("enable", _parse_rule_ids((m.group(1) or "").strip()), line, **kwargs)
     return None
 
 

--- a/src/skillsaw/suppression.py
+++ b/src/skillsaw/suppression.py
@@ -44,16 +44,22 @@ from typing import Dict, FrozenSet, List, Optional, Set
 
 # Directive patterns applied to the *text inside* an HTML comment.
 # These match the full comment body, allowing arbitrary whitespace/newlines.
+#
+# Directives are anchored to the *start* of the (whitespace-normalised) comment
+# text so that prose merely mentioning a directive — e.g.
+# ``<!-- TODO: document skillsaw-disable -->`` — is inert rather than silently
+# disabling every rule.  The ``(?![\w-])`` boundary stops ``skillsaw-disabled``
+# / ``skillsaw-disablement`` from being read as a bare ``disable`` directive.
 _DISABLE_NEXT_LINE_DIR = re.compile(
-    r"skillsaw-disable-next-line(?![\w-])(?:\s+([\w,\s-]+))?",
+    r"^skillsaw-disable-next-line(?![\w-])(?:\s+([\w,\s-]+))?",
     re.IGNORECASE,
 )
 _DISABLE_DIR = re.compile(
-    r"skillsaw-disable(?!-next-line)\s*([\w,\s-]*)",
+    r"^skillsaw-disable(?!-next-line)(?![\w-])\s*([\w,\s-]*)",
     re.IGNORECASE,
 )
 _ENABLE_DIR = re.compile(
-    r"skillsaw-enable\s*([\w,\s-]*)",
+    r"^skillsaw-enable(?![\w-])\s*([\w,\s-]*)",
     re.IGNORECASE,
 )
 
@@ -125,44 +131,41 @@ def _extract_html_directives(content: str) -> List[_Directive]:
     return parser.directives
 
 
-def _extract_markdown_directives(content: str) -> List[_Directive]:
-    """Extract directives from HTML comments via the markdown AST.
-
-    Unlike a raw scan, this honours markdown structure: a directive shown
-    inside a fenced or indented code block is documentation, not a directive.
-    """
-    from skillsaw.markdown_doc import MarkdownDoc
-
-    directives: List[_Directive] = []
-    for comment in MarkdownDoc(content).html_comments():
-        text = " ".join(comment.text.split())
-        directive = _classify_directive(
-            text, comment.body_line_start, end_line=comment.body_line_end
-        )
-        if directive is not None:
-            directives.append(directive)
-    return directives
-
-
-def _extract_yaml_directives(content: str) -> List[_Directive]:
+def _extract_yaml_directives(
+    content: str, skip_lines: Optional[Set[int]] = None
+) -> List[_Directive]:
     """Extract skillsaw directives from YAML ``#`` comments.
 
     Only full-line comments are matched (``#`` must be the first non-whitespace
     character).  Inline comments like ``key: value # skillsaw-disable`` are
     ignored to avoid ambiguity.
+
+    *skip_lines* is a set of 1-based line numbers to ignore — used in markdown
+    to skip ``#`` lines that fall inside fenced or indented code blocks, where a
+    directive is documentation rather than a live directive.
     """
     directives: List[_Directive] = []
     for lineno_0, raw_line in enumerate(content.splitlines()):
+        line = lineno_0 + 1  # 1-based
+        if skip_lines and line in skip_lines:
+            continue
         m = _YAML_COMMENT_RE.match(raw_line)
         if not m:
             continue
         text = m.group(1).strip()
-        line = lineno_0 + 1  # 1-based
         directive = _classify_directive(text, line, is_yaml=True)
         if directive is not None:
             directives.append(directive)
 
     return directives
+
+
+def _fence_line_set(doc) -> Set[int]:
+    """1-based body line numbers covered by fenced/indented code blocks."""
+    code_lines: Set[int] = set()
+    for fence in doc.fences():
+        code_lines.update(range(fence.body_line_start, fence.body_line_end + 1))
+    return code_lines
 
 
 def _extract_directives(content: str, *, markdown: bool = True) -> List[_Directive]:
@@ -172,13 +175,25 @@ def _extract_directives(content: str, *, markdown: bool = True) -> List[_Directi
     syntaxes don't overlap so results are simply merged by line number.
 
     When *markdown* is true, HTML comments are located through the markdown
-    AST so directives shown inside fenced code blocks are not honoured.
+    AST and ``#`` directives inside fenced/indented code blocks are ignored, so
+    a directive shown as a documentation example does not silently fire.
     """
     if markdown:
-        html = _extract_markdown_directives(content)
+        from skillsaw.markdown_doc import MarkdownDoc
+
+        doc = MarkdownDoc(content)
+        html: List[_Directive] = []
+        for comment in doc.html_comments():
+            text = " ".join(comment.text.split())
+            directive = _classify_directive(
+                text, comment.body_line_start, end_line=comment.body_line_end
+            )
+            if directive is not None:
+                html.append(directive)
+        yaml = _extract_yaml_directives(content, skip_lines=_fence_line_set(doc))
     else:
         html = _extract_html_directives(content)
-    yaml = _extract_yaml_directives(content)
+        yaml = _extract_yaml_directives(content)
     return sorted(html + yaml, key=lambda d: d.line)
 
 

--- a/tests/fixtures/cli-overrides/type-override/commands/foo.md
+++ b/tests/fixtures/cli-overrides/type-override/commands/foo.md
@@ -1,0 +1,1 @@
+Missing frontmatter

--- a/tests/fixtures/cli-overrides/type-unknown/README.md
+++ b/tests/fixtures/cli-overrides/type-unknown/README.md
@@ -1,0 +1,1 @@
+Fixture used for CLI type override validation.

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -505,16 +505,19 @@ class TestBaselineRootStability:
         v = _make_violation(rule_id="weak", file_path=src, line=1, message="weak")
         built = build_baseline([v], tmp_path, "0.14.0")
         assert built.violations[0].file_path == "skills/s/SKILL.md"
+        assert built.root_path == tmp_path.resolve()
 
-        # Failing control: fingerprinting against the subdirectory (the old
-        # buggy behavior) does NOT match — the violation would be reported.
         lint_subdir = tmp_path / "skills" / "s"
-        kept_wrong, _ = filter_baselined_violations([v], built, lint_subdir)
-        assert len(kept_wrong) == 1
+        kept, stale = filter_baselined_violations([v], built, lint_subdir)
+        assert kept == []
+        assert stale == []
 
-        # Filtering against the directory that owns the baseline file suppresses
-        # it, even though the "lint path" is the subdirectory.
-        kept, stale = filter_baselined_violations([v], built, tmp_path)
+        baseline_path = tmp_path / BASELINE_FILENAME
+        save_baseline(baseline_path, built)
+        loaded = load_baseline(baseline_path)
+        assert loaded.root_path == tmp_path.resolve()
+
+        kept, stale = filter_baselined_violations([v], loaded, lint_subdir)
         assert kept == []
         assert stale == []
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -432,9 +432,18 @@ class TestRatchetMetricDiscriminator:
         return v
 
     def test_metric_distinguishes_fingerprints(self, tmp_path):
-        file_v = self._v(tmp_path, 5000, metric="skill")
+        # The whole-file violation stays metric-less (legacy fingerprint); only
+        # the description carries a metric. They must not collide.
+        file_v = self._v(tmp_path, 5000, metric=None)
         desc_v = self._v(tmp_path, 80, metric="skill-description", line=2)
         assert fingerprint_violation(file_v, tmp_path) != fingerprint_violation(desc_v, tmp_path)
+
+    def test_whole_file_keeps_legacy_fingerprint(self, tmp_path):
+        """Backward-compat: the whole-file ratchet fingerprint is unchanged so a
+        pre-upgrade baseline keeps matching after the metric was added."""
+        file_v = self._v(tmp_path, 5000, metric=None)
+        legacy = hashlib.sha256(b"context-budget\0SKILL.md").hexdigest()[:16]
+        assert fingerprint_violation(file_v, tmp_path) == legacy
 
     def test_no_metric_keeps_legacy_fingerprint(self, tmp_path):
         """Backward-compat: an empty metric must not change the fingerprint."""
@@ -445,8 +454,9 @@ class TestRatchetMetricDiscriminator:
 
     def test_both_metrics_ratchet_independently(self, tmp_path):
         """A regression in one metric is not masked by the other's baseline."""
+        # Whole-file entry: legacy (metric-less) fingerprint.
         file_entry = BaselineEntry(
-            fingerprint=hashlib.sha256(b"context-budget\0SKILL.md\0skill").hexdigest()[:16],
+            fingerprint=hashlib.sha256(b"context-budget\0SKILL.md").hexdigest()[:16],
             rule_id="context-budget",
             file_path="SKILL.md",
             line=None,
@@ -455,6 +465,7 @@ class TestRatchetMetricDiscriminator:
             value=5000,
             baseline_mode="ceiling",
         )
+        # Description entry: metric-tagged fingerprint.
         desc_entry = BaselineEntry(
             fingerprint=hashlib.sha256(b"context-budget\0SKILL.md\0skill-description").hexdigest()[
                 :16
@@ -473,8 +484,8 @@ class TestRatchetMetricDiscriminator:
             generated_at="2025-01-01T00:00:00+00:00",
             violations=[file_entry, desc_entry],
         )
-        # File metric improved (suppressed), description metric regressed (kept).
-        file_v = self._v(tmp_path, 4800, metric="skill")
+        # Whole-file improved (suppressed), description regressed (kept).
+        file_v = self._v(tmp_path, 4800, metric=None)
         desc_v = self._v(tmp_path, 120, metric="skill-description", line=2)
         kept, stale = filter_baselined_violations([file_v, desc_v], baseline, tmp_path)
         assert len(kept) == 1

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -495,9 +495,14 @@ class TestBaselineRootStability:
         built = build_baseline([v], tmp_path, "0.14.0")
         assert built.violations[0].file_path == "skills/s/SKILL.md"
 
-        # Filtering the same violation against the repo-root baseline (the
-        # directory that owns the baseline file) must suppress it, even though
-        # the "lint path" is the subdirectory.
+        # Failing control: fingerprinting against the subdirectory (the old
+        # buggy behavior) does NOT match — the violation would be reported.
+        lint_subdir = tmp_path / "skills" / "s"
+        kept_wrong, _ = filter_baselined_violations([v], built, lint_subdir)
+        assert len(kept_wrong) == 1
+
+        # Filtering against the directory that owns the baseline file suppresses
+        # it, even though the "lint path" is the subdirectory.
         kept, stale = filter_baselined_violations([v], built, tmp_path)
         assert kept == []
         assert stale == []

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -417,6 +417,92 @@ class TestFindBaseline:
         assert find_baseline(tmp_path) is None
 
 
+class TestRatchetMetricDiscriminator:
+    """Regression: two ratchet violations on one file must not collide (§1.11)."""
+
+    def _v(self, tmp_path, value, metric=None, line=None):
+        src = tmp_path / "SKILL.md"
+        if not src.exists():
+            src.write_text("content\n")
+        v = _make_violation(
+            rule_id="context-budget", file_path=src, line=line, message=f"value={value}"
+        )
+        v.value = value
+        v.metric = metric
+        return v
+
+    def test_metric_distinguishes_fingerprints(self, tmp_path):
+        file_v = self._v(tmp_path, 5000, metric="skill")
+        desc_v = self._v(tmp_path, 80, metric="skill-description", line=2)
+        assert fingerprint_violation(file_v, tmp_path) != fingerprint_violation(desc_v, tmp_path)
+
+    def test_no_metric_keeps_legacy_fingerprint(self, tmp_path):
+        """Backward-compat: an empty metric must not change the fingerprint."""
+        v = self._v(tmp_path, 5000, metric=None)
+        rel = "SKILL.md"
+        legacy = hashlib.sha256(f"context-budget\0{rel}".encode()).hexdigest()[:16]
+        assert fingerprint_violation(v, tmp_path) == legacy
+
+    def test_both_metrics_ratchet_independently(self, tmp_path):
+        """A regression in one metric is not masked by the other's baseline."""
+        file_entry = BaselineEntry(
+            fingerprint=hashlib.sha256(b"context-budget\0SKILL.md\0skill").hexdigest()[:16],
+            rule_id="context-budget",
+            file_path="SKILL.md",
+            line=None,
+            message="file",
+            severity="warning",
+            value=5000,
+            baseline_mode="ceiling",
+        )
+        desc_entry = BaselineEntry(
+            fingerprint=hashlib.sha256(b"context-budget\0SKILL.md\0skill-description").hexdigest()[
+                :16
+            ],
+            rule_id="context-budget",
+            file_path="SKILL.md",
+            line=None,
+            message="desc",
+            severity="warning",
+            value=80,
+            baseline_mode="ceiling",
+        )
+        baseline = BaselineFile(
+            version="1",
+            generated_by="test",
+            generated_at="2025-01-01T00:00:00+00:00",
+            violations=[file_entry, desc_entry],
+        )
+        # File metric improved (suppressed), description metric regressed (kept).
+        file_v = self._v(tmp_path, 4800, metric="skill")
+        desc_v = self._v(tmp_path, 120, metric="skill-description", line=2)
+        kept, stale = filter_baselined_violations([file_v, desc_v], baseline, tmp_path)
+        assert len(kept) == 1
+        assert kept[0].metric == "skill-description"
+        assert stale == []
+
+
+class TestBaselineRootStability:
+    """Regression: a baseline matches when lint runs from a subdirectory (§1.3)."""
+
+    def test_fingerprint_relative_to_baseline_root(self, tmp_path):
+        # Baseline built at the repo root over skills/s/SKILL.md.
+        skill = tmp_path / "skills" / "s"
+        skill.mkdir(parents=True)
+        src = skill / "SKILL.md"
+        src.write_text("You should probably try to do it\n")
+        v = _make_violation(rule_id="weak", file_path=src, line=1, message="weak")
+        built = build_baseline([v], tmp_path, "0.14.0")
+        assert built.violations[0].file_path == "skills/s/SKILL.md"
+
+        # Filtering the same violation against the repo-root baseline (the
+        # directory that owns the baseline file) must suppress it, even though
+        # the "lint path" is the subdirectory.
+        kept, stale = filter_baselined_violations([v], built, tmp_path)
+        assert kept == []
+        assert stale == []
+
+
 class TestBuildBaseline:
     def test_builds_from_violations(self, tmp_path):
         src = tmp_path / "CLAUDE.md"

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -15,6 +15,7 @@ from skillsaw.rules.builtin.content_analysis import (
     gather_all_content_files,
     _get_body_from_cf,
     ContentFile,
+    CodeRabbitContentBlock,
 )
 from skillsaw.rules.builtin.content_rules import (
     ContentWeakLanguageRule,
@@ -288,8 +289,14 @@ class TestExtractInstructions:
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
-        assert "src/**" in result[0][0]
-        assert "tests/**" in result[1][0]
+        # Index-based yaml_path (robust against globs containing dots/brackets).
+        assert result[0][0] == "reviews.path_instructions[0].instructions"
+        assert result[0][1] == "Check src."
+        assert result[1][0] == "reviews.path_instructions[1].instructions"
+        assert result[1][1] == "Check tests."
+        # Lines point at the correct 'instructions' key for each entry.
+        assert result[0][2] == 4
+        assert result[1][2] == 6
 
     def test_tool_instructions(self):
         raw = (
@@ -342,9 +349,9 @@ class TestExtractInstructions:
         data = yaml.safe_load(raw)
         result = _extract_instructions(data, raw)
         assert len(result) == 2
-        assert "Go Error Handling" in result[0][0]
+        assert result[0][0] == "reviews.pre_merge_checks.custom_checks[0].instructions"
         assert result[0][1] == "Check error handling."
-        assert "SQL Injection" in result[1][0]
+        assert result[1][0] == "reviews.pre_merge_checks.custom_checks[1].instructions"
         assert result[1][1] == "Prevent SQL injection."
 
     def test_custom_check_instructions_line_numbers(self):
@@ -503,3 +510,40 @@ class TestCoderabbitWriterRoundTrip:
         assert "Better review stuff." in updated
         assert "language: en-US" in updated
         assert "high_level_summary: true" in updated
+
+    def test_write_body_path_instructions_with_dotted_glob(self, temp_dir):
+        """Regression (§1.5): a path glob containing a dot must not crash write_body."""
+        yaml_content = (
+            "reviews:\n"
+            "  path_instructions:\n"
+            '    - path: "**/*.py"\n'
+            "      instructions: 'Try to be careful.'\n"
+            '    - path: "src/*.ts"\n'
+            "      instructions: 'Check the types.'\n"
+        )
+        cr_path = temp_dir / ".coderabbit.yaml"
+        cr_path.write_text(yaml_content)
+        context = RepositoryContext(temp_dir)
+        cr_files = [cf for cf in gather_all_content_files(context) if cf.category == "coderabbit"]
+        py_block = [cf for cf in cr_files if cf.body == "Try to be careful."][0]
+        py_block.write_body("Be precise and thorough.")
+
+        updated = yaml.safe_load(cr_path.read_text(encoding="utf-8"))
+        pis = updated["reviews"]["path_instructions"]
+        # Only the targeted entry changed; the other and its glob are intact.
+        assert pis[0]["path"] == "**/*.py"
+        assert pis[0]["instructions"] == "Be precise and thorough."
+        assert pis[1]["instructions"] == "Check the types."
+
+    def test_write_body_missing_path_is_noop(self, temp_dir):
+        """A yaml_path that no longer resolves degrades to a no-op, not a crash."""
+        cr_path = temp_dir / ".coderabbit.yaml"
+        cr_path.write_text("reviews:\n  instructions: 'Keep me.'\n")
+        block = CodeRabbitContentBlock(
+            path=cr_path,
+            category="coderabbit",
+            body="x",
+            yaml_path="reviews.path_instructions[9].instructions",
+        )
+        block.write_body("ignored")  # must not raise
+        assert "Keep me." in cr_path.read_text(encoding="utf-8")

--- a/tests/test_coderabbit_rules.py
+++ b/tests/test_coderabbit_rules.py
@@ -242,6 +242,18 @@ class TestGatherContentFilesCoderabbit:
         # Body line 1 should map to file line 3 (one past the key line)
         assert cr_files[0].file_line(1) == 3
 
+    def test_line_offsets_plain_scalar_with_quoted_block_marker_text(self, temp_dir):
+        (temp_dir / ".coderabbit.yaml").write_text(
+            "reviews:\n"  # 1
+            '  instructions: "Mention marker: | but stay on one line."\n'  # 2
+        )
+        context = RepositoryContext(temp_dir)
+        files = gather_all_content_files(context)
+        cr_files = [cf for cf in files if cf.category == "coderabbit"]
+        assert len(cr_files) == 1
+        # The quoted ": |" belongs to the scalar value, not YAML block syntax.
+        assert cr_files[0].file_line(1) == 2
+
     def test_no_instructions_yields_nothing(self, temp_dir):
         (temp_dir / ".coderabbit.yaml").write_text("language: en-US\n")
         context = RepositoryContext(temp_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1122,9 +1122,9 @@ def test_non_mapping_llm_raises_valueerror(tmp_path):
 def test_llm_field_type_validation(tmp_path):
     import pytest
 
-    with pytest.raises(ValueError, match="'llm.max_iterations' must be an integer"):
+    with pytest.raises(ValueError, match=r"'llm\.max_iterations' must be an integer"):
         LinterConfig.from_file(_write(tmp_path, "llm:\n  max_iterations: ten\n"))
-    with pytest.raises(ValueError, match="'llm.confirm' must be a boolean"):
+    with pytest.raises(ValueError, match=r"'llm\.confirm' must be a boolean"):
         LinterConfig.from_file(_write(tmp_path, "llm:\n  confirm: maybe\n"))
 
 
@@ -1159,6 +1159,15 @@ def test_present_version_no_warning(tmp_path):
     assert not any("version" in w for w in config.warnings)
 
 
+def test_null_version_treated_as_missing(tmp_path):
+    """`version:` (YAML null) must warn and default, not gate as 0.0.0."""
+    from skillsaw.config import _DEFAULT_VERSION
+
+    config = LinterConfig.from_file(_write(tmp_path, "version:\nrules: {}\n"))
+    assert config.version == _DEFAULT_VERSION
+    assert any("version" in w for w in config.warnings)
+
+
 def test_unknown_key_emits_warning(tmp_path):
     config = LinterConfig.from_file(
         _write(tmp_path, 'version: "0.14.0"\nexcludes:\n  - "**/foo/**"\n')
@@ -1166,10 +1175,22 @@ def test_unknown_key_emits_warning(tmp_path):
     assert any("excludes" in w for w in config.warnings)
 
 
-def test_default_configs_compare_equal_despite_warnings(tmp_path):
-    # warnings field is compare=False, so loaded configs still equate by content
+def test_custom_rules_non_string_items_raises(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'custom-rules' must be a list of strings"):
+        LinterConfig.from_file(_write(tmp_path, "custom-rules:\n  - 42\n"))
+
+
+def test_warnings_excluded_from_equality(tmp_path):
+    # One config carries an extra warning (unknown key) but identical content;
+    # they must still compare equal because `warnings` is compare=False.
     a = LinterConfig.from_file(_write(tmp_path, 'version: "0.14.0"\nrules: {}\n'))
-    b = LinterConfig.from_file(_write(tmp_path, 'version: "0.14.0"\nrules: {}\n'))
+    b = LinterConfig.from_file(
+        _write(tmp_path, 'version: "0.14.0"\nrules: {}\nexcludes:\n  - "**/foo/**"\n')
+    )
+    assert b.warnings  # b warned about the unknown 'excludes' key
+    assert not a.warnings
     assert a == b
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1084,3 +1084,96 @@ def test_save_round_trips_yaml_significant_strings(tmp_path):
     reloaded = LinterConfig.from_file(config_path)
     assert reloaded.exclude_patterns == tricky
     assert reloaded.rules["content-weak-language"]["note"] == "warning: avoid #hedging"
+
+
+# ---------------------------------------------------------------------------
+# Malformed-config handling: every mistake must raise ValueError (friendly
+# CLI error), never an unhandled traceback.
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path, text):
+    p = tmp_path / ".skillsaw.yaml"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_list_root_config_raises_valueerror(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        LinterConfig.from_file(_write(tmp_path, "- a\n- b\n"))
+
+
+def test_scalar_root_config_raises_valueerror(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        LinterConfig.from_file(_write(tmp_path, "just a string\n"))
+
+
+def test_non_mapping_llm_raises_valueerror(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'llm' must be a mapping"):
+        LinterConfig.from_file(_write(tmp_path, "llm: gpt-4\n"))
+
+
+def test_llm_field_type_validation(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'llm.max_iterations' must be an integer"):
+        LinterConfig.from_file(_write(tmp_path, "llm:\n  max_iterations: ten\n"))
+    with pytest.raises(ValueError, match="'llm.confirm' must be a boolean"):
+        LinterConfig.from_file(_write(tmp_path, "llm:\n  confirm: maybe\n"))
+
+
+def test_content_paths_string_raises_valueerror(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'content-paths' must be a list of strings"):
+        LinterConfig.from_file(_write(tmp_path, 'content-paths: "docs/*.md"\n'))
+
+
+def test_content_paths_list_of_strings_ok(tmp_path):
+    config = LinterConfig.from_file(_write(tmp_path, 'content-paths:\n  - "docs/*.md"\n'))
+    assert config.content_paths == ["docs/*.md"]
+
+
+def test_exclude_non_string_items_raises_valueerror(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'exclude' must be a list of strings"):
+        LinterConfig.from_file(_write(tmp_path, "exclude:\n  - 42\n"))
+
+
+def test_missing_version_emits_warning(tmp_path):
+    config = LinterConfig.from_file(
+        _write(tmp_path, "rules:\n  skill-frontmatter:\n    severity: warning\n")
+    )
+    assert any("version" in w for w in config.warnings)
+
+
+def test_present_version_no_warning(tmp_path):
+    config = LinterConfig.from_file(_write(tmp_path, 'version: "0.14.0"\nrules: {}\n'))
+    assert not any("version" in w for w in config.warnings)
+
+
+def test_unknown_key_emits_warning(tmp_path):
+    config = LinterConfig.from_file(
+        _write(tmp_path, 'version: "0.14.0"\nexcludes:\n  - "**/foo/**"\n')
+    )
+    assert any("excludes" in w for w in config.warnings)
+
+
+def test_default_configs_compare_equal_despite_warnings(tmp_path):
+    # warnings field is compare=False, so loaded configs still equate by content
+    a = LinterConfig.from_file(_write(tmp_path, 'version: "0.14.0"\nrules: {}\n'))
+    b = LinterConfig.from_file(_write(tmp_path, 'version: "0.14.0"\nrules: {}\n'))
+    assert a == b
+
+
+def test_find_config_at_filesystem_walk_includes_start_dir(tmp_path):
+    # The walk must include the start directory itself.
+    (tmp_path / ".skillsaw.yaml").write_text("rules: {}\n", encoding="utf-8")
+    assert find_config(tmp_path) == tmp_path / ".skillsaw.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1112,6 +1112,21 @@ def test_scalar_root_config_raises_valueerror(tmp_path):
         LinterConfig.from_file(_write(tmp_path, "just a string\n"))
 
 
+def test_falsy_non_mapping_roots_raise(tmp_path):
+    """`[]`, `false`, `0` must not be silently coerced to an empty config."""
+    import pytest
+
+    for payload in ("[]\n", "false\n", "0\n"):
+        with pytest.raises(ValueError, match="must be a mapping"):
+            LinterConfig.from_file(_write(tmp_path, payload))
+
+
+def test_empty_file_is_empty_config(tmp_path):
+    """An empty document (None) is a valid empty config, not an error."""
+    config = LinterConfig.from_file(_write(tmp_path, ""))
+    assert config.rules == {}
+
+
 def test_non_mapping_llm_raises_valueerror(tmp_path):
     import pytest
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -622,3 +622,12 @@ def test_promptfoo_config_at_root_still_detected(temp_dir):
 
     context = RepositoryContext(temp_dir)
     assert RepositoryType.PROMPTFOO in context.repo_types
+
+
+def test_explicit_repo_type_override_drives_discovery(temp_dir):
+    """Constructor repo_types override must apply before plugin discovery."""
+    context = RepositoryContext(temp_dir, repo_types={RepositoryType.SINGLE_PLUGIN})
+
+    assert context.repo_types == {RepositoryType.SINGLE_PLUGIN}
+    assert context.repo_type == RepositoryType.SINGLE_PLUGIN
+    assert [p.resolve() for p in context.plugins] == [temp_dir.resolve()]

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -658,6 +658,18 @@ def test_two_custom_rule_files_distinct_modules(valid_plugin, temp_dir):
     assert "custom-rule-a" in rule_ids
     assert "custom-rule-b" in rule_ids
 
+    # Prove module isolation: each file is registered under a distinct
+    # sys.modules key (they previously all loaded as "custom_rule").
+    import re
+    import sys
+
+    mod_a = "skillsaw_custom_" + re.sub(r"\W", "_", str(a.resolve()))
+    mod_b = "skillsaw_custom_" + re.sub(r"\W", "_", str(b.resolve()))
+    assert mod_a != mod_b
+    assert mod_a in sys.modules
+    assert mod_b in sys.modules
+    assert sys.modules[mod_a] is not sys.modules[mod_b]
+
 
 def test_unknown_skip_rule_raises(valid_plugin):
     """A typo in --skip-rule must error, not silently leave the rule running."""

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -647,28 +647,63 @@ def test_custom_rule_is_version_gated(valid_plugin, temp_dir):
 
 def test_two_custom_rule_files_distinct_modules(valid_plugin, temp_dir):
     """Two custom rule files must not clobber each other in sys.modules (§1.10)."""
-    a = temp_dir / "rule_a.py"
+    a = temp_dir / "rule-a.py"
     b = temp_dir / "rule_b.py"
     _write_custom_rule(a, "custom-rule-a")
     _write_custom_rule(b, "custom-rule-b")
     config = LinterConfig(version="0.1.0", custom_rules=[str(a), str(b)])
     context = RepositoryContext(valid_plugin)
     linter = Linter(context, config)
-    rule_ids = {r.rule_id for r in linter.rules}
+    rules = {r.rule_id: r for r in linter.rules}
+    rule_ids = set(rules)
     assert "custom-rule-a" in rule_ids
     assert "custom-rule-b" in rule_ids
 
     # Prove module isolation: each file is registered under a distinct
     # sys.modules key (they previously all loaded as "custom_rule").
-    import re
     import sys
 
-    mod_a = "skillsaw_custom_" + re.sub(r"\W", "_", str(a.resolve()))
-    mod_b = "skillsaw_custom_" + re.sub(r"\W", "_", str(b.resolve()))
+    mod_a = type(rules["custom-rule-a"]).__module__
+    mod_b = type(rules["custom-rule-b"]).__module__
     assert mod_a != mod_b
+    assert mod_a.startswith("skillsaw_custom_rule_a_")
+    assert mod_b.startswith("skillsaw_custom_rule_b_")
     assert mod_a in sys.modules
     assert mod_b in sys.modules
     assert sys.modules[mod_a] is not sys.modules[mod_b]
+
+
+def test_custom_rule_constructor_error_is_wrapped(valid_plugin, temp_dir):
+    """Errors after importing a custom rule file should still be CLI-friendly."""
+    custom_rule_file = temp_dir / "broken_constructor_rule.py"
+    custom_rule_file.write_text("""
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+
+class BrokenRule(Rule):
+    def __init__(self, config=None):
+        raise RuntimeError("constructor boom")
+
+    @property
+    def rule_id(self) -> str:
+        return "broken-custom-rule"
+
+    @property
+    def description(self) -> str:
+        return "broken"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return []
+""")
+    config = LinterConfig(custom_rules=[str(custom_rule_file)])
+    context = RepositoryContext(valid_plugin)
+
+    with pytest.raises(ValueError, match="Failed to load custom rule.*constructor boom"):
+        Linter(context, config)
 
 
 def test_unknown_skip_rule_raises(valid_plugin):

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -64,8 +64,8 @@ def test_load_custom_rule_missing_file(valid_plugin):
     config = LinterConfig(custom_rules=["nonexistent_rule.py"])
     context = RepositoryContext(valid_plugin)
 
-    # Should raise FileNotFoundError
-    with pytest.raises(FileNotFoundError, match="Custom rule file not found"):
+    # Raises ValueError so the CLI surfaces a friendly error, not a traceback.
+    with pytest.raises(ValueError, match="Custom rule file not found"):
         Linter(context, config)
 
 
@@ -97,8 +97,8 @@ class BadImportRule(Rule):
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
 
-    # Should raise ModuleNotFoundError or ImportError
-    with pytest.raises((ModuleNotFoundError, ImportError)):
+    # Wrapped as ValueError (CLI-friendly); message names the offending file.
+    with pytest.raises(ValueError, match="Failed to load custom rule"):
         Linter(context, config)
 
 
@@ -129,8 +129,8 @@ class SyntaxErrorRule(Rule):
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
 
-    # Should raise SyntaxError
-    with pytest.raises(SyntaxError):
+    # Wrapped as ValueError so the CLI shows a friendly error, not a traceback.
+    with pytest.raises(ValueError, match="Failed to load custom rule"):
         Linter(context, config)
 
 
@@ -162,8 +162,8 @@ class MissingExportRule(Rule):
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
 
-    # Should raise ImportError
-    with pytest.raises(ImportError, match="cannot import name 'NonExistentClass'"):
+    # Wrapped as ValueError; the original ImportError detail is preserved.
+    with pytest.raises(ValueError, match="cannot import name 'NonExistentClass'"):
         Linter(context, config)
 
 
@@ -608,3 +608,65 @@ class MyCustomRule(Rule):
     context = RepositoryContext(valid_plugin)
     violations = Linter(context, typo_config, no_custom_rules=True).run()
     assert any(v.rule_id == "invalid-config" for v in violations)
+
+
+def _write_custom_rule(path, rule_id, since=None):
+    since_attr = f'\n    since = "{since}"' if since else ""
+    path.write_text(f"""
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+
+class MyRule(Rule):{since_attr}
+    @property
+    def rule_id(self) -> str:
+        return "{rule_id}"
+
+    @property
+    def description(self) -> str:
+        return "custom"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return []
+""")
+
+
+def test_custom_rule_is_version_gated(valid_plugin, temp_dir):
+    """A custom rule's `since` must be honored, like builtin rules (§1.10)."""
+    rule_file = temp_dir / "future_rule.py"
+    _write_custom_rule(rule_file, "future-custom-rule", since="99.0.0")
+    config = LinterConfig(version="0.1.0", custom_rules=[str(rule_file)])
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, config)
+    rule_ids = {r.rule_id for r in linter.rules}
+    assert "future-custom-rule" not in rule_ids
+
+
+def test_two_custom_rule_files_distinct_modules(valid_plugin, temp_dir):
+    """Two custom rule files must not clobber each other in sys.modules (§1.10)."""
+    a = temp_dir / "rule_a.py"
+    b = temp_dir / "rule_b.py"
+    _write_custom_rule(a, "custom-rule-a")
+    _write_custom_rule(b, "custom-rule-b")
+    config = LinterConfig(version="0.1.0", custom_rules=[str(a), str(b)])
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, config)
+    rule_ids = {r.rule_id for r in linter.rules}
+    assert "custom-rule-a" in rule_ids
+    assert "custom-rule-b" in rule_ids
+
+
+def test_unknown_skip_rule_raises(valid_plugin):
+    """A typo in --skip-rule must error, not silently leave the rule running."""
+    context = RepositoryContext(valid_plugin)
+    with pytest.raises(ValueError, match="Unknown rule.*skip-rule"):
+        Linter(context, LinterConfig.default(), skip_rule_ids={"no-such-rule-xyz"})
+
+
+def test_valid_skip_rule_accepted(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    linter = Linter(context, LinterConfig.default(), skip_rule_ids={"content-weak-language"})
+    assert "content-weak-language" not in {r.rule_id for r in linter.rules}

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -440,6 +440,26 @@ def test_sarif_uri_is_posix_and_root_relative(valid_plugin):
     assert artifact["uriBaseId"] == "%SRCROOT%"
 
 
+def test_sarif_relative_path_is_root_relative(valid_plugin):
+    """A root-relative violation path keeps uriBaseId and uses forward slashes."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="command-naming",
+            severity=Severity.WARNING,
+            message="bad",
+            file_path=Path("plugins/foo/commands/bar.md"),
+            line=2,
+        ),
+    ]
+    output = format_sarif(violations, context, [], "1.0.0")
+    artifact = json.loads(output)["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]
+    assert artifact["uri"] == "plugins/foo/commands/bar.md"
+    assert artifact["uriBaseId"] == "%SRCROOT%"
+
+
 def test_sarif_outside_root_omits_uribaseid(valid_plugin, tmp_path):
     """A file outside the repo root must not claim %SRCROOT% as its base."""
     context = RepositoryContext(valid_plugin)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -111,6 +111,14 @@ def test_parse_output_spec_unknown_prefix_falls_through():
     assert parse_output_spec("foo:report.json") == ("json", "foo:report.json")
 
 
+def test_parse_output_spec_empty_path_raises():
+    """`json:` (no path) must error up front, not crash after the lint."""
+    import pytest
+
+    with pytest.raises(ValueError, match="output file path missing"):
+        parse_output_spec("json:")
+
+
 def test_parse_output_spec_txt_infers_text():
     assert parse_output_spec("report.txt") == ("text", "report.txt")
 
@@ -408,6 +416,49 @@ def test_sarif_locations(valid_plugin):
     # Second violation: file_path + line
     v1_loc = results[1]["locations"][0]["physicalLocation"]
     assert v1_loc["region"]["startLine"] == 3
+
+
+def test_sarif_uri_is_posix_and_root_relative(valid_plugin):
+    """SARIF artifact URIs use forward slashes and carry uriBaseId under root."""
+    context = RepositoryContext(valid_plugin)
+    abs_path = context.root_path / "plugins" / "foo" / "commands" / "bar.md"
+    violations = [
+        RuleViolation(
+            rule_id="command-naming",
+            severity=Severity.WARNING,
+            message="bad",
+            file_path=abs_path,
+            line=2,
+        ),
+    ]
+    output = format_sarif(violations, context, [], "1.0.0")
+    artifact = json.loads(output)["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]
+    assert artifact["uri"] == "plugins/foo/commands/bar.md"  # forward slashes
+    assert "\\" not in artifact["uri"]
+    assert artifact["uriBaseId"] == "%SRCROOT%"
+
+
+def test_sarif_outside_root_omits_uribaseid(valid_plugin, tmp_path):
+    """A file outside the repo root must not claim %SRCROOT% as its base."""
+    context = RepositoryContext(valid_plugin)
+    outside = tmp_path / "elsewhere" / "other.md"
+    violations = [
+        RuleViolation(
+            rule_id="command-naming",
+            severity=Severity.WARNING,
+            message="bad",
+            file_path=outside,
+            line=1,
+        ),
+    ]
+    output = format_sarif(violations, context, [], "1.0.0")
+    artifact = json.loads(output)["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+        "artifactLocation"
+    ]
+    assert "uriBaseId" not in artifact
+    assert "\\" not in artifact["uri"]
 
 
 def test_sarif_line_zero_omits_region(valid_plugin):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1059,10 +1059,7 @@ class TestCliOverrides:
 
     def test_type_override_affects_discovery(self, tmp_path):
         """--type must influence discovery, not just rule enablement."""
-        repo = tmp_path / "repo"
-        command_dir = repo / "commands"
-        command_dir.mkdir(parents=True)
-        (command_dir / "foo.md").write_text("Missing frontmatter\n", encoding="utf-8")
+        repo = copy_fixture("cli-overrides/type-override", tmp_path)
 
         r = run_lint(repo, "--type", "single-plugin", "--rule", "command-frontmatter")
 
@@ -1072,8 +1069,7 @@ class TestCliOverrides:
         assert r["out"]["stats"]["repo_types"] == ["single-plugin"]
 
     def test_type_unknown_rejected(self, tmp_path):
-        repo = tmp_path / "repo"
-        repo.mkdir()
+        repo = copy_fixture("cli-overrides/type-unknown", tmp_path)
 
         r = run_lint(repo, "--type", "unknown")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1051,6 +1051,37 @@ class TestConfigFeatures:
         assert len(docs_violations) >= 1
 
 
+# ── CLI Overrides ────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestCliOverrides:
+
+    def test_type_override_affects_discovery(self, tmp_path):
+        """--type must influence discovery, not just rule enablement."""
+        repo = tmp_path / "repo"
+        command_dir = repo / "commands"
+        command_dir.mkdir(parents=True)
+        (command_dir / "foo.md").write_text("Missing frontmatter\n", encoding="utf-8")
+
+        r = run_lint(repo, "--type", "single-plugin", "--rule", "command-frontmatter")
+
+        assert r["rc"] == 1
+        assert "command-frontmatter" in rule_ids(r)
+        assert any("foo.md" in v["file_path"] for v in by_rule(r)["command-frontmatter"])
+        assert r["out"]["stats"]["repo_types"] == ["single-plugin"]
+
+    def test_type_unknown_rejected(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        r = run_lint(repo, "--type", "unknown")
+
+        assert r["rc"] == 1
+        assert r["out"] is None
+        assert "Unknown repository type 'unknown'" in r["stderr"]
+
+
 # ── Exit Codes ───────────────────────────────────────────────────
 
 

--- a/tests/test_promptfoo_rules.py
+++ b/tests/test_promptfoo_rules.py
@@ -1128,6 +1128,53 @@ def test_threshold_exceeded_reports_line(temp_dir):
 
 
 # ---------------------------------------------------------------------------
+# Regression (§1.13): prompt line numbers for plain vs block scalars
+# ---------------------------------------------------------------------------
+
+
+def _prompt_blocks(temp_dir):
+    from skillsaw.lint_tree import build_lint_tree
+    from skillsaw.rules.builtin.content_analysis import PromptfooPromptBlock
+
+    context = RepositoryContext(temp_dir)
+    return PromptfooPromptBlock.gather_from_tree(build_lint_tree(context))
+
+
+def test_plain_scalar_prompt_line_is_correct(temp_dir):
+    _write_raw_yaml(
+        temp_dir / "promptfooconfig.yaml",
+        """\
+        prompts:
+          - "Try to be helpful and answer"
+        providers:
+          - openai:gpt-4
+        """,
+    )
+    blocks = _prompt_blocks(temp_dir)
+    assert len(blocks) == 1
+    # The prompt content is on file line 2; file_line(1) must report 2, not 3.
+    assert blocks[0].file_line(1) == 2
+
+
+def test_block_scalar_prompt_line_is_correct(temp_dir):
+    _write_raw_yaml(
+        temp_dir / "promptfooconfig.yaml",
+        """\
+        prompts:
+          - |
+            Try to be helpful
+            across two lines
+        providers:
+          - openai:gpt-4
+        """,
+    )
+    blocks = _prompt_blocks(temp_dir)
+    assert len(blocks) == 1
+    # Block-scalar content starts on the line after the '- |' marker (line 3).
+    assert blocks[0].file_line(1) == 3
+
+
+# ---------------------------------------------------------------------------
 # Integration: rule coverage guard
 # ---------------------------------------------------------------------------
 

--- a/tests/test_promptfoo_rules.py
+++ b/tests/test_promptfoo_rules.py
@@ -1174,6 +1174,24 @@ def test_block_scalar_prompt_line_is_correct(temp_dir):
     assert blocks[0].file_line(1) == 3
 
 
+def test_block_scalar_with_trailing_comment_line_is_correct(temp_dir):
+    """A block-scalar header with an inline comment is still a block scalar."""
+    _write_raw_yaml(
+        temp_dir / "promptfooconfig.yaml",
+        """\
+        prompts:
+          - | # system prompt
+            Try to be helpful
+        providers:
+          - openai:gpt-4
+        """,
+    )
+    blocks = _prompt_blocks(temp_dir)
+    assert len(blocks) == 1
+    # Content starts on line 3, not the '- | # system prompt' marker line.
+    assert blocks[0].file_line(1) == 3
+
+
 # ---------------------------------------------------------------------------
 # Integration: rule coverage guard
 # ---------------------------------------------------------------------------

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -487,6 +487,17 @@ class TestDirectivesInCodeAndProse:
         smap = build_suppression_map(content, markdown=True)
         assert not smap.is_suppressed("anything", 2)
 
+    def test_trailing_punctuation_not_a_directive(self):
+        """End-anchored: `skillsaw-disable.` must not parse as suppress-all."""
+        content = "<!-- skillsaw-disable. -->\n" "Try to be careful\n"
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("anything", 2)
+
+    def test_next_line_with_trailing_colon_not_a_directive(self):
+        content = "<!-- skillsaw-disable-next-line: -->\n" "Try to be careful\n"
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("anything", 2)
+
     def test_real_directive_still_works_after_anchoring(self):
         content = (
             "<!-- skillsaw-disable content-weak-language -->\n"

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -434,6 +434,70 @@ class TestBuildSuppressionMap:
         assert smap.is_suppressed("promptfoo-valid", 4)
 
 
+class TestDirectivesInCodeAndProse:
+    """Regression tests: directives shown as documentation must be inert."""
+
+    def test_hash_directive_in_fenced_code_not_honored(self):
+        """A `# skillsaw-disable` inside a ``` fence is documentation, not live."""
+        content = (
+            "Instructions.\n\n"
+            "```bash\n"
+            "# skillsaw-disable\n"
+            "make build\n"
+            "```\n\n"
+            "Try to be careful always.\n"
+        )
+        smap = build_suppression_map(content, markdown=True)
+        # Line 8 is real prose after the fence — must NOT be suppressed.
+        assert not smap.is_suppressed("content-weak-language", 8)
+        assert not smap.is_suppressed("any-rule", 8)
+
+    def test_hash_directive_in_yaml_fence_not_honored(self):
+        content = (
+            "Doc.\n\n"
+            "```yaml\n"
+            "# skillsaw-disable content-weak-language\n"
+            "```\n\n"
+            "Try to handle this.\n"
+        )
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("content-weak-language", 7)
+
+    def test_hash_directive_in_indented_code_not_honored(self):
+        content = "Doc.\n\n" "    # skillsaw-disable\n\n" "Try to be careful.\n"
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("content-weak-language", 5)
+
+    def test_hash_directive_outside_fence_still_honored(self):
+        """Non-markdown (YAML) ``#`` directives are unaffected by fence filtering."""
+        content = "# skillsaw-disable promptfoo-valid\n" "tests: 42\n"
+        smap = build_suppression_map(content, markdown=False)
+        assert smap.is_suppressed("promptfoo-valid", 2)
+
+    def test_prose_mention_in_html_comment_not_honored(self):
+        """A comment that merely mentions the directive must not disable rules."""
+        content = "<!-- TODO: document skillsaw-disable. -->\n" "Try to be careful\n"
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("anything", 2)
+        assert not smap.is_suppressed("content-weak-language", 2)
+
+    def test_disable_word_boundary(self):
+        """``skillsaw-disabledthing`` must not parse as a bare disable."""
+        content = "<!-- skillsaw-disabledthing -->\n" "Try to be careful\n"
+        smap = build_suppression_map(content, markdown=True)
+        assert not smap.is_suppressed("anything", 2)
+
+    def test_real_directive_still_works_after_anchoring(self):
+        content = (
+            "<!-- skillsaw-disable content-weak-language -->\n"
+            "Try to handle errors.\n"
+            "<!-- skillsaw-enable content-weak-language -->\n"
+        )
+        smap = build_suppression_map(content, markdown=True)
+        assert smap.is_suppressed("content-weak-language", 2)
+        assert not smap.is_suppressed("content-weak-language", 4)
+
+
 class TestBuildSuppressionMapForFile:
     def test_reads_file(self, temp_dir):
         f = temp_dir / "test.md"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from skillsaw.rules.builtin.utils import (
     read_text,
     read_json,
+    extract_section,
     frontmatter_key_line,
     heading_line,
     parse_frontmatter,
@@ -20,6 +21,21 @@ from skillsaw.rules.builtin.utils import (
     yaml_nth_list_item_key_line,
     _extract_frontmatter_text,
 )
+
+
+def test_extract_section_lf():
+    content = "# T\n\n## Build\nrun make\n\n## Other\nx\n"
+    assert extract_section(content, "Build") == "run make"
+
+
+def test_extract_section_crlf():
+    """CRLF content must resolve the section the same as LF (§1.14)."""
+    content = "# T\r\n\r\n## Build\r\nrun make\r\n\r\n## Other\r\nx\r\n"
+    assert extract_section(content, "Build") == "run make"
+
+
+def test_extract_section_missing_returns_empty():
+    assert extract_section("# T\n\n## Build\nrun\n", "Nope") == ""
 
 
 def test_read_text_returns_content(temp_dir):

--- a/tests/test_yaml_line_numbers_integration.py
+++ b/tests/test_yaml_line_numbers_integration.py
@@ -60,11 +60,11 @@ class TestCoderabbitLineNumbers:
         # reviews.instructions
         assert result[0][0] == "reviews.instructions"
         assert result[0][2] == 2
-        # path_instructions[0]
-        assert "src/**" in result[1][0]
+        # path_instructions[0] — index-based label, line points at its own key
+        assert result[1][0] == "reviews.path_instructions[0].instructions"
         assert result[1][2] == 5
         # path_instructions[1]
-        assert "tests/**" in result[2][0]
+        assert result[2][0] == "reviews.path_instructions[1].instructions"
         assert result[2][2] == 7
 
     def test_multiple_instructions_at_different_levels(self):
@@ -105,11 +105,12 @@ class TestCoderabbitLineNumbers:
         assert len(result) == 3
         assert result[0][0] == "reviews.instructions"
         assert result[0][2] == 2
-        assert "src/**" in result[1][0]
+        assert result[1][0] == "reviews.path_instructions[0].instructions"
         assert result[1][2] == 5
-        assert "docs/**" in result[2][0]
-        assert result[2][2] is not None
-        assert result[2][2] > 0
+        # docs/** is the third list entry (index 2); the empty entry at index 1
+        # is skipped but still consumes its position.
+        assert result[2][0] == "reviews.path_instructions[2].instructions"
+        assert result[2][2] == 9
 
     def test_content_rule_fires_on_coderabbit_with_file_path(self, temp_dir):
         """Content rules should fire on .coderabbit.yaml and report the file path."""
@@ -477,6 +478,7 @@ class TestCoderabbitFullIntegration:
         assert len(result) == 2
         assert result[0][0] == "reviews.instructions"
         assert result[0][2] == 2
-        assert "tests/**" in result[1][0]
-        assert result[1][2] is not None
-        assert result[1][2] > 0
+        # tests/** is the second list entry (index 1); the null entry at index 0
+        # is skipped but still consumes its position.
+        assert result[1][0] == "reviews.path_instructions[1].instructions"
+        assert result[1][2] == 7


### PR DESCRIPTION
A batch of confirmed bugs surfaced by a multi-angle architecture/quality review of the codebase, each fixed with a regression test. **+37 tests, full suite green (2119 passed), `make lint` clean, self-lint and `openshift-eng/ai-helpers` both exit 0.**

The companion review report is filed as a tracking issue (the "Fable sweep"); this PR implements the confirmed-bug subset. Large architectural refactors from the report (block-hierarchy extraction, `__main__.py` split, LLM-orchestrator carve-out) are intentionally **not** bundled here — they belong in their own PRs.

## Suppression
- **Directives inside markdown code fences no longer fire.** A `# skillsaw-disable` in a fenced example previously suppressed every rule for the rest of the file. `#` directives are now skipped inside fenced/indented code blocks (headings stay honored).
- **Word boundary + start anchor on directives.** Prose like `<!-- TODO: document skillsaw-disable -->` and `skillsaw-disabledthing` are now inert instead of disabling all rules.

## Config
- **Friendly errors instead of tracebacks** for malformed configs: non-mapping root (`- a`), `llm: gpt-4`, `content-paths: "x"`, mistyped `llm`/`exclude` items — all now raise `ValueError` and exit 1 cleanly.
- **Warnings** for a missing `version` field (silently disables newer rules) and unknown top-level keys.
- `encoding="utf-8"` on config reads; default-rules mapping cached (was rebuilt per-violation on the filter hot path); `find_config` now checks the filesystem root.

## Baseline
- **Baseline in a parent directory now matches when linting a subdirectory** — fingerprints are computed relative to the directory that owns the baseline file (previously nothing matched and every entry went stale).
- **Ratchet fingerprint collisions fixed** via an optional `metric` discriminator (context-budget emitted whole-file + per-description token violations with identical fingerprints). Empty metric preserves the legacy fingerprint, so existing baselines keep matching.
- `find_baseline` now checks the filesystem root.

## CodeRabbit / promptfoo
- **`CodeRabbitContentBlock.write_body` no longer crashes** on a `path` glob containing a dot (`**/*.py` — the common case). Uses index-based, bracket-aware yaml paths; a bad path degrades to a no-op.
- **Correct line numbers** for path_instructions/tools/custom_checks (was an nth-occurrence heuristic that mis-attributed lines when other `instructions` keys preceded them).
- **promptfoo prompt line numbers** distinguish plain vs block scalars (plain one-line prompts were one line too low).

## CLI / linter / formatters
- Missing/broken `custom-rules` files raise a friendly error instead of a traceback; each custom rule loads under a **unique module name**; custom rules now honor their `since` version gate.
- **`--skip-rule` validates IDs** (a typo previously left the rule running).
- `--output FORMAT:` with an empty path errors up front; duplicate `--output` targets with conflicting formats error instead of silently dropping one.
- **SARIF URIs** use forward slashes and omit `uriBaseId` for paths outside the repo root.
- `extract_section` matches CRLF content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits non-fatal configuration warnings at runtime.
  * Distinguishes multiple ratchet violations per file via optional metrics (when emitted).
* **Bug Fixes**
  * Improves baseline fingerprinting/filtering consistency (including stability when baselines/configs are nested) and avoids metric collisions.
  * Tightens configuration validation and discovery, including “Version Pinning” behavior.
  * Validates `--output FORMAT:PATH` (errors on missing paths) and improves SARIF URIs.
  * Fixes `skillsaw-disable*` directive handling in markdown code vs prose.
  * Hardens custom-rule loading and rejects unknown skip IDs; `--type` overrides now affect discovery.
* **Documentation**
  * Added “Version Pinning” guidance and updated CLI `--type` options (includes `apm`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->