### PR TITLE
Add pluribus.md context file detection

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -37,6 +37,7 @@ HAS_GEMINI = "HAS_GEMINI"
 HAS_AGENTS_MD = "HAS_AGENTS_MD"
 HAS_KIRO = "HAS_KIRO"
 HAS_CLAUDE_MD = "HAS_CLAUDE_MD"
+HAS_PLURIBUS = "HAS_PLURIBUS"
 HAS_CODERABBIT = "HAS_CODERABBIT"
 ALL_INSTRUCTION_FORMATS = frozenset(
     {
@@ -46,6 +47,7 @@ ALL_INSTRUCTION_FORMATS = frozenset(
         HAS_AGENTS_MD,
         HAS_KIRO,
         HAS_CLAUDE_MD,
+        HAS_PLURIBUS,
         HAS_CODERABBIT,
     }
 )
@@ -58,7 +60,7 @@ class RepositoryContext:
     Automatically detects repository type and gathers relevant metadata.
     """
 
-    _INSTRUCTION_FILENAMES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md")
+    _INSTRUCTION_FILENAMES = ("AGENTS.md", "CLAUDE.md", "GEMINI.md", "pluribus.md")
 
     _TYPE_PRIORITY = [
         RepositoryType.MARKETPLACE,
@@ -189,6 +191,8 @@ class RepositoryContext:
             formats.add(HAS_KIRO)
         if (self.root_path / "CLAUDE.md").exists():
             formats.add(HAS_CLAUDE_MD)
+        if (self.root_path / "pluribus.md").exists():
+            formats.add(HAS_PLURIBUS)
         if (self.root_path / ".coderabbit.yaml").exists():
             formats.add(HAS_CODERABBIT)
         return formats

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -40,6 +40,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         CursorRuleBlock,
         ExtraBlock,
         GeminiMdBlock,
+        PluribusMdBlock,
         HooksBlock,
         InstructionBlock,
         McpBlock,
@@ -55,6 +56,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         "AGENTS.md": AgentsMdBlock,
         "CLAUDE.md": ClaudeMdBlock,
         "GEMINI.md": GeminiMdBlock,
+        "pluribus.md": PluribusMdBlock,
     }
 
     root = LintTarget(path=context.root_path)

--- a/src/skillsaw/rules/builtin/content_analysis.py
+++ b/src/skillsaw/rules/builtin/content_analysis.py
@@ -151,6 +151,7 @@ _INSTRUCTION_FILE_CATEGORIES = {
     "AGENTS.md": "agents-md",
     "CLAUDE.md": "claude-md",
     "GEMINI.md": "gemini-md",
+    "pluribus.md": "pluribus-md",
 }
 
 
@@ -572,6 +573,13 @@ class GeminiMdBlock(InstructionBlock):
     """GEMINI.md instruction file."""
 
     category: str = "gemini-md"
+
+
+@dataclass(eq=False)
+class PluribusMdBlock(InstructionBlock):
+    """pluribus.md shared context file."""
+
+    category: str = "pluribus-md"
 
 
 def _parse_file_frontmatter(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ from skillsaw.context import (
     HAS_AGENTS_MD,
     HAS_KIRO,
     HAS_CLAUDE_MD,
+    HAS_PLURIBUS,
     HAS_CODERABBIT,
 )
 
@@ -370,15 +371,25 @@ def test_detected_formats_claude_md(temp_dir):
     assert HAS_CLAUDE_MD in context.detected_formats
 
 
+def test_detected_formats_pluribus_md(temp_dir):
+    """Detect pluribus.md at root"""
+    (temp_dir / "pluribus.md").write_text("# Shared context")
+    context = RepositoryContext(temp_dir)
+    assert HAS_PLURIBUS in context.detected_formats
+    assert temp_dir / "pluribus.md" in context.instruction_files
+
+
 def test_detected_formats_multiple(temp_dir):
     """Detect multiple formats in the same repo"""
     (temp_dir / "CLAUDE.md").write_text("# Claude")
     (temp_dir / "AGENTS.md").write_text("# Agents")
+    (temp_dir / "pluribus.md").write_text("# Shared context")
     (temp_dir / ".cursor" / "rules").mkdir(parents=True)
     context = RepositoryContext(temp_dir)
     assert HAS_CLAUDE_MD in context.detected_formats
     assert HAS_AGENTS_MD in context.detected_formats
     assert HAS_CURSOR in context.detected_formats
+    assert HAS_PLURIBUS in context.detected_formats
     assert HAS_COPILOT not in context.detected_formats
 
 

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -218,6 +218,21 @@ def test_tree_contains_coderabbit_node(temp_dir):
     assert len(tree.find(CodeRabbitNode)) == 1
 
 
+def test_tree_contains_pluribus_md_block(temp_dir):
+    """pluribus.md should be linted as a typed instruction content block."""
+    from skillsaw.rules.builtin.content_analysis import PluribusMdBlock
+
+    (temp_dir / "pluribus.md").write_text("# Shared context\nAvoid hidden state drift.\n")
+
+    context = RepositoryContext(temp_dir)
+    tree = context.lint_tree
+
+    blocks = tree.find(PluribusMdBlock)
+    assert len(blocks) == 1
+    assert blocks[0].path == temp_dir / "pluribus.md"
+    assert blocks[0].category == "pluribus-md"
+
+
 def test_content_blocks_returns_all_content(temp_dir):
     """content_blocks() should return all ContentBlock subclasses polymorphically."""
     (temp_dir / "CLAUDE.md").write_text("# Instructions\nBe helpful.\n")


### PR DESCRIPTION
## Summary
- detect root-level `pluribus.md` as an instruction/context format
- include it in the lint tree as a typed `PluribusMdBlock` with `pluribus-md` category
- add coverage for format detection and lint-tree block discovery

## Why
skillsaw already audits cross-agent context surfaces like AGENTS.md, CLAUDE.md, GEMINI.md, Cursor rules, Copilot instructions, and APM context files. `pluribus.md` is another shared context file used to sync project context across AI coding tools, so treating it as lintable instruction content keeps it visible instead of an untyped markdown file.

## Validation
- `python3 -m compileall -q src tests`
- `git diff --check`

I could not run pytest in this container because Python has neither pytest nor pip installed (`python3 -m pytest` -> `No module named pytest`; `python3 -m pip --version` -> `No module named pip`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Pluribus repositories as an additional instruction format source.
  * The system now automatically detects and processes Pluribus instruction files at the repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->