### PR TITLE
Add streamable-http as a valid MCP transport type

### DIFF
--- a/src/skillsaw/rules/builtin/mcp/valid_json.py
+++ b/src/skillsaw/rules/builtin/mcp/valid_json.py
@@ -15,8 +15,13 @@ from skillsaw.rules.builtin.utils import read_json
 class McpValidJsonRule(Rule):
     """Check that MCP configuration is valid JSON with proper structure"""
 
-    VALID_MCP_TYPES = ("stdio", "http", "sse")
-    REQUIRED_FIELDS_BY_TYPE = {"stdio": "command", "http": "url", "sse": "url"}
+    VALID_MCP_TYPES = ("stdio", "http", "sse", "streamable-http")
+    REQUIRED_FIELDS_BY_TYPE = {
+        "stdio": "command",
+        "http": "url",
+        "sse": "url",
+        "streamable-http": "url",
+    }
 
     @property
     def rule_id(self) -> str:

--- a/tests/test_mcp_rules.py
+++ b/tests/test_mcp_rules.py
@@ -190,6 +190,34 @@ def plugin_with_explicit_stdio_mcp(temp_dir):
 
 
 @pytest.fixture
+def plugin_with_streamable_http_mcp(temp_dir):
+    """Create a plugin with valid streamable-http MCP configuration"""
+    mcp_config = {
+        "mcpServers": {
+            "streamable-http-server": {
+                "type": "streamable-http",
+                "url": "https://mcp.example.com/api",
+            }
+        }
+    }
+    return _create_plugin_with_mcp(temp_dir, mcp_config)
+
+
+@pytest.fixture
+def plugin_with_streamable_http_mcp_missing_url(temp_dir):
+    """Create a plugin with streamable-http MCP missing url field"""
+    mcp_config = {
+        "mcpServers": {
+            "streamable-http-server": {
+                "type": "streamable-http"
+                # Missing "url" field
+            }
+        }
+    }
+    return _create_plugin_with_mcp(temp_dir, mcp_config)
+
+
+@pytest.fixture
 def plugin_with_http_mcp_missing_url(temp_dir):
     """Create a plugin with HTTP MCP missing url field"""
     mcp_config = {
@@ -369,6 +397,24 @@ def test_explicit_stdio_mcp_valid(plugin_with_explicit_stdio_mcp):
     rule = McpValidJsonRule()
     violations = rule.check(context)
     assert len(violations) == 0
+
+
+def test_streamable_http_mcp_valid(plugin_with_streamable_http_mcp):
+    """Test that valid streamable-http MCP passes validation"""
+    context = RepositoryContext(plugin_with_streamable_http_mcp)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_streamable_http_mcp_missing_url(plugin_with_streamable_http_mcp_missing_url):
+    """Test that streamable-http MCP missing url field is detected"""
+    context = RepositoryContext(plugin_with_streamable_http_mcp_missing_url)
+    rule = McpValidJsonRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "'url' field" in violations[0].message
+    assert "streamable-http" in violations[0].message
 
 
 def test_http_mcp_missing_url(plugin_with_http_mcp_missing_url):


### PR DESCRIPTION
## Summary

- Adds `streamable-http` to the list of valid MCP transport types in the `mcp-valid-json` rule
- Like `http` and `sse`, `streamable-http` requires a `url` field
- Adds test fixtures and test cases for valid and missing-url scenarios

## Context

The [MCP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) defines `streamable-http` as a transport type, but skillsaw only recognized `stdio`, `http`, and `sse`. This caused false positive `mcp-valid-json` errors on repositories using `streamable-http` servers (e.g., remote MCP endpoints like Red Hat's Dataverse).

## Test plan

- [x] Existing tests pass (2084 passed)
- [x] New test: valid `streamable-http` config passes validation
- [x] New test: `streamable-http` missing `url` field is detected
- [x] `make update` passes (format, lint, self-lint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded MCP server type support to include `streamable-http`, which requires the `url` field in configuration to ensure valid server setup.

* **Tests**
  * Added test coverage for the new `streamable-http` server type, verifying both valid configurations and validation of required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->