### PR TITLE
[Auto] Pin mkdocs-redirects <1.2.3 to exclude properdocs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
     "mkdocs-material>=9.0",
-    "mkdocs-redirects>=1.2",
+    "mkdocs-redirects>=1.2,<1.2.3",
 ]
 dev = [
     "pytest>=7.0",


### PR DESCRIPTION
## Summary

- Pins `mkdocs-redirects` to `>=1.2,<1.2.3` in the `docs` optional dependency group
- `mkdocs-redirects` 1.2.3 added a hard dependency on `properdocs` (a third-party MkDocs fork), introducing an unexpected transitive dependency into the docs toolchain
- This caps the version at 1.2.2, which depends only on `mkdocs`

Closes #320

## Test plan

- [x] `make test` — all 2087 tests pass
- [x] `make lint` — clean
- [x] `make update` — generated files up to date
- [x] `skillsaw lint` on `openshift-eng/ai-helpers` — 0 errors
- [x] Verified `pip install -e '.[docs]'` installs `mkdocs-redirects==1.2.2` without `properdocs`

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.