### PR TITLE
Plugin extension points: custom repo types and lint tree contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,8 @@ executables on PATH.
 Beyond rules, plugins can extend skillsaw itself: declare custom
 **repository types** (`SKILLSAW_REPO_TYPES`) with their own detection and
 content paths, and **contribute nodes to the lint tree**
-(`SKILLSAW_TREE_CONTRIBUTORS`) so plugin rules can lint file formats
+(`SKILLSAW_TREE_CONTRIBUTORS`) — prose content blocks, structured config
+blocks, or any other lint-tree nodes — so plugin rules can lint things
 skillsaw doesn't know about.
 
 See the [plugin documentation](https://skillsaw.org/plugins/), the complete

--- a/README.md
+++ b/README.md
@@ -944,6 +944,12 @@ same package becomes reachable as `skillsaw <name> [args...]`, git-style —
 but only for registered plugins, never for arbitrary `skillsaw-*`
 executables on PATH.
 
+Beyond rules, plugins can extend skillsaw itself: declare custom
+**repository types** (`SKILLSAW_REPO_TYPES`) with their own detection and
+content paths, and **contribute nodes to the lint tree**
+(`SKILLSAW_TREE_CONTRIBUTORS`) so plugin rules can lint file formats
+skillsaw doesn't know about.
+
 See the [plugin documentation](https://skillsaw.org/plugins/), the complete
 [`examples/plugins/skillsaw-example-plugin/`](examples/plugins/skillsaw-example-plugin/)
 package, and the `skillsaw-create-plugin` skill in [`skills/`](skills/) that

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -287,8 +287,10 @@ When `detect(root_path)` returns True for the linted repository:
 
 Type names must be kebab-case and must not collide with builtin type values
 or other plugins' types — colliding declarations are skipped with a warning
-(first plugin wins). A crashing detector becomes a `plugin-load-error`
-violation and the type is treated as not detected; the lint continues.
+(first plugin wins). A malformed declaration (non-kebab-case `name`,
+non-callable `detect`, invalid `content_paths`) fails the whole plugin at
+load time, and a crashing detector becomes a `plugin-load-error` violation
+with the type treated as not detected; either way the lint continues.
 
 ### Optional: contribute nodes to the lint tree
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -241,6 +241,96 @@ Plugins can also ship **deterministic autofixes** by setting
 plugin. Fixes must be deterministic, scoped to the violation's exact lines,
 and idempotent.
 
+### Optional: declare a repository type
+
+Plugins can teach skillsaw to recognize repository layouts it doesn't know
+about — for example a new AI assistant's config format. Declare types in a
+`SKILLSAW_REPO_TYPES` list on the plugin module:
+
+```python
+from skillsaw.plugins import PluginRepoType
+
+SKILLSAW_REPO_TYPES = [
+    PluginRepoType(
+        name="acme",
+        description="Repository configured for the ACME assistant",
+        detect=lambda root: (root / "ACME.md").exists() or (root / ".acme").is_dir(),
+        content_paths=["ACME.md", ".acme/rules/*.md"],
+    ),
+]
+```
+
+When `detect(root_path)` returns True for the linted repository:
+
+- The type name appears in the lint report's detected repository types and
+  in `skillsaw plugins` output.
+- Rules can scope to it by listing the name as a **string** in `repo_types`
+  (mixing freely with builtin `RepositoryType` members) — with the default
+  `enabled: auto`, such rules activate only on matching repositories:
+
+  ```python
+  class AcmeConfigRule(Rule):
+      repo_types = {"acme"}
+  ```
+
+- The type's `content_paths` globs are pulled into content linting, exactly
+  like the user-side [`content-paths`](configuration.md#content-paths)
+  config key: matched files become content blocks and every `content-*`
+  rule covers them automatically.
+
+Type names must be kebab-case and must not collide with builtin type values
+or other plugins' types — colliding declarations are skipped with a warning
+(first plugin wins). A crashing detector becomes a `plugin-load-error`
+violation and the type is treated as not detected; the lint continues.
+
+### Optional: contribute nodes to the lint tree
+
+For files that need *dedicated* rules (rather than the generic content
+rules), a plugin can add its own nodes to the [lint tree](lint-tree.md).
+Declare contributor callables in `SKILLSAW_TREE_CONTRIBUTORS`; each is
+invoked as `contribute(context, root)` during tree construction and returns
+an iterable of node instances to attach at the root (or None):
+
+```python
+from dataclasses import dataclass
+
+from skillsaw.blocks import JsonConfigBlock
+
+
+@dataclass(eq=False)
+class AcmeConfigBlock(JsonConfigBlock):
+    """.acme/config.json — machine config, never linted as prose."""
+
+    category: str = "acme-config"
+
+
+def contribute_acme_config(context, root):
+    config_path = context.root_path / ".acme" / "config.json"
+    if config_path.exists():
+        return [AcmeConfigBlock(path=config_path)]
+    return []
+
+
+SKILLSAW_TREE_CONTRIBUTORS = [contribute_acme_config]
+```
+
+The plugin's rules then discover the nodes the standard way —
+`context.lint_tree.find(AcmeConfigBlock)` — and the nodes show up in
+`skillsaw tree` like any builtin node.
+
+Contract and guarantees:
+
+- **Choose the right base class.** Prose destined for an agent's context
+  window subclasses `ContentBlock` (or `FileContentBlock`) and gets every
+  content-quality rule automatically; structured machine config subclasses
+  `JsonConfigBlock` so content rules never lint JSON as instruction text.
+- **skillsaw applies its own guards**: contributed nodes pointing at files
+  already in the tree are dropped (no double-linting), and `exclude`
+  patterns from config apply to contributed nodes too.
+- **Fault isolation**: a contributor that raises (or returns non-node
+  values) produces a `plugin-load-error` violation; tree construction and
+  the rest of the lint continue.
+
 ### Optional: ship a CLI
 
 Add a console script named `skillsaw-<name>` and it becomes available as

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,6 +11,13 @@ automatically — no `.skillsaw.yaml` changes needed.
     the Claude Code plugins (`.claude-plugin/plugin.json`) that skillsaw
     *lints* — those are content skillsaw checks, not extensions to skillsaw.
 
+!!! tip "When to plugin, when to upstream"
+    For common, popular formats it is recommended to contribute repository
+    types, rules, and tree support back to skillsaw itself — builtin support
+    reaches every user with zero installs. Plugins are the right home for
+    private/organization-specific conventions and for incubating ideas
+    before proposing them upstream.
+
 ## Using plugins
 
 Install a plugin into the same environment as skillsaw and its rules are

--- a/examples/custom-rules/promptfoo/promptfoo_budget_rule.py
+++ b/examples/custom-rules/promptfoo/promptfoo_budget_rule.py
@@ -80,7 +80,9 @@ class PromptfooBudgetRule(Rule):
         budget_data, error, error_line = read_yaml_commented(budget_path)
         if error:
             violations.append(
-                self.violation(f"Budget file error: {error}", file_path=budget_path, line=error_line)
+                self.violation(
+                    f"Budget file error: {error}", file_path=budget_path, line=error_line
+                )
             )
             return violations
 
@@ -104,7 +106,9 @@ class PromptfooBudgetRule(Rule):
             if err or not isinstance(data, dict):
                 continue
 
-            default_test = data.get("defaultTest") if isinstance(data.get("defaultTest"), dict) else None
+            default_test = (
+                data.get("defaultTest") if isinstance(data.get("defaultTest"), dict) else None
+            )
             tests = _collect_tests(node, context)
 
             entity = self._entity_name(context, node)
@@ -301,7 +305,9 @@ class PromptfooBudgetRule(Rule):
             s_latency = smaller_def.get("max-latency")
 
             cost_fits = test_cost is None or (s_cost is not None and test_cost <= s_cost)
-            latency_fits = test_latency is None or (s_latency is not None and test_latency <= s_latency)
+            latency_fits = test_latency is None or (
+                s_latency is not None and test_latency <= s_latency
+            )
 
             if cost_fits and latency_fits:
                 violations.append(

--- a/examples/plugins/skillsaw-example-plugin/README.md
+++ b/examples/plugins/skillsaw-example-plugin/README.md
@@ -17,8 +17,9 @@ skillsaw-example-plugin/
 ├── pyproject.toml                        # entry point registration
 ├── src/
 │   └── skillsaw_example_plugin/
-│       ├── __init__.py                   # SKILLSAW_RULES = [...]
+│       ├── __init__.py                   # SKILLSAW_* declarations
 │       ├── rules.py                      # the Rule subclass
+│       ├── extensions.py                 # repo type + lint tree contributor
 │       └── cli.py                        # optional: `skillsaw example` CLI
 └── tests/
     ├── fixture/CLAUDE.md                 # realistic test fixture
@@ -34,13 +35,19 @@ The two pieces that make it a plugin:
    example = "skillsaw_example_plugin"
    ```
 
-2. **The rule declaration** in `src/skillsaw_example_plugin/__init__.py`:
+2. **The declarations** in `src/skillsaw_example_plugin/__init__.py`:
 
    ```python
-   from .rules import NoTodoInstructionsRule
-
-   SKILLSAW_RULES = [NoTodoInstructionsRule]
+   SKILLSAW_RULES = [NoTodoInstructionsRule, AcmeConfigVersionRule]
+   SKILLSAW_REPO_TYPES = [ACME_REPO_TYPE]
+   SKILLSAW_TREE_CONTRIBUTORS = [contribute_acme_config]
    ```
+
+`extensions.py` demonstrates the extension points with a fictional "ACME"
+assistant: a `PluginRepoType` whose detector recognizes ACME repositories
+(scoping `acme-config-version` to them and pulling `ACME.md` /
+`.acme/rules/*.md` into content linting), and a tree contributor that
+attaches `.acme/config.json` as a `JsonConfigBlock` for the rule to lint.
 
 ## Try it
 

--- a/examples/plugins/skillsaw-example-plugin/src/skillsaw_example_plugin/__init__.py
+++ b/examples/plugins/skillsaw-example-plugin/src/skillsaw_example_plugin/__init__.py
@@ -1,9 +1,18 @@
 """Example skillsaw plugin.
 
-The ``skillsaw.plugins`` entry point in pyproject.toml points here;
-``SKILLSAW_RULES`` declares which rule classes the plugin provides.
+The ``skillsaw.plugins`` entry point in pyproject.toml points here; the
+``SKILLSAW_*`` declarations below are what skillsaw discovers:
+
+- ``SKILLSAW_RULES`` — the rule classes the plugin provides
+- ``SKILLSAW_REPO_TYPES`` — custom repository types with detection
+- ``SKILLSAW_TREE_CONTRIBUTORS`` — callables adding nodes to the lint tree
 """
 
+from .extensions import ACME_REPO_TYPE, AcmeConfigVersionRule, contribute_acme_config
 from .rules import NoTodoInstructionsRule
 
-SKILLSAW_RULES = [NoTodoInstructionsRule]
+SKILLSAW_RULES = [NoTodoInstructionsRule, AcmeConfigVersionRule]
+
+SKILLSAW_REPO_TYPES = [ACME_REPO_TYPE]
+
+SKILLSAW_TREE_CONTRIBUTORS = [contribute_acme_config]

--- a/examples/plugins/skillsaw-example-plugin/src/skillsaw_example_plugin/extensions.py
+++ b/examples/plugins/skillsaw-example-plugin/src/skillsaw_example_plugin/extensions.py
@@ -1,0 +1,73 @@
+"""Extension points: a custom repository type and a lint tree contributor.
+
+This demonstrates the two ways a plugin extends skillsaw beyond rules,
+using a fictional "ACME" assistant whose repositories carry an ACME.md
+instruction file and an .acme/ directory:
+
+- The ``PluginRepoType`` teaches skillsaw to *recognize* ACME repositories.
+  When detected, rules can scope to the type (``repo_types = {"acme"}``)
+  and the type's ``content_paths`` files get every ``content-*`` rule.
+- The tree contributor attaches ``.acme/config.json`` to the lint tree as
+  a config block, so dedicated rules can lint it via ``lint_tree.find()``.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
+from skillsaw.blocks import JsonConfigBlock
+from skillsaw.plugins import PluginRepoType
+
+ACME_REPO_TYPE = PluginRepoType(
+    name="acme",
+    description="Repository configured for the ACME assistant",
+    detect=lambda root: (root / "ACME.md").exists() or (root / ".acme").is_dir(),
+    # Pulled into content linting when the type is detected — matched files
+    # become content blocks and get all content-* rules automatically.
+    content_paths=["ACME.md", ".acme/rules/*.md"],
+)
+
+
+@dataclass(eq=False)
+class AcmeConfigBlock(JsonConfigBlock):
+    """.acme/config.json — machine config, never linted as prose."""
+
+    category: str = "acme-config"
+
+
+def contribute_acme_config(context, root):
+    """Attach .acme/config.json to the lint tree when present."""
+    config_path = context.root_path / ".acme" / "config.json"
+    if config_path.exists():
+        return [AcmeConfigBlock(path=config_path)]
+    return []
+
+
+class AcmeConfigVersionRule(Rule):
+    """Runs only on detected ACME repositories (string repo type entry)."""
+
+    repo_types = {"acme"}
+
+    @property
+    def rule_id(self) -> str:
+        return "acme-config-version"
+
+    @property
+    def description(self) -> str:
+        return "ACME config must declare a version field"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        for block in context.lint_tree.find(AcmeConfigBlock):
+            if block.parse_error:
+                violations.append(
+                    self.violation(f"Invalid JSON: {block.parse_error}", file_path=block.path)
+                )
+            elif not isinstance(block.raw_data, dict) or "version" not in block.raw_data:
+                violations.append(
+                    self.violation("Missing required 'version' field", file_path=block.path)
+                )
+        return violations

--- a/examples/plugins/skillsaw-example-plugin/tests/fixture/.acme/config.json
+++ b/examples/plugins/skillsaw-example-plugin/tests/fixture/.acme/config.json
@@ -1,0 +1,3 @@
+{
+  "model": "acme-large"
+}

--- a/examples/plugins/skillsaw-example-plugin/tests/fixture/.acme/rules/style.md
+++ b/examples/plugins/skillsaw-example-plugin/tests/fixture/.acme/rules/style.md
@@ -1,0 +1,3 @@
+# Style rules
+
+- Write error messages in lowercase without trailing punctuation.

--- a/examples/plugins/skillsaw-example-plugin/tests/fixture/ACME.md
+++ b/examples/plugins/skillsaw-example-plugin/tests/fixture/ACME.md
@@ -1,0 +1,6 @@
+# ACME Assistant Instructions
+
+Instructions for the ACME coding assistant working in this repository.
+
+- Deploy with `make deploy ENV=staging`; production requires approval in
+  the release channel first.

--- a/examples/plugins/skillsaw-example-plugin/tests/test_extensions.py
+++ b/examples/plugins/skillsaw-example-plugin/tests/test_extensions.py
@@ -47,3 +47,23 @@ def test_version_rule_fires_on_contributed_block(tmp_path):
     assert len(violations) == 1
     assert "version" in violations[0].message
     assert violations[0].file_path.name == "config.json"
+
+
+def test_version_rule_passes_on_valid_config(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / ".acme" / "config.json").write_text(
+        '{"model": "acme-large", "version": "1.0"}\n', encoding="utf-8"
+    )
+    context = RepositoryContext(repo)
+    context.plugin_tree_contributors.append(("example", contribute_acme_config))
+    assert AcmeConfigVersionRule().check(context) == []
+
+
+def test_version_rule_reports_invalid_json(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / ".acme" / "config.json").write_text("{not json", encoding="utf-8")
+    context = RepositoryContext(repo)
+    context.plugin_tree_contributors.append(("example", contribute_acme_config))
+    violations = AcmeConfigVersionRule().check(context)
+    assert len(violations) == 1
+    assert "Invalid JSON" in violations[0].message

--- a/examples/plugins/skillsaw-example-plugin/tests/test_extensions.py
+++ b/examples/plugins/skillsaw-example-plugin/tests/test_extensions.py
@@ -1,0 +1,49 @@
+"""Tests for the example plugin's extension points."""
+
+import shutil
+from pathlib import Path
+
+from skillsaw.context import RepositoryContext
+
+from skillsaw_example_plugin.extensions import (
+    ACME_REPO_TYPE,
+    AcmeConfigBlock,
+    AcmeConfigVersionRule,
+    contribute_acme_config,
+)
+
+FIXTURE = Path(__file__).parent / "fixture"
+
+
+def make_repo(tmp_path):
+    repo = tmp_path / "repo"
+    shutil.copytree(FIXTURE, repo)
+    return repo
+
+
+def test_repo_type_detection(tmp_path):
+    repo = make_repo(tmp_path)
+    assert ACME_REPO_TYPE.detect(repo)
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert not ACME_REPO_TYPE.detect(plain)
+
+
+def test_contributor_attaches_config_block(tmp_path):
+    repo = make_repo(tmp_path)
+    context = RepositoryContext(repo)
+    blocks = contribute_acme_config(context, None)
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], AcmeConfigBlock)
+
+
+def test_version_rule_fires_on_contributed_block(tmp_path):
+    repo = make_repo(tmp_path)
+    context = RepositoryContext(repo)
+    # In a real run skillsaw registers the contributor automatically; tests
+    # register it directly on the context the same way.
+    context.plugin_tree_contributors.append(("example", contribute_acme_config))
+    violations = AcmeConfigVersionRule().check(context)
+    assert len(violations) == 1
+    assert "version" in violations[0].message
+    assert violations[0].file_path.name == "config.json"

--- a/skills/skillsaw-create-plugin/SKILL.md
+++ b/skills/skillsaw-create-plugin/SKILL.md
@@ -102,139 +102,31 @@ class the plugin provides goes in this list.
 
 ## Step 3: Write the rules
 
-Each rule subclasses `skillsaw.Rule` in `src/skillsaw_<name>/rules.py`:
+Read `references/rule-authoring.md` in this skill's directory for the full
+rule template, the requirements every rule must meet (lint tree discovery,
+line numbers, `config_schema`, `repo_types`, `default_enabled`, YAML and
+markdown parsing rules), and the deterministic-autofix template with its
+scoping and idempotency requirements. Follow it exactly — the requirements
+match what skillsaw's own review process enforces.
 
-```python
-from typing import List
+In short: each rule subclasses `skillsaw.Rule` in
+`src/skillsaw_<name>/rules.py`, discovers files with
+`context.lint_tree.find(NodeType)`, reports violations via
+`self.violation(message, block=block, line=i)`, and exposes tunable settings
+through `config_schema`.
 
-from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
-from skillsaw.blocks import InstructionBlock
+### Optional capabilities
 
+Read `references/extensions.md` when the plugin needs any of:
 
-class MyFirstRule(Rule):
-    """One-line summary of what this enforces."""
-
-    config_schema = {
-        "patterns": {
-            "type": "list",
-            "default": ["TODO"],
-            "description": "Patterns to flag",
-        },
-    }
-
-    @property
-    def rule_id(self) -> str:
-        return "my-rule-id"
-
-    @property
-    def description(self) -> str:
-        return "Instruction files should not contain TODO markers"
-
-    def default_severity(self) -> Severity:
-        return Severity.WARNING
-
-    def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        violations = []
-        patterns = self.config.get("patterns", self.config_schema["patterns"]["default"])
-        for block in context.lint_tree.find(InstructionBlock):
-            content = block.read_body(strip_code_blocks=False)
-            if content is None:
-                continue
-            for i, line in enumerate(content.splitlines(), start=1):
-                if any(p in line for p in patterns):
-                    violations.append(
-                        self.violation(f"Found marker: {line.strip()}", block=block, line=i)
-                    )
-        return violations
-```
-
-Rules you must follow when writing rules:
-
-- **Discover files through the lint tree** (`context.lint_tree.find(NodeType)`),
-  never by walking the filesystem. Common block types from `skillsaw.blocks`:
-  `InstructionBlock` (CLAUDE.md, AGENTS.md, …), `SkillBlock`, `CommandBlock`,
-  `AgentBlock`, `ClaudeMdBlock`. Run `skillsaw tree` on a target repo to see
-  its nodes.
-- **Report a line number** on every violation traceable to a line; never
-  fabricate one when it is not.
-- **Pass `block=`** to `self.violation()` for content violations — line
-  numbers then map to the right file lines even for YAML-embedded bodies.
-- **Expose tunable settings through `config_schema`** and read them from
-  `self.config`. Users configure the rule in `.skillsaw.yaml` under `rules:`
-  by its rule ID, exactly like builtin rules.
-- **Declare `repo_types`** when the rule only applies to certain repository
-  types — the rule then activates only on matching repositories.
-- **Set `default_enabled`** to control activation: the base default `"auto"`
-  runs everywhere (or on matching `repo_types`/`formats` when declared);
-  `default_enabled = False` makes the rule opt-in via config.
-- Parse YAML with `read_yaml_commented()` from `skillsaw.utils` (preserves
-  line numbers), never `yaml.safe_load()`.
-- Read markdown structure (links, fences, headings) from `block.markdown`
-  accessors, never hand-rolled regexes.
-
-### Optional: deterministic autofix
-
-To make violations fixable by `skillsaw fix`, set `autofix_confidence` and
-override `fix()`:
-
-```python
-from skillsaw import AutofixConfidence, AutofixResult
-
-
-class MyFirstRule(Rule):
-    autofix_confidence = AutofixConfidence.SAFE  # or SUGGEST
-
-    def fix(self, context, violations) -> List[AutofixResult]:
-        by_file = {}
-        for v in violations:
-            by_file.setdefault(v.file_path, []).append(v)
-
-        results = []
-        for path, file_violations in by_file.items():
-            original = path.read_text(encoding="utf-8")
-            lines = original.splitlines(keepends=True)
-            remove = {v.file_line for v in file_violations if v.file_line}
-            fixed = "".join(ln for i, ln in enumerate(lines, start=1) if i not in remove)
-            if fixed != original:
-                results.append(
-                    AutofixResult(
-                        rule_id=self.rule_id,
-                        file_path=path,
-                        confidence=AutofixConfidence.SAFE,
-                        original_content=original,
-                        fixed_content=fixed,
-                        description="Removed marker lines",
-                        violations_fixed=file_violations,
-                    )
-                )
-        return results
-```
-
-Autofix rules:
-
-- Fixes must be **deterministic and scoped to the violation's exact location**
-  (use `v.file_line`; never `str.replace()` across the whole file — it can
-  match the wrong occurrence).
-- Use `AutofixConfidence.SAFE` only when the fix cannot change meaning;
-  otherwise use `SUGGEST` (applied only with `skillsaw fix --suggest`).
-- Fixes must be idempotent: fixing already-fixed content produces no changes.
-- Do not build fixes on LLM hooks — plugins provide deterministic fixes only.
-
-### Optional: ship a CLI subcommand
-
-If the plugin needs its own commands (for example an `accept` command that
-appends currently-flagged values to the rule's config), add a console script
-named `skillsaw-<name>` to `pyproject.toml`:
-
-```toml
-[project.scripts]
-skillsaw-<name> = "skillsaw_<name>.cli:main"
-```
-
-skillsaw dispatches `skillsaw <name> [args...]` to that executable
-(registered plugins only), forwarding arguments and the exit code. The
-script owns its own argument parsing and can `import skillsaw` to reuse the
-config loader and lint tree.
+- **A CLI subcommand** — a `skillsaw-<name>` console script, dispatched as
+  `skillsaw <name> [args...]` (registered plugins only).
+- **A custom repository type** — `SKILLSAW_REPO_TYPES` declares a detector;
+  detected types scope rules (string entries in `repo_types`) and pull the
+  type's `content_paths` into content linting.
+- **Lint tree nodes** — `SKILLSAW_TREE_CONTRIBUTORS` attaches plugin-defined
+  blocks (`ContentBlock` for prose, `JsonConfigBlock` for machine config)
+  that the plugin's rules find with `lint_tree.find()`.
 
 ## Step 4: Write tests
 

--- a/skills/skillsaw-create-plugin/references/extensions.md
+++ b/skills/skillsaw-create-plugin/references/extensions.md
@@ -4,6 +4,12 @@ Optional capabilities beyond rules. Read this when the plugin needs a CLI,
 a custom repository type, or its own lint tree nodes. Full documentation:
 https://skillsaw.org/plugins/
 
+Guidance to share with the user first: for common, popular formats,
+contribute repository types and rules back to skillsaw itself (builtin
+support reaches every user). Plugins are the right home for
+private/organization-specific conventions and for incubating ideas before
+proposing them upstream.
+
 ## CLI subcommand
 
 If the plugin needs its own commands (for example an `accept` command that

--- a/skills/skillsaw-create-plugin/references/extensions.md
+++ b/skills/skillsaw-create-plugin/references/extensions.md
@@ -1,0 +1,101 @@
+# Plugin extension points reference
+
+Optional capabilities beyond rules. Read this when the plugin needs a CLI,
+a custom repository type, or its own lint tree nodes. Full documentation:
+https://skillsaw.org/plugins/
+
+## CLI subcommand
+
+If the plugin needs its own commands (for example an `accept` command that
+appends currently-flagged values to the rule's config), add a console script
+named `skillsaw-<name>` to `pyproject.toml`:
+
+```toml
+[project.scripts]
+skillsaw-<name> = "skillsaw_<name>.cli:main"
+```
+
+skillsaw dispatches `skillsaw <name> [args...]` to that executable
+(registered plugins only), forwarding arguments and the exit code. The
+script owns its own argument parsing and can `import skillsaw` to reuse the
+config loader and lint tree.
+
+## Custom repository types
+
+When the plugin supports a repository layout skillsaw doesn't know (a new
+assistant's config format), declare it on the plugin module:
+
+```python
+from skillsaw.plugins import PluginRepoType
+
+SKILLSAW_REPO_TYPES = [
+    PluginRepoType(
+        name="acme",
+        description="Repository configured for the ACME assistant",
+        detect=lambda root: (root / "ACME.md").exists() or (root / ".acme").is_dir(),
+        content_paths=["ACME.md", ".acme/rules/*.md"],
+    ),
+]
+```
+
+When `detect(root_path)` returns True for the linted repository:
+
+- The type name appears in the lint report's detected repository types.
+- Rules scope to it by listing the name as a **string** in `repo_types`
+  (mixing freely with builtin `RepositoryType` members):
+
+  ```python
+  class AcmeConfigRule(Rule):
+      repo_types = {"acme"}
+  ```
+
+- The type's `content_paths` globs are pulled into content linting: matched
+  files become content blocks and every `content-*` rule covers them
+  automatically.
+
+Names must be kebab-case and unique — collisions with builtin type values or
+other plugins are skipped with a warning. A crashing detector becomes a
+`plugin-load-error` violation; the lint continues.
+
+## Lint tree contributors
+
+For files that need *dedicated* rules (rather than the generic content
+rules), contribute nodes to the lint tree:
+
+```python
+from dataclasses import dataclass
+
+from skillsaw.blocks import JsonConfigBlock
+
+
+@dataclass(eq=False)
+class AcmeConfigBlock(JsonConfigBlock):
+    """.acme/config.json — machine config, never linted as prose."""
+
+    category: str = "acme-config"
+
+
+def contribute_acme_config(context, root):
+    config_path = context.root_path / ".acme" / "config.json"
+    if config_path.exists():
+        return [AcmeConfigBlock(path=config_path)]
+    return []
+
+
+SKILLSAW_TREE_CONTRIBUTORS = [contribute_acme_config]
+```
+
+Each contributor is invoked as `contribute(context, root)` during tree
+construction and returns an iterable of node instances (or None). The
+plugin's rules then discover them with `context.lint_tree.find(AcmeConfigBlock)`.
+
+Contract:
+
+- **Choose the right base class**: prose for an agent's context window
+  subclasses `ContentBlock`/`FileContentBlock` (content-quality rules apply
+  automatically); structured machine config subclasses `JsonConfigBlock` so
+  content rules never lint JSON as instruction text.
+- skillsaw drops contributed nodes that duplicate files already in the tree
+  and applies the user's `exclude` patterns.
+- A contributor that raises (or returns non-node values) produces a
+  `plugin-load-error` violation; tree construction and the lint continue.

--- a/skills/skillsaw-create-plugin/references/rule-authoring.md
+++ b/skills/skillsaw-create-plugin/references/rule-authoring.md
@@ -1,0 +1,124 @@
+# Rule authoring reference
+
+Full templates and requirements for skillsaw plugin rules. Read this when
+implementing Step 3 of the skillsaw-create-plugin skill.
+
+## Rule template
+
+Each rule subclasses `skillsaw.Rule` in `src/skillsaw_<name>/rules.py`:
+
+```python
+from typing import List
+
+from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
+from skillsaw.blocks import InstructionBlock
+
+
+class MyFirstRule(Rule):
+    """One-line summary of what this enforces."""
+
+    config_schema = {
+        "patterns": {
+            "type": "list",
+            "default": ["TODO"],
+            "description": "Patterns to flag",
+        },
+    }
+
+    @property
+    def rule_id(self) -> str:
+        return "my-rule-id"
+
+    @property
+    def description(self) -> str:
+        return "Instruction files should not contain TODO markers"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        patterns = self.config.get("patterns", self.config_schema["patterns"]["default"])
+        for block in context.lint_tree.find(InstructionBlock):
+            content = block.read_body(strip_code_blocks=False)
+            if content is None:
+                continue
+            for i, line in enumerate(content.splitlines(), start=1):
+                if any(p in line for p in patterns):
+                    violations.append(
+                        self.violation(f"Found marker: {line.strip()}", block=block, line=i)
+                    )
+        return violations
+```
+
+## Requirements for every rule
+
+- **Discover files through the lint tree** (`context.lint_tree.find(NodeType)`),
+  never by walking the filesystem. Common block types from `skillsaw.blocks`:
+  `InstructionBlock` (CLAUDE.md, AGENTS.md, …), `SkillBlock`, `CommandBlock`,
+  `AgentBlock`, `ClaudeMdBlock`. Run `skillsaw tree` on a target repo to see
+  its nodes.
+- **Report a line number** on every violation traceable to a line; never
+  fabricate one when it is not.
+- **Pass `block=`** to `self.violation()` for content violations — line
+  numbers then map to the right file lines even for YAML-embedded bodies.
+- **Expose tunable settings through `config_schema`** and read them from
+  `self.config`. Users configure the rule in `.skillsaw.yaml` under `rules:`
+  by its rule ID, exactly like builtin rules.
+- **Declare `repo_types`** when the rule only applies to certain repository
+  types — the rule then activates only on matching repositories.
+- **Set `default_enabled`** to control activation: the base default `"auto"`
+  runs everywhere (or on matching `repo_types`/`formats` when declared);
+  `default_enabled = False` makes the rule opt-in via config.
+- Parse YAML with `read_yaml_commented()` from `skillsaw.utils` (preserves
+  line numbers), never `yaml.safe_load()`.
+- Read markdown structure (links, fences, headings) from `block.markdown`
+  accessors, never hand-rolled regexes.
+
+## Deterministic autofix
+
+To make violations fixable by `skillsaw fix`, set `autofix_confidence` and
+override `fix()`:
+
+```python
+from skillsaw import AutofixConfidence, AutofixResult
+
+
+class MyFirstRule(Rule):
+    autofix_confidence = AutofixConfidence.SAFE  # or SUGGEST
+
+    def fix(self, context, violations) -> List[AutofixResult]:
+        by_file = {}
+        for v in violations:
+            by_file.setdefault(v.file_path, []).append(v)
+
+        results = []
+        for path, file_violations in by_file.items():
+            original = path.read_text(encoding="utf-8")
+            lines = original.splitlines(keepends=True)
+            remove = {v.file_line for v in file_violations if v.file_line}
+            fixed = "".join(ln for i, ln in enumerate(lines, start=1) if i not in remove)
+            if fixed != original:
+                results.append(
+                    AutofixResult(
+                        rule_id=self.rule_id,
+                        file_path=path,
+                        confidence=AutofixConfidence.SAFE,
+                        original_content=original,
+                        fixed_content=fixed,
+                        description="Removed marker lines",
+                        violations_fixed=file_violations,
+                    )
+                )
+        return results
+```
+
+Autofix requirements:
+
+- Fixes must be **deterministic and scoped to the violation's exact location**
+  (use `v.file_line`; never `str.replace()` across the whole file — it can
+  match the wrong occurrence).
+- Use `AutofixConfidence.SAFE` only when the fix cannot change meaning;
+  otherwise use `SUGGEST` (applied only with `skillsaw fix --suggest`).
+- Fixes must be idempotent: fixing already-fixed content produces no changes.
+- Do not build fixes on LLM hooks — plugins provide deterministic fixes only.

--- a/src/skillsaw/cli/_explain.py
+++ b/src/skillsaw/cli/_explain.py
@@ -113,7 +113,12 @@ def _run_explain(args):
     if config.plugins_enabled:
         from ..plugins import load_plugins, register_extensions
 
-        register_extensions(context, load_plugins(disabled=set(config.disabled_plugins)))
+        # A crashed or colliding detector would otherwise silently read as
+        # "no matching repo type detected" — surface it like `skillsaw tree`.
+        for problem in register_extensions(
+            context, load_plugins(disabled=set(config.disabled_plugins))
+        ):
+            print(f"Warning: {problem.message}", file=sys.stderr)
 
     enabled, reason = config.rule_enabled_reason(
         args.rule_id,

--- a/src/skillsaw/cli/_explain.py
+++ b/src/skillsaw/cli/_explain.py
@@ -80,7 +80,8 @@ def _run_explain(args):
         print(long_docs)
 
     if default_rule.repo_types:
-        repo_types_str = ", ".join(sorted(t.value for t in default_rule.repo_types))
+        # repo_types may mix RepositoryType members with plugin type names.
+        repo_types_str = ", ".join(sorted(getattr(t, "value", t) for t in default_rule.repo_types))
         print()
         print(f"{c['bold']}Applies to repo types:{c['reset']} {repo_types_str}")
 
@@ -107,12 +108,22 @@ def _run_explain(args):
     )
     config_label = str(config_path) if config_path else "builtin defaults"
 
+    # Plugin-contributed repo types must be detected for the effective state
+    # to match a real lint run (rules may scope to them via string entries).
+    if config.plugins_enabled:
+        from ..plugins import load_plugins, register_extensions
+
+        register_extensions(context, load_plugins(disabled=set(config.disabled_plugins)))
+
     enabled, reason = config.rule_enabled_reason(
         args.rule_id,
         context,
         default_rule.repo_types,
         default_rule.formats,
         since_version=default_rule.since,
+        # Plugin rules have no entry in the builtin defaults registry; their
+        # class-level default drives activation (None for builtins).
+        default_enabled=default_rule.default_enabled if plugin_name else None,
     )
     try:
         effective_rule = rule_class(config.get_rule_config(args.rule_id))

--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -84,11 +84,12 @@ def _is_subpath(child, parent):
 class _MergedContext:
     """Duck-typed context for formatters when linting multiple paths."""
 
-    def __init__(self, root_path, repo_types, plugins, skills):
+    def __init__(self, root_path, repo_types, plugins, skills, plugin_repo_types=frozenset()):
         self.root_path = root_path
         self.repo_types = repo_types
         self.plugins = plugins
         self.skills = skills
+        self.plugin_repo_types = set(plugin_repo_types)
 
     @property
     def repo_type(self):
@@ -96,6 +97,14 @@ class _MergedContext:
             if t in self.repo_types:
                 return t
         return RepositoryType.UNKNOWN
+
+    def repo_type_names(self, include_unknown: bool = True):
+        """Sorted names of all detected repository types, builtin and plugin."""
+        names = {t.value for t in self.repo_types}
+        if not include_unknown:
+            names.discard(RepositoryType.UNKNOWN.value)
+        names.update(self.plugin_repo_types)
+        return sorted(names)
 
 
 def _build_merged_context(contexts):
@@ -107,13 +116,15 @@ def _build_merged_context(contexts):
     except ValueError:
         root_path = contexts[0].root_path
     repo_types = set()
+    plugin_repo_types = set()
     plugins = []
     skills = []
     for ctx in contexts:
         repo_types |= ctx.repo_types
+        plugin_repo_types |= ctx.plugin_repo_types
         plugins.extend(ctx.plugins)
         skills.extend(ctx.skills)
-    return _MergedContext(root_path, repo_types, plugins, skills)
+    return _MergedContext(root_path, repo_types, plugins, skills, plugin_repo_types)
 
 
 def _dedup_rules(rules):

--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -101,9 +101,9 @@ class _MergedContext:
     def repo_type_names(self, include_unknown: bool = True):
         """Sorted names of all detected repository types, builtin and plugin."""
         names = {t.value for t in self.repo_types}
-        if not include_unknown:
-            names.discard(RepositoryType.UNKNOWN.value)
         names.update(self.plugin_repo_types)
+        if not include_unknown or len(names) > 1:
+            names.discard(RepositoryType.UNKNOWN.value)
         return sorted(names)
 
 

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -132,17 +132,6 @@ def _run_lint(args):
         )
         contexts.append(context)
 
-        if context.repo_type == RepositoryType.UNKNOWN:
-            print(
-                "Warning: Directory doesn't appear to be a recognized repository",
-                file=sys.stderr,
-            )
-            print(
-                "Expected: .claude-plugin/plugin.json, plugins/ directory,"
-                " or SKILL.md (agentskills.io)\n",
-                file=sys.stderr,
-            )
-
         try:
             linter = Linter(
                 context,
@@ -156,6 +145,19 @@ def _run_lint(args):
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
             sys.exit(1)
+
+        # After Linter construction plugin repo type detectors have run, so
+        # a repository recognized only by a plugin is not warned about.
+        if context.repo_type == RepositoryType.UNKNOWN and not context.plugin_repo_types:
+            print(
+                "Warning: Directory doesn't appear to be a recognized repository",
+                file=sys.stderr,
+            )
+            print(
+                "Expected: .claude-plugin/plugin.json, plugins/ directory,"
+                " or SKILL.md (agentskills.io)\n",
+                file=sys.stderr,
+            )
 
         rule_progress = _RuleProgress(args)
         try:

--- a/src/skillsaw/cli/_simple.py
+++ b/src/skillsaw/cli/_simple.py
@@ -79,17 +79,26 @@ def _run_plugins():
         if plugin.error:
             had_errors = True
             print(f"    ERROR: {plugin.error}")
-        elif not plugin.rule_classes:
-            print("    rules: (none)")
         else:
-            print("    rules:")
-            for rule_class in plugin.rule_classes:
-                try:
-                    rule = rule_class()
-                    print(f"      {rule.rule_id} — {rule.description}")
-                except Exception as e:
-                    had_errors = True
-                    print(f"      {rule_class.__name__}: failed to instantiate ({e})")
+            if not plugin.rule_classes:
+                print("    rules: (none)")
+            else:
+                print("    rules:")
+                for rule_class in plugin.rule_classes:
+                    try:
+                        rule = rule_class()
+                        print(f"      {rule.rule_id} — {rule.description}")
+                    except Exception as e:
+                        had_errors = True
+                        print(f"      {rule_class.__name__}: failed to instantiate ({e})")
+            if plugin.repo_types:
+                print("    repo types:")
+                for repo_type in plugin.repo_types:
+                    desc = f" — {repo_type.description}" if repo_type.description else ""
+                    print(f"      {repo_type.name}{desc}")
+            if plugin.tree_contributors:
+                names = ", ".join(getattr(c, "__name__", repr(c)) for c in plugin.tree_contributors)
+                print(f"    tree contributors: {names}")
         print()
 
     print("Disable a plugin with `plugins: {disable: [<name>]}` in .skillsaw.yaml,")

--- a/src/skillsaw/cli/_tree.py
+++ b/src/skillsaw/cli/_tree.py
@@ -8,6 +8,19 @@ from ..context import RepositoryContext
 from ._config import load_config
 
 
+def _apply_plugin_extensions(context, config) -> None:
+    """Register plugin repo types / tree contributors so the displayed tree
+    matches what a lint run sees. Problems go to stderr — the tree itself
+    must still print."""
+    if not config.plugins_enabled:
+        return
+    from ..plugins import load_plugins, register_extensions
+
+    plugins = load_plugins(disabled=set(config.disabled_plugins))
+    for problem in register_extensions(context, plugins):
+        print(f"Warning: {problem.message}", file=sys.stderr)
+
+
 def _run_tree(args):
     if not args.path.exists():
         print(f"Error: Path not found: {args.path}", file=sys.stderr)
@@ -19,10 +32,13 @@ def _run_tree(args):
         exclude_patterns=config.exclude_patterns,
         content_paths=config.content_paths,
     )
+    _apply_plugin_extensions(context, config)
 
     tree = context.lint_tree
     if args.fmt == "dot":
         print(tree.print_dot(root_path=context.root_path))
     else:
         print(tree.print_tree(root_path=context.root_path))
+    for message in context.plugin_extension_errors:
+        print(f"Warning: {message}", file=sys.stderr)
     sys.exit(0)

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -403,9 +403,17 @@ class LinterConfig:
         if enabled == "auto":
             if repo_types is None and formats is None:
                 return True, "enabled: auto (applies to all repo types)"
-            if repo_types is not None and repo_types & context.repo_types:
-                matched = sorted(t.value for t in repo_types & context.repo_types)
-                return True, f"enabled: auto — detected repo type: {', '.join(matched)}"
+            if repo_types is not None:
+                # ``repo_types`` may mix RepositoryType members with string
+                # names of plugin-contributed types (see skillsaw.plugins.
+                # PluginRepoType); strings match against the plugin set.
+                plugin_types = getattr(context, "plugin_repo_types", set())
+                matched_types = {
+                    t for t in repo_types if t in context.repo_types or t in plugin_types
+                }
+                if matched_types:
+                    matched = sorted(getattr(t, "value", t) for t in matched_types)
+                    return True, f"enabled: auto — detected repo type: {', '.join(matched)}"
             if formats is not None and formats & context.detected_formats:
                 matched = sorted(formats & context.detected_formats)
                 return True, f"enabled: auto — detected format: {', '.join(matched)}"

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -176,11 +176,15 @@ class RepositoryContext:
         return RepositoryType.UNKNOWN
 
     def repo_type_names(self, include_unknown: bool = True) -> List[str]:
-        """Sorted names of all detected repository types, builtin and plugin."""
+        """Sorted names of all detected repository types, builtin and plugin.
+
+        ``unknown`` is a sentinel for "nothing detected"; when a plugin type
+        matched, the repository *is* recognized, so the sentinel is dropped.
+        """
         names = {t.value for t in self.repo_types}
-        if not include_unknown:
-            names.discard(RepositoryType.UNKNOWN.value)
         names.update(self.plugin_repo_types)
+        if not include_unknown or len(names) > 1:
+            names.discard(RepositoryType.UNKNOWN.value)
         return sorted(names)
 
     def is_path_excluded(self, path: Path) -> bool:

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -133,6 +133,14 @@ class RepositoryContext:
         self.skills: List[Path] = self._discover_skills()
         self.instruction_files: List[Path] = self._discover_instruction_files()
         self.detected_formats: Set[str] = set()
+        # Plugin-contributed extension state, registered by the Linter after
+        # plugin loading (see Linter._register_plugin_extensions):
+        # detected custom repository type names, lint tree contributors as
+        # (plugin name, callable) pairs, and errors raised by contributors
+        # during tree construction (surfaced as violations by the Linter).
+        self.plugin_repo_types: Set[str] = set()
+        self.plugin_tree_contributors: List[tuple] = []
+        self.plugin_extension_errors: List[str] = []
         self._lint_tree: Optional["LintTarget"] = None
         # Filters discovery results and computes detected_formats — excludes
         # must be applied before format detection so excluded files (e.g.
@@ -158,6 +166,14 @@ class RepositoryContext:
             if t in self.repo_types:
                 return t
         return RepositoryType.UNKNOWN
+
+    def repo_type_names(self, include_unknown: bool = True) -> List[str]:
+        """Sorted names of all detected repository types, builtin and plugin."""
+        names = {t.value for t in self.repo_types}
+        if not include_unknown:
+            names.discard(RepositoryType.UNKNOWN.value)
+        names.update(self.plugin_repo_types)
+        return sorted(names)
 
     def is_path_excluded(self, path: Path) -> bool:
         """Check if a path matches any exclude pattern."""

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -139,8 +139,16 @@ class RepositoryContext:
         # (plugin name, callable) pairs, and errors raised by contributors
         # during tree construction (surfaced as violations by the Linter).
         self.plugin_repo_types: Set[str] = set()
+        # Content globs contributed by detected plugin repo types. Kept
+        # separate from ``content_paths`` (user config), which the Linter
+        # overwrites on construction — a shared context must not lose
+        # plugin contributions to that reset.
+        self.plugin_content_paths: List[str] = []
         self.plugin_tree_contributors: List[tuple] = []
         self.plugin_extension_errors: List[str] = []
+        # Set by skillsaw.plugins.register_extensions so repeated calls on a
+        # shared context (e.g. two Linters over one context) are no-ops.
+        self._plugin_extensions_registered = False
         self._lint_tree: Optional["LintTarget"] = None
         # Filters discovery results and computes detected_formats — excludes
         # must be applied before format detection so excluded files (e.g.

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -205,7 +205,7 @@ def format_html(
   <section class="stats">
     <article class="stat-card">
       <div class="label">Repo Type</div>
-      <div class="value">{html.escape(", ".join(sorted(t.value for t in context.repo_types if t.value != "unknown")) or "unknown")}</div>
+      <div class="value">{html.escape(", ".join(context.repo_type_names(include_unknown=False)) or "unknown")}</div>
     </article>
     <article class="stat-card">
       <div class="label">Plugins</div>

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -19,7 +19,7 @@ def format_json(
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
-    repo_types_list = sorted(t.value for t in context.repo_types)
+    repo_types_list = context.repo_type_names()
 
     if verbose:
         stats = {

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -103,7 +103,7 @@ def format_sarif(
                 "properties": {
                     "stats": {
                         "repo_type": context.repo_type.value,
-                        "repo_types": sorted(t.value for t in context.repo_types),
+                        "repo_types": context.repo_type_names(),
                         "plugins": len(context.plugins),
                         "skills": len(context.skills),
                         "rules_run": len(rules),

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -80,7 +80,7 @@ def format_text(
             output.append(f"  {rule_doc_url(rule_id)}")
 
     output.append(f"\n{bold}Scanned:{reset}")
-    repo_types_str = ", ".join(sorted(t.value for t in context.repo_types if t.value != "unknown"))
+    repo_types_str = ", ".join(context.repo_type_names(include_unknown=False))
     output.append(f"  Repo type: {repo_types_str or 'unknown'}")
     output.append(f"  Plugins:   {len(context.plugins)}")
     output.append(f"  Skills:    {len(context.skills)}")

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -282,6 +282,23 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     # guards against double-linting files already discovered above, and
     # failures are collected for the Linter to surface as violations —
     # a broken contributor must not abort tree construction.
+    def _admit_contributed_node(block) -> bool:
+        """Validate/dedupe a contributed node and its whole subtree.
+
+        Contributors may return nodes with children; every descendant gets
+        the same guards as top-level discovery (type check, ``seen`` dedupe,
+        exclude patterns), with rejected descendants pruned in place.
+        Returns False when the node itself must not be attached.
+        """
+        if not isinstance(block, LintTarget):
+            raise TypeError(f"contributor returned {block!r}, which is not a lint tree node")
+        resolved = block.path.resolve()
+        if resolved in seen or not block.path.exists() or _is_excluded(block.path):
+            return False
+        seen.add(resolved)
+        block.children = [child for child in block.children if _admit_contributed_node(child)]
+        return True
+
     for plugin_name, contribute in context.plugin_tree_contributors:
         try:
             contributed = contribute(context, root)
@@ -290,15 +307,8 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             # (None, or resolve() raising an OSError) must be reported like
             # any other contributor failure, not crash tree construction.
             for block in blocks:
-                if not isinstance(block, LintTarget):
-                    raise TypeError(
-                        f"contributor returned {block!r}, which is not a lint tree node"
-                    )
-                resolved = block.path.resolve()
-                if resolved in seen or not block.path.exists() or _is_excluded(block.path):
-                    continue
-                seen.add(resolved)
-                root.children.append(block)
+                if _admit_contributed_node(block):
+                    root.children.append(block)
         except Exception as e:
             context.plugin_extension_errors.append(
                 f"Plugin '{plugin_name}': tree contributor failed: " f"{e.__class__.__name__}: {e}"

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -274,6 +274,33 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             if extra.is_file():
                 _add_block(root, extra, ExtraBlock)
 
+    # --- Plugin tree contributors ---
+    # Contributors return pre-constructed nodes (typically ContentBlock or
+    # JsonConfigBlock subclasses), attached at the root. The ``seen`` set
+    # guards against double-linting files already discovered above, and
+    # failures are collected for the Linter to surface as violations —
+    # a broken contributor must not abort tree construction.
+    for plugin_name, contribute in context.plugin_tree_contributors:
+        try:
+            contributed = contribute(context, root)
+            blocks = list(contributed) if contributed is not None else []
+            for block in blocks:
+                if not isinstance(block, LintTarget):
+                    raise TypeError(
+                        f"contributor returned {block!r}, which is not a lint tree node"
+                    )
+        except Exception as e:
+            context.plugin_extension_errors.append(
+                f"Plugin '{plugin_name}': tree contributor failed: " f"{e.__class__.__name__}: {e}"
+            )
+            continue
+        for block in blocks:
+            resolved = block.path.resolve()
+            if resolved in seen or not block.path.exists() or _is_excluded(block.path):
+                continue
+            seen.add(resolved)
+            root.children.append(block)
+
     root.set_parents()
     nodes = list(root.walk())
     logger.info("Built lint tree: %d nodes", len(nodes))

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -269,7 +269,9 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         root.children.append(apm_node)
 
     # --- Extra content paths from config ---
-    for glob_pattern in context.content_paths:
+    # User-configured content paths plus globs contributed by detected
+    # plugin repo types; the ``seen`` set dedupes any overlap.
+    for glob_pattern in [*context.content_paths, *context.plugin_content_paths]:
         for extra in sorted(context.root_path.glob(glob_pattern)):
             if extra.is_file():
                 _add_block(root, extra, ExtraBlock)
@@ -284,22 +286,24 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         try:
             contributed = contribute(context, root)
             blocks = list(contributed) if contributed is not None else []
+            # Attachment stays inside the try: a node with a broken path
+            # (None, or resolve() raising an OSError) must be reported like
+            # any other contributor failure, not crash tree construction.
             for block in blocks:
                 if not isinstance(block, LintTarget):
                     raise TypeError(
                         f"contributor returned {block!r}, which is not a lint tree node"
                     )
+                resolved = block.path.resolve()
+                if resolved in seen or not block.path.exists() or _is_excluded(block.path):
+                    continue
+                seen.add(resolved)
+                root.children.append(block)
         except Exception as e:
             context.plugin_extension_errors.append(
                 f"Plugin '{plugin_name}': tree contributor failed: " f"{e.__class__.__name__}: {e}"
             )
             continue
-        for block in blocks:
-            resolved = block.path.resolve()
-            if resolved in seen or not block.path.exists() or _is_excluded(block.path):
-                continue
-            seen.add(resolved)
-            root.children.append(block)
 
     root.set_parents()
     nodes = list(root.walk())

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -130,7 +130,14 @@ class Linter:
         """
         from .plugins import load_plugins
 
-        for plugin in load_plugins(disabled=set(self.config.disabled_plugins)):
+        plugins = load_plugins(disabled=set(self.config.disabled_plugins))
+
+        # Extensions (repo types, tree contributors) must register before any
+        # rule's enablement is evaluated: a plugin rule scoped to its own
+        # plugin's repo type needs the detector to have run already.
+        self._register_plugin_extensions(plugins)
+
+        for plugin in plugins:
             if plugin.error:
                 self._plugin_load_violations.append(
                     RuleViolation(
@@ -223,6 +230,44 @@ class Linter:
                     logger.info("Rule %-30s enabled (plugin: %s)", rid, plugin.name)
                 else:
                     logger.info("Rule %-30s skipped (plugin: %s)", rid, plugin.name)
+
+    def _register_plugin_extensions(self, plugins) -> None:
+        """Register plugin-declared repo types and lint tree contributors.
+
+        Delegates to :func:`skillsaw.plugins.register_extensions` (shared
+        with the ``tree`` and ``explain`` commands) and maps the problems it
+        reports to ``plugin-load-error`` violations: crashed detectors are
+        errors, skipped duplicate/builtin-colliding declarations warnings.
+        """
+        from .plugins import register_extensions
+
+        for problem in register_extensions(self.context, plugins):
+            self._plugin_load_violations.append(
+                RuleViolation(
+                    rule_id="plugin-load-error",
+                    severity=Severity.ERROR if problem.severity == "error" else Severity.WARNING,
+                    message=problem.message,
+                )
+            )
+
+    def _plugin_extension_error_violations(self) -> List[RuleViolation]:
+        """Violations for tree-contributor failures collected during tree build.
+
+        Contributors run inside ``build_lint_tree`` (lazily, on first tree
+        access), so their errors surface after the rule loop rather than at
+        load time. Consumes the collected errors so repeated runs on the same
+        Linter don't duplicate them.
+        """
+        errors = self.context.plugin_extension_errors
+        self.context.plugin_extension_errors = []
+        return [
+            RuleViolation(
+                rule_id="plugin-load-error",
+                severity=Severity.ERROR,
+                message=message,
+            )
+            for message in errors
+        ]
 
     def _load_custom_rule(self, rule_path: str):
         """
@@ -481,6 +526,10 @@ class Linter:
                 print(f"Error running rule {rule.rule_id}: {e}", file=sys.stderr)
                 violations.append(self._crash_violation(rule, e))
 
+        # Tree contributors run lazily inside build_lint_tree (triggered by
+        # the rule checks above), so their failures are only known now.
+        violations.extend(self._plugin_extension_error_violations())
+
         return self._filter_violations(violations)
 
     @staticmethod
@@ -539,6 +588,8 @@ class Linter:
                     all_violations.extend(visible)
             else:
                 all_violations.extend(visible)
+
+        all_violations.extend(self._plugin_extension_error_violations())
 
         # Baseline stale/suppressed accounting must consider all rules'
         # violations together, exactly as run() does — the per-rule calls

--- a/src/skillsaw/plugins.py
+++ b/src/skillsaw/plugins.py
@@ -298,15 +298,22 @@ def register_extensions(context, plugins: List[PluginInfo]) -> List[ExtensionPro
     """Register plugin repo types and tree contributors on a context.
 
     Runs each declared repo type's detector (fault-isolated), records
-    detected type names in ``context.plugin_repo_types``, merges detected
-    types' ``content_paths`` into ``context.content_paths``, and hands tree
-    contributors to the context for ``build_lint_tree``. Idempotent per
-    context is not required — call once per fresh context.
+    detected type names in ``context.plugin_repo_types``, collects detected
+    types' ``content_paths`` into ``context.plugin_content_paths``, and hands
+    tree contributors to the context for ``build_lint_tree``.
+
+    Idempotent per context: repeated calls (e.g. two Linters sharing one
+    context) are no-ops, so contributors never accumulate duplicates and
+    problems are reported once.
 
     Returns problems (name collisions, crashed detectors) for the caller to
     surface; the linter maps them to violations, the CLI prints them.
     """
     from .context import RepositoryType
+
+    if getattr(context, "_plugin_extensions_registered", False):
+        return []
+    context._plugin_extensions_registered = True
 
     problems: List[ExtensionProblem] = []
     builtin_type_values = {t.value for t in RepositoryType}
@@ -361,9 +368,12 @@ def register_extensions(context, plugins: List[PluginInfo]) -> List[ExtensionPro
         )
 
     if contributed_paths:
-        merged = list(context.content_paths)
-        merged.extend(p for p in contributed_paths if p not in merged)
-        context.content_paths = merged
+        # Separate from context.content_paths (user config): the Linter
+        # resets that attribute on construction, and plugin contributions
+        # must survive a shared context being reused.
+        context.plugin_content_paths.extend(
+            p for p in contributed_paths if p not in context.plugin_content_paths
+        )
     if contributed_paths or context.plugin_tree_contributors:
         # The tree is built lazily on first access, so nothing is wasted;
         # dropping any cached tree guarantees the contributions apply.

--- a/src/skillsaw/plugins.py
+++ b/src/skillsaw/plugins.py
@@ -25,12 +25,15 @@ it as a ``plugin-load-error`` violation instead.
 from __future__ import annotations
 
 import functools
+import importlib
 import inspect
 import logging
+import re
 import types
 from dataclasses import dataclass, field
 from importlib import metadata
-from typing import Iterable, List, Optional, Set, Type
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Set, Type
 
 from .rule import Rule
 
@@ -41,10 +44,58 @@ ENTRY_POINT_GROUP = "skillsaw.plugins"
 # Module attribute a plugin can set to declare its rules explicitly.
 RULES_ATTRIBUTE = "SKILLSAW_RULES"
 
+# Module attribute declaring custom repository types (list of PluginRepoType).
+REPO_TYPES_ATTRIBUTE = "SKILLSAW_REPO_TYPES"
+
+# Module attribute declaring lint tree contributors: callables invoked as
+# ``contribute(context, root)`` during tree construction, returning an
+# iterable of block/node instances to attach at the root (or None).
+TREE_CONTRIBUTORS_ATTRIBUTE = "SKILLSAW_TREE_CONTRIBUTORS"
+
+_REPO_TYPE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+@dataclass
+class PluginRepoType:
+    """A repository type contributed by a plugin.
+
+    When ``detect`` returns True for the linted repository, the type's
+    ``name`` behaves like a builtin repository type: rules (plugin, custom,
+    or builtin) can list it in ``repo_types`` to scope ``enabled: auto``
+    activation, and it appears in the lint report's detected types.
+    """
+
+    name: str
+    """Kebab-case type name (e.g. ``acme``). Must not collide with builtin
+    repository type values or other plugins' types."""
+
+    detect: Callable[[Path], bool]
+    """Called with the repository root path; True when the repo is this type."""
+
+    description: str = ""
+
+    content_paths: List[str] = field(default_factory=list)
+    """Glob patterns (relative to the repo root) pulled into content linting
+    when the type is detected — the plugin-declared equivalent of the
+    ``content-paths`` config key. Matched markdown/text files become content
+    blocks and get every ``content-*`` rule automatically."""
+
+    def validate(self) -> None:
+        if not isinstance(self.name, str) or not _REPO_TYPE_NAME_RE.match(self.name):
+            raise TypeError(f"PluginRepoType name must be a kebab-case string, got {self.name!r}")
+        if not callable(self.detect):
+            raise TypeError(f"PluginRepoType '{self.name}': detect must be callable")
+        if not isinstance(self.content_paths, (list, tuple)) or not all(
+            isinstance(p, str) for p in self.content_paths
+        ):
+            raise TypeError(
+                f"PluginRepoType '{self.name}': content_paths must be a list of glob strings"
+            )
+
 
 @dataclass
 class PluginInfo:
-    """A discovered plugin and the rule classes it provides."""
+    """A discovered plugin and the rules/extensions it provides."""
 
     name: str
     """Entry point name (the plugin's short name, e.g. ``acme-rules``)."""
@@ -60,8 +111,14 @@ class PluginInfo:
 
     rule_classes: List[Type[Rule]] = field(default_factory=list)
 
+    repo_types: List[PluginRepoType] = field(default_factory=list)
+    """Custom repository types declared via ``SKILLSAW_REPO_TYPES``."""
+
+    tree_contributors: List[Callable] = field(default_factory=list)
+    """Lint tree contributors declared via ``SKILLSAW_TREE_CONTRIBUTORS``."""
+
     error: Optional[str] = None
-    """Load failure message; when set, ``rule_classes`` is empty."""
+    """Load failure message; when set, the other collections are empty."""
 
 
 def _iter_entry_points():
@@ -176,6 +233,40 @@ def _dist_by_entry_point():
     return mapping
 
 
+def _module_attr(module_name: str, attribute: str):
+    """Read a declaration attribute from a plugin's module, tolerating
+    raising PEP 562 ``__getattr__`` implementations."""
+    module = importlib.import_module(module_name)
+    try:
+        return getattr(module, attribute, None)
+    except Exception:
+        return None
+
+
+def _resolve_repo_types(module_name: str) -> List[PluginRepoType]:
+    declared = _module_attr(module_name, REPO_TYPES_ATTRIBUTE)
+    if declared is None:
+        return []
+    if not isinstance(declared, (list, tuple)):
+        raise TypeError(f"{REPO_TYPES_ATTRIBUTE} must be a list of PluginRepoType")
+    repo_types = []
+    for item in declared:
+        if not isinstance(item, PluginRepoType):
+            raise TypeError(f"{REPO_TYPES_ATTRIBUTE} entries must be PluginRepoType, got {item!r}")
+        item.validate()
+        repo_types.append(item)
+    return repo_types
+
+
+def _resolve_tree_contributors(module_name: str) -> List[Callable]:
+    declared = _module_attr(module_name, TREE_CONTRIBUTORS_ATTRIBUTE)
+    if declared is None:
+        return []
+    if not isinstance(declared, (list, tuple)) or not all(callable(c) for c in declared):
+        raise TypeError(f"{TREE_CONTRIBUTORS_ATTRIBUTE} must be a list of callables")
+    return list(declared)
+
+
 def _entry_point_dist(ep) -> tuple:
     """(distribution name, version) for an entry point, best effort.
 
@@ -193,6 +284,91 @@ def _entry_point_dist(ep) -> tuple:
         return name, dist.version
     except Exception:  # pragma: no cover - metadata access can fail oddly
         return None, None
+
+
+@dataclass
+class ExtensionProblem:
+    """A non-fatal problem found while registering plugin extensions."""
+
+    severity: str  # "error" or "warning"
+    message: str
+
+
+def register_extensions(context, plugins: List[PluginInfo]) -> List[ExtensionProblem]:
+    """Register plugin repo types and tree contributors on a context.
+
+    Runs each declared repo type's detector (fault-isolated), records
+    detected type names in ``context.plugin_repo_types``, merges detected
+    types' ``content_paths`` into ``context.content_paths``, and hands tree
+    contributors to the context for ``build_lint_tree``. Idempotent per
+    context is not required — call once per fresh context.
+
+    Returns problems (name collisions, crashed detectors) for the caller to
+    surface; the linter maps them to violations, the CLI prints them.
+    """
+    from .context import RepositoryType
+
+    problems: List[ExtensionProblem] = []
+    builtin_type_values = {t.value for t in RepositoryType}
+    registered_types: dict = {}  # type name -> plugin name
+    contributed_paths: List[str] = []
+
+    for plugin in plugins:
+        if plugin.error:
+            continue
+        for repo_type in plugin.repo_types:
+            if repo_type.name in builtin_type_values:
+                problems.append(
+                    ExtensionProblem(
+                        "warning",
+                        f"Plugin '{plugin.name}' declares repo type "
+                        f"'{repo_type.name}', which is a builtin repository "
+                        "type — the declaration was skipped.",
+                    )
+                )
+                continue
+            if repo_type.name in registered_types:
+                problems.append(
+                    ExtensionProblem(
+                        "warning",
+                        f"Plugin '{plugin.name}' declares repo type "
+                        f"'{repo_type.name}', already provided by plugin "
+                        f"'{registered_types[repo_type.name]}' — the "
+                        "declaration was skipped.",
+                    )
+                )
+                continue
+            registered_types[repo_type.name] = plugin.name
+
+            try:
+                detected = bool(repo_type.detect(context.root_path))
+            except Exception as e:
+                problems.append(
+                    ExtensionProblem(
+                        "error",
+                        f"Plugin '{plugin.name}': repo type '{repo_type.name}' "
+                        f"detector crashed: {e.__class__.__name__}: {e}",
+                    )
+                )
+                continue
+            if detected:
+                context.plugin_repo_types.add(repo_type.name)
+                contributed_paths.extend(repo_type.content_paths)
+                logger.info("Repo type %-24s detected (plugin: %s)", repo_type.name, plugin.name)
+
+        context.plugin_tree_contributors.extend(
+            (plugin.name, contributor) for contributor in plugin.tree_contributors
+        )
+
+    if contributed_paths:
+        merged = list(context.content_paths)
+        merged.extend(p for p in contributed_paths if p not in merged)
+        context.content_paths = merged
+    if contributed_paths or context.plugin_tree_contributors:
+        # The tree is built lazily on first access, so nothing is wasted;
+        # dropping any cached tree guarantees the contributions apply.
+        context.rebuild_lint_tree()
+    return problems
 
 
 def load_plugins(disabled: Optional[Set[str]] = None) -> List[PluginInfo]:
@@ -223,10 +399,25 @@ def load_plugins(disabled: Optional[Set[str]] = None) -> List[PluginInfo]:
         try:
             obj = ep.load()
             info.rule_classes = _resolve_rule_classes(obj, ep.value)
+            # Extension declarations live as sibling attributes on the entry
+            # point's module (already imported by ep.load()), so they work
+            # for every entry point form, not just the module form.
+            module_name = ep.value.split(":", 1)[0]
+            info.repo_types = _resolve_repo_types(module_name)
+            info.tree_contributors = _resolve_tree_contributors(module_name)
         except Exception as e:
             info.error = f"{e.__class__.__name__}: {e}"
+            info.rule_classes = []
+            info.repo_types = []
+            info.tree_contributors = []
             logger.warning("Plugin %-30s failed to load: %s", ep.name, info.error)
         else:
-            logger.info("Plugin %-30s loaded (%d rule(s))", ep.name, len(info.rule_classes))
+            logger.info(
+                "Plugin %-30s loaded (%d rule(s), %d repo type(s), %d tree contributor(s))",
+                ep.name,
+                len(info.rule_classes),
+                len(info.repo_types),
+                len(info.tree_contributors),
+            )
         plugins.append(info)
     return plugins

--- a/tests/fixtures/plugin-dist/skillsaw_no_wip/__init__.py
+++ b/tests/fixtures/plugin-dist/skillsaw_no_wip/__init__.py
@@ -6,6 +6,7 @@ the sibling ``.dist-info`` directory registers this module under the
 ``PYTHONPATH`` makes it discoverable just like a pip-installed package.
 """
 
+from dataclasses import dataclass
 from typing import List
 
 from skillsaw import (
@@ -16,7 +17,8 @@ from skillsaw import (
     RuleViolation,
     Severity,
 )
-from skillsaw.blocks import InstructionBlock
+from skillsaw.blocks import InstructionBlock, JsonConfigBlock
+from skillsaw.plugins import PluginRepoType
 
 
 class NoWipMarkersRule(Rule):
@@ -89,4 +91,60 @@ class NoWipMarkersRule(Rule):
         return results
 
 
-SKILLSAW_RULES = [NoWipMarkersRule]
+@dataclass(eq=False)
+class AcmeConfigBlock(JsonConfigBlock):
+    """.acme/config.json — machine config, never linted as prose."""
+
+    category: str = "acme-config"
+
+
+class AcmeConfigVersionRule(Rule):
+    """ACME config files must declare a version."""
+
+    repo_types = {"acme"}  # plugin-contributed repo type (string entry)
+
+    @property
+    def rule_id(self) -> str:
+        return "acme-config-version"
+
+    @property
+    def description(self) -> str:
+        return "ACME config must declare a version field"
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        for block in context.lint_tree.find(AcmeConfigBlock):
+            if block.parse_error:
+                violations.append(
+                    self.violation(f"Invalid JSON: {block.parse_error}", file_path=block.path)
+                )
+            elif not isinstance(block.raw_data, dict) or "version" not in block.raw_data:
+                violations.append(
+                    self.violation("Missing required 'version' field", file_path=block.path)
+                )
+        return violations
+
+
+def contribute_acme_config(context, root):
+    """Attach .acme/config.json to the lint tree as a config block."""
+    config_path = context.root_path / ".acme" / "config.json"
+    if config_path.exists():
+        return [AcmeConfigBlock(path=config_path)]
+    return []
+
+
+SKILLSAW_RULES = [NoWipMarkersRule, AcmeConfigVersionRule]
+
+SKILLSAW_REPO_TYPES = [
+    PluginRepoType(
+        name="acme",
+        description="Repository configured for the ACME assistant",
+        detect=lambda root: (root / "ACME.md").exists() or (root / ".acme").is_dir(),
+        content_paths=["ACME.md", ".acme/rules/*.md"],
+    ),
+]
+
+SKILLSAW_TREE_CONTRIBUTORS = [contribute_acme_config]

--- a/tests/fixtures/plugin-target-acme/.acme/config.json
+++ b/tests/fixtures/plugin-target-acme/.acme/config.json
@@ -1,0 +1,4 @@
+{
+  "model": "acme-large",
+  "temperature": 0.2
+}

--- a/tests/fixtures/plugin-target-acme/.acme/rules/style.md
+++ b/tests/fixtures/plugin-target-acme/.acme/rules/style.md
@@ -1,0 +1,4 @@
+# Style rules
+
+- Write error messages in lowercase without trailing punctuation.
+- Wrap SQL identifiers in double quotes; never interpolate values.

--- a/tests/fixtures/plugin-target-acme/ACME.md
+++ b/tests/fixtures/plugin-target-acme/ACME.md
@@ -1,0 +1,9 @@
+# ACME Assistant Instructions
+
+Instructions for the ACME coding assistant working in this repository.
+
+## Deployments
+
+- Deploy with `make deploy ENV=staging`; production requires an approval in
+  the release channel first.
+- You might want to consider adding retries when the deploy API times out.

--- a/tests/fixtures/plugin-target-acme/CLAUDE.md
+++ b/tests/fixtures/plugin-target-acme/CLAUDE.md
@@ -1,0 +1,14 @@
+# Project Standards
+
+This repository contains the inventory service. Follow these instructions
+when making changes.
+
+## Build and test
+
+- Build with `make build`; run unit tests with `make test`.
+- Run `make integration` before opening a pull request.
+
+## Code conventions
+
+- Handlers live in `internal/api/`; one file per resource.
+- Database access goes through the repository layer in `internal/store/`.

--- a/tests/test_integration_plugins.py
+++ b/tests/test_integration_plugins.py
@@ -246,3 +246,72 @@ def test_plugins_subcommand_shows_command(tmp_path):
     r = run_cli("plugins", path_prepend=bin_dir)
     assert r["rc"] == 0
     assert "command: skillsaw no-wip" in r["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# Extension points: plugin repo types and tree contributors
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_repo_type_detected_and_reported(tmp_path):
+    repo = copy_fixture("plugin-target-acme", tmp_path)
+    r = run_cli("lint", str(repo), fmt="json")
+    assert "acme" in r["out"]["stats"]["repo_types"], r["stdout"] + r["stderr"]
+
+
+def test_scoped_plugin_rule_fires_on_contributed_block(tmp_path):
+    """Detector -> repo type -> scoped rule -> contributor block, end to end."""
+    repo = copy_fixture("plugin-target-acme", tmp_path)
+    r = run_cli("lint", str(repo), fmt="json")
+    fired = plugin_violations(r, rule_id="acme-config-version")
+    assert len(fired) == 1, r["stdout"] + r["stderr"]
+    v = fired[0]
+    assert v["severity"] == "error"
+    assert v["source"] == "plugin:no-wip"
+    assert v["file_path"].endswith("config.json")
+    assert r["rc"] == 1
+
+
+def test_scoped_plugin_rule_inactive_without_repo_type(tmp_path):
+    repo = copy_fixture("plugin-target", tmp_path)  # no ACME markers
+    r = run_cli("lint", str(repo), fmt="json")
+    assert plugin_violations(r, rule_id="acme-config-version") == []
+    assert "acme" not in r["out"]["stats"]["repo_types"]
+
+
+def test_content_rules_cover_plugin_content_paths(tmp_path):
+    """Files matched by a repo type's content_paths get content-* rules."""
+    repo = copy_fixture("plugin-target-acme", tmp_path)
+    r = run_cli("lint", str(repo), fmt="json")
+    weak = [
+        v
+        for v in r["out"]["violations"]
+        if v["rule_id"] == "content-weak-language" and v["file_path"].endswith("ACME.md")
+    ]
+    assert weak, r["stdout"] + r["stderr"]
+
+
+def test_tree_shows_plugin_contributed_nodes(tmp_path):
+    repo = copy_fixture("plugin-target-acme", tmp_path)
+    r = run_cli("tree", str(repo))
+    assert r["rc"] == 0, r["stdout"] + r["stderr"]
+    assert "ACME.md" in r["stdout"]
+    assert "config.json" in r["stdout"]
+
+
+def test_plugins_subcommand_lists_extensions():
+    r = run_cli("plugins")
+    assert r["rc"] == 0, r["stdout"] + r["stderr"]
+    assert "acme — Repository configured for the ACME assistant" in r["stdout"]
+    assert "tree contributors: contribute_acme_config" in r["stdout"]
+
+
+def test_explain_shows_plugin_repo_type_scope(tmp_path):
+    import re
+
+    repo = copy_fixture("plugin-target-acme", tmp_path)
+    r = run_cli("explain", "acme-config-version", str(repo))
+    assert r["rc"] == 0, r["stdout"] + r["stderr"]
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", r["stdout"])
+    assert "Applies to repo types: acme" in plain
+    assert "detected repo type: acme" in plain

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -671,3 +671,42 @@ def test_invalid_tree_contributors_declaration_fails_plugin(fake_plugin):
     (plugin,) = load_plugins()
     assert plugin.error is not None
     assert "SKILLSAW_TREE_CONTRIBUTORS" in plugin.error
+
+
+def test_tree_contributor_with_broken_path_surfaces_violation(fake_plugin, acme_repo):
+    """A contributed node whose path is unusable is a reported failure, not a crash."""
+
+    def contribute(context, root):
+        return [FileContentBlock(path=None, category="broken")]
+
+    fake_plugin(
+        "fake_contrib_nopath",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, violations = _lint(acme_repo)
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert errors and "tree contributor failed" in errors[0].message
+
+
+def test_register_extensions_is_idempotent(fake_plugin, acme_repo):
+    """Two Linters sharing one context must not duplicate registrations."""
+
+    def contribute(context, root):
+        return []
+
+    fake_plugin(
+        "fake_reg_twice",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type()],
+            "SKILLSAW_TREE_CONTRIBUTORS": [contribute],
+        },
+    )
+    context = RepositoryContext(acme_repo)
+    Linter(context, LinterConfig.default())
+    Linter(context, LinterConfig.default())
+    assert len(context.plugin_tree_contributors) == 1
+    assert context.plugin_content_paths == ["ACME.md"]
+    # Plugin content paths survive the second Linter's config reset.
+    tree_paths = {node.path.name for node in context.lint_tree.walk()}
+    assert "ACME.md" in tree_paths

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -710,3 +710,30 @@ def test_register_extensions_is_idempotent(fake_plugin, acme_repo):
     # Plugin content paths survive the second Linter's config reset.
     tree_paths = {node.path.name for node in context.lint_tree.walk()}
     assert "ACME.md" in tree_paths
+
+
+def test_tree_contributor_subtree_is_validated_recursively(fake_plugin, acme_repo):
+    """Children of a contributed node get the same dedupe/exclude guards."""
+    (acme_repo / "notes.txt").write_text("Deployment notes.\n", encoding="utf-8")
+    (acme_repo / "child.txt").write_text("Child notes.\n", encoding="utf-8")
+
+    def contribute(context, root):
+        parent = FileContentBlock(path=context.root_path / "notes.txt", category="notes")
+        parent.children.append(
+            # Duplicate of a node already in the tree: must be pruned.
+            FileContentBlock(path=context.root_path / "CLAUDE.md", category="dup")
+        )
+        parent.children.append(
+            FileContentBlock(path=context.root_path / "child.txt", category="child")
+        )
+        return [parent]
+
+    fake_plugin(
+        "fake_contrib_subtree",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, violations = _lint(acme_repo)
+    names = [node.path.name for node in linter.context.lint_tree.walk()]
+    assert names.count("CLAUDE.md") == 1
+    assert "notes.txt" in names and "child.txt" in names
+    assert "plugin-load-error" not in {v.rule_id for v in violations}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -439,3 +439,235 @@ def test_config_plugins_unknown_subkey_warns(tmp_path):
     cfg.write_text('version: "1.0"\nplugins:\n  bogus: true\n', encoding="utf-8")
     config = LinterConfig.from_file(cfg)
     assert any("plugins" in w and "bogus" in w for w in config.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Extension points: repo types and tree contributors
+# ---------------------------------------------------------------------------
+
+from skillsaw.blocks import FileContentBlock  # noqa: E402
+from skillsaw.plugins import PluginRepoType  # noqa: E402
+
+
+def acme_repo_type(**overrides):
+    kwargs = dict(
+        name="acme",
+        description="ACME assistant repository",
+        detect=lambda root: (root / "ACME.md").exists(),
+        content_paths=["ACME.md"],
+    )
+    kwargs.update(overrides)
+    return PluginRepoType(**kwargs)
+
+
+@pytest.fixture
+def acme_repo(tmp_path):
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Project\n\nRun `make test` before pushing changes.\n", encoding="utf-8"
+    )
+    (tmp_path / "ACME.md").write_text(
+        "# ACME instructions\n\nRun `make build` before deploying.\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_repo_type_declared_and_detected(fake_plugin, acme_repo):
+    fake_plugin(
+        "fake_rt",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_REPO_TYPES": [acme_repo_type()]},
+    )
+    linter, violations = _lint(acme_repo)
+    assert "acme" in linter.context.plugin_repo_types
+    assert "acme" in linter.context.repo_type_names()
+    assert "plugin-load-error" not in {v.rule_id for v in violations}
+
+
+def test_repo_type_not_detected_without_marker(fake_plugin, repo):
+    fake_plugin(
+        "fake_rt_nomark",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_REPO_TYPES": [acme_repo_type()]},
+    )
+    linter, _ = _lint(repo)
+    assert "acme" not in linter.context.plugin_repo_types
+
+
+def test_repo_type_content_paths_pull_files_into_tree(fake_plugin, acme_repo):
+    fake_plugin(
+        "fake_rt_content",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_REPO_TYPES": [acme_repo_type()]},
+    )
+    linter, _ = _lint(acme_repo)
+    tree_paths = {node.path.name for node in linter.context.lint_tree.walk()}
+    assert "ACME.md" in tree_paths
+
+
+def test_rule_scoped_to_plugin_repo_type(fake_plugin, acme_repo, tmp_path_factory):
+    class AcmeOnlyRule(AlwaysFiresRule):
+        repo_types = {"acme"}
+
+        @property
+        def rule_id(self) -> str:
+            return "plugin-acme-only"
+
+    fake_plugin(
+        "fake_rt_scoped",
+        module_attrs={
+            "SKILLSAW_RULES": [AcmeOnlyRule],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type()],
+        },
+    )
+    linter, _ = _lint(acme_repo)
+    assert "plugin-acme-only" in {r.rule_id for r in linter.rules}
+
+    plain = tmp_path_factory.mktemp("plain-repo")  # no ACME.md marker
+    (plain / "CLAUDE.md").write_text(
+        "# Project\n\nRun `make test` before pushing changes.\n", encoding="utf-8"
+    )
+    linter, _ = _lint(plain)
+    assert "plugin-acme-only" not in {r.rule_id for r in linter.rules}
+
+
+def test_repo_type_colliding_with_builtin_is_skipped(fake_plugin, acme_repo):
+    fake_plugin(
+        "fake_rt_builtin",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type(name="apm", detect=lambda root: True)],
+        },
+    )
+    linter, violations = _lint(acme_repo)
+    assert "apm" not in linter.context.plugin_repo_types
+    warnings = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert warnings and "builtin repository type" in warnings[0].message
+
+
+def test_repo_type_duplicate_across_plugins_first_wins(fake_plugin, monkeypatch, acme_repo):
+    import types as types_mod
+    from importlib.metadata import EntryPoint
+
+    mod_b = types_mod.ModuleType("fake_rt_dup_b")
+    mod_b.SKILLSAW_RULES = []
+    mod_b.SKILLSAW_REPO_TYPES = [acme_repo_type(description="duplicate")]
+    monkeypatch.setitem(sys.modules, "fake_rt_dup_b", mod_b)
+    extra = EntryPoint("secondplug", "fake_rt_dup_b", plugins_mod.ENTRY_POINT_GROUP)
+
+    fake_plugin(
+        "fake_rt_dup_a",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_REPO_TYPES": [acme_repo_type()]},
+        extra_eps=[extra],
+    )
+    linter, violations = _lint(acme_repo)
+    assert "acme" in linter.context.plugin_repo_types
+    warnings = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert warnings and "already provided by plugin 'testplug'" in warnings[0].message
+
+
+def test_detector_crash_is_isolated(fake_plugin, acme_repo):
+    def boom(root):
+        raise RuntimeError("boom")
+
+    fake_plugin(
+        "fake_rt_crash",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type(detect=boom)],
+        },
+    )
+    linter, violations = _lint(acme_repo)
+    assert "acme" not in linter.context.plugin_repo_types
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert errors and "detector crashed" in errors[0].message
+    # Builtin rules still ran.
+    assert any(getattr(r, "_source", "") == "builtin" for r in linter.rules)
+
+
+def test_invalid_repo_type_declaration_fails_plugin(fake_plugin, acme_repo):
+    fake_plugin(
+        "fake_rt_invalid",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_REPO_TYPES": "nope"},
+    )
+    (plugin,) = load_plugins()
+    assert plugin.error is not None
+    assert "SKILLSAW_REPO_TYPES" in plugin.error
+
+
+def test_invalid_repo_type_name_fails_plugin(fake_plugin):
+    fake_plugin(
+        "fake_rt_badname",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type(name="Not Kebab")],
+        },
+    )
+    (plugin,) = load_plugins()
+    assert plugin.error is not None
+    assert "kebab-case" in plugin.error
+
+
+def test_tree_contributor_adds_block(fake_plugin, acme_repo):
+    (acme_repo / "notes.txt").write_text("Deployment notes for the agent.\n", encoding="utf-8")
+
+    def contribute(context, root):
+        return [FileContentBlock(path=context.root_path / "notes.txt", category="acme-notes")]
+
+    fake_plugin(
+        "fake_contrib",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, violations = _lint(acme_repo)
+    tree_paths = {node.path.name for node in linter.context.lint_tree.walk()}
+    assert "notes.txt" in tree_paths
+    assert "plugin-load-error" not in {v.rule_id for v in violations}
+
+
+def test_tree_contributor_cannot_duplicate_existing_nodes(fake_plugin, acme_repo):
+    def contribute(context, root):
+        # CLAUDE.md is already in the tree; the seen-set must reject this.
+        return [FileContentBlock(path=context.root_path / "CLAUDE.md", category="dup")]
+
+    fake_plugin(
+        "fake_contrib_dup",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, _ = _lint(acme_repo)
+    claude_nodes = [n for n in linter.context.lint_tree.walk() if n.path.name == "CLAUDE.md"]
+    assert len(claude_nodes) == 1
+
+
+def test_tree_contributor_crash_surfaces_violation(fake_plugin, acme_repo):
+    def contribute(context, root):
+        raise RuntimeError("kaboom")
+
+    fake_plugin(
+        "fake_contrib_crash",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, violations = _lint(acme_repo)
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert errors and "tree contributor failed" in errors[0].message
+    # The error is consumed: a second run must not duplicate it.
+    second = [v for v in linter.run() if v.rule_id == "plugin-load-error"]
+    assert second == []
+
+
+def test_tree_contributor_returning_non_node_surfaces_violation(fake_plugin, acme_repo):
+    def contribute(context, root):
+        return [42]
+
+    fake_plugin(
+        "fake_contrib_garbage",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [contribute]},
+    )
+    linter, violations = _lint(acme_repo)
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert errors and "not a lint tree node" in errors[0].message
+
+
+def test_invalid_tree_contributors_declaration_fails_plugin(fake_plugin):
+    fake_plugin(
+        "fake_contrib_invalid",
+        module_attrs={"SKILLSAW_RULES": [], "SKILLSAW_TREE_CONTRIBUTORS": [42]},
+    )
+    (plugin,) = load_plugins()
+    assert plugin.error is not None
+    assert "SKILLSAW_TREE_CONTRIBUTORS" in plugin.error


### PR DESCRIPTION
## Summary

Follow-up to #312: plugins can now extend skillsaw beyond rules. Two new declarations live as sibling module attributes next to `SKILLSAW_RULES` (the forward-compatible convention #312 established — old skillsaw versions ignore attributes they don't know):

- **`SKILLSAW_REPO_TYPES`** — `PluginRepoType(name, detect, description, content_paths)` declares a custom repository type (e.g. a new assistant's config layout). When `detect(root)` matches:
  - the type name shows up in detected repo types across all report formats (new `context.repo_type_names()` helper covers text/json/html/sarif and the multi-path merged context),
  - rules — plugin, custom, or builtin — scope to it by listing the name as a **string** in `repo_types`, mixing freely with `RepositoryType` members (`enabled: auto` matching handles mixed sets),
  - the type's `content_paths` globs are pulled into content linting, the plugin-declared equivalent of the `content-paths` config key: matched files get every `content-*` rule automatically.
- **`SKILLSAW_TREE_CONTRIBUTORS`** — callables `contribute(context, root) -> nodes` run during `build_lint_tree`, attaching plugin-defined blocks that rules discover with `lint_tree.find()`. The prose-vs-config hierarchy is preserved: contributors subclass `ContentBlock` for prose and `JsonConfigBlock` for machine config. skillsaw dedupes contributed nodes against files already in the tree and applies the user's `exclude` patterns to them.

## Integration points

- **Shared registration** (`skillsaw.plugins.register_extensions`) is used by the Linter and by `skillsaw tree` / `skillsaw explain`, so the displayed tree matches a lint run and explain computes the same effective enablement (including plugin repo type scoping and `default_enabled`).
- **`skillsaw plugins`** lists each plugin's repo types (with descriptions) and tree contributors.
- **Fault isolation everywhere**, in the style #312 established: crashed detectors, crashed contributors, contributors returning non-nodes, kebab-case violations, and name collisions (with builtin type values, first-plugin-wins across plugins) all become `plugin-load-error` violations while the lint continues. Contributor errors are collected at tree-build time (the tree is lazy) and surfaced after the rule loop.

## Docs & skill

- `docs/plugins.md`: two new authoring sections with copy-paste examples and the contract/guarantees.
- `skills/skillsaw-create-plugin` now uses **progressive disclosure**: SKILL.md carries the workflow and links `references/rule-authoring.md` and `references/extensions.md` for full templates — bringing it back under the skill context budget (self-lint is at grade A, zero warnings).
- README: extension points paragraph.

## Testing

- 13 new unit tests: declaration resolution/validation, detection, string `repo_types` scoping, collisions (builtin + cross-plugin), detector/contributor crash isolation, contributed-block discovery, dedupe against existing nodes, error consumption across runs.
- 7 new integration tests against the fixture plugin's end-to-end "acme" demo: repo type in JSON report, detector → scoped rule → contributed config block chain, content-path coverage by `content-weak-language`, `skillsaw tree` showing contributed nodes, `skillsaw plugins`/`explain` output.
- Full suite: 2112 passed; `make lint`/`make update` clean; `openshift-eng/ai-helpers` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for plugin-defined repository types and lint-tree contributions, expanding what plugins can recognize and lint.
  * Enhanced plugin-aware CLI outputs (including `plugins`, `tree`, `explain`) to reflect detected repo types and contributed tree nodes.
* **Bug Fixes**
  * Improved repository type scoping and reporting consistency across output formats.
  * Improved resilience: plugin extension issues are isolated so linting/tree generation can continue.
* **Documentation**
  * Updated and expanded plugin and rule-authoring guides with new extension-point references and clearer guidance.
* **Tests**
  * Added end-to-end integration and plugin extension coverage for repo types, content paths, and tree contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->