### PR TITLE
Switch issue solver action to claude-opus-4-8

### DIFF
--- a/.github/workflows/skillsaw-issue-solver.yml
+++ b/.github/workflows/skillsaw-issue-solver.yml
@@ -93,7 +93,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
             --max-turns 200
-            --model claude-fable-5
+            --model claude-opus-4-8
 
       - name: Upload execution log
         if: always()


### PR DESCRIPTION
## Summary
- Update the issue solver GitHub Action workflow to use `claude-opus-4-8` instead of `claude-fable-5`

## Test plan
- [ ] Verify the workflow runs successfully with the new model on the next triggered issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)