### PR TITLE
Make agentskill-description max length configurable

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -14,6 +14,7 @@ rules:
   agentskill-description:
     enabled: auto
     severity: warning
+    # max_length: 1024
 
   # Validate evals/evals.json format when present
   agentskill-evals:

--- a/README.md
+++ b/README.md
@@ -622,6 +622,12 @@ These rules validate skills against the [agentskills.io specification](https://a
 |-----------|-------------|---------|
 | `autofix-min-segments` | Minimum hyphen-separated segments in the old name for autofix to apply (single-word names are too ambiguous to fix safely) | `2` |
 
+**`agentskill-description` parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `max_length` | Maximum description length in characters (spec limit 1024; consider 256 to keep routing context lean) | `1024` |
+
 **`agentskill-structure` parameters:**
 
 | Parameter | Description | Default |

--- a/docs/rules/agentskill-description.md
+++ b/docs/rules/agentskill-description.md
@@ -48,6 +48,25 @@ it. Keep it under 200 tokens — enough for the agent to make a
 selection decision, not a full manual. Use imperative voice and
 include trigger phrases the user might say.
 
+## Choosing a tighter budget
+
+The length limit defaults to the agentskills.io spec's 1024
+characters, so default behavior matches the spec. It is configurable
+via `max_length`, and a tighter budget is recommended: the
+description is permanent context, loaded into every prompt so the
+agent can decide which skill to route to, meaning every character is
+paid on every request — and some ecosystems rank or route on only a
+prefix of the description. `256` is a good working budget:
+
+```yaml
+rules:
+  agentskill-description:
+    max_length: 256
+```
+
+Values above 1024 are honored as configured; the spec's own limit is
+enforced by the ecosystem at publish time.
+
 ## Configuration
 
 ```yaml
@@ -56,6 +75,10 @@ rules:
     enabled: auto  # true | false | auto
     severity: warning
 ```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `max_length` | Maximum description length in characters (spec limit 1024; consider 256 to keep routing context lean) | `1024` |
 
 
 *Run `skillsaw explain agentskill-description` to see this documentation and the rule's effective configuration in your terminal.*

--- a/src/skillsaw/rules/builtin/agentskills/description.py
+++ b/src/skillsaw/rules/builtin/agentskills/description.py
@@ -50,7 +50,12 @@ class AgentSkillDescriptionRule(Rule):
         return Severity.WARNING
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
-        max_length = self.config.get("max_length", DESCRIPTION_MAX_LENGTH)
+        # Fall back to the spec limit when the configured value isn't a
+        # positive integer (a blank key parses as None; bool is an int
+        # subclass — reject it) so a bad config can't crash the lint.
+        max_length = self.config.get("max_length")
+        if isinstance(max_length, bool) or not isinstance(max_length, int) or max_length <= 0:
+            max_length = DESCRIPTION_MAX_LENGTH
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):

--- a/src/skillsaw/rules/builtin/agentskills/description.py
+++ b/src/skillsaw/rules/builtin/agentskills/description.py
@@ -11,13 +11,31 @@ from ._helpers import DESCRIPTION_MAX_LENGTH
 
 
 class AgentSkillDescriptionRule(Rule):
-    """Validate skill description quality"""
+    """Validate skill description quality.
+
+    The length limit defaults to the agentskills.io spec's 1024
+    characters, and is configurable via ``max_length``. A tighter
+    budget such as ``max_length: 256`` is recommended: descriptions
+    are permanent context loaded into every prompt for skill routing,
+    so every character is paid on every request, and some ecosystems
+    rank or route on only a prefix of the description. Values above
+    1024 are honored as configured — the spec limit itself is
+    validated by the ecosystem at publish time.
+    """
 
     repo_types = {
         RepositoryType.AGENTSKILLS,
         RepositoryType.SINGLE_PLUGIN,
         RepositoryType.MARKETPLACE,
         RepositoryType.DOT_CLAUDE,
+    }
+
+    config_schema = {
+        "max_length": {
+            "type": "int",
+            "default": DESCRIPTION_MAX_LENGTH,
+            "description": "Maximum description length in characters (spec limit 1024; consider 256 to keep routing context lean)",
+        },
     }
 
     @property
@@ -32,6 +50,7 @@ class AgentSkillDescriptionRule(Rule):
         return Severity.WARNING
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        max_length = self.config.get("max_length", DESCRIPTION_MAX_LENGTH)
         violations = []
 
         for skill_node in context.lint_tree.find(SkillNode):
@@ -58,10 +77,10 @@ class AgentSkillDescriptionRule(Rule):
                 )
                 continue
 
-            if len(stripped) > DESCRIPTION_MAX_LENGTH:
+            if len(stripped) > max_length:
                 violations.append(
                     self.violation(
-                        f"Description exceeds {DESCRIPTION_MAX_LENGTH} characters ({len(stripped)})",
+                        f"Description exceeds {max_length} characters ({len(stripped)})",
                         file_path=block.path,
                         line=desc_line,
                     )

--- a/src/skillsaw/rules/docs/agentskill-description.md
+++ b/src/skillsaw/rules/docs/agentskill-description.md
@@ -32,3 +32,22 @@ Write a description that states what the skill does and when to use
 it. Keep it under 200 tokens — enough for the agent to make a
 selection decision, not a full manual. Use imperative voice and
 include trigger phrases the user might say.
+
+## Choosing a tighter budget
+
+The length limit defaults to the agentskills.io spec's 1024
+characters, so default behavior matches the spec. It is configurable
+via `max_length`, and a tighter budget is recommended: the
+description is permanent context, loaded into every prompt so the
+agent can decide which skill to route to, meaning every character is
+paid on every request — and some ecosystems rank or route on only a
+prefix of the description. `256` is a good working budget:
+
+```yaml
+rules:
+  agentskill-description:
+    max_length: 256
+```
+
+Values above 1024 are honored as configured; the spec's own limit is
+enforced by the ecosystem at publish time.

--- a/tests/fixtures/config/description-max-length/.skillsaw-relaxed.yaml
+++ b/tests/fixtures/config/description-max-length/.skillsaw-relaxed.yaml
@@ -1,0 +1,4 @@
+version: "99.0.0"
+rules:
+  agentskill-description:
+    max_length: 2000

--- a/tests/fixtures/config/description-max-length/.skillsaw.yaml
+++ b/tests/fixtures/config/description-max-length/.skillsaw.yaml
@@ -1,0 +1,4 @@
+version: "99.0.0"
+rules:
+  agentskill-description:
+    max_length: 256

--- a/tests/fixtures/config/description-max-length/deploy-staging/SKILL.md
+++ b/tests/fixtures/config/description-max-length/deploy-staging/SKILL.md
@@ -13,3 +13,5 @@ Deploy the application to the staging environment.
 2. Run the pre-deployment validation suite.
 3. Upload the artifacts and roll the staging cluster.
 4. Verify health checks and post a summary to the team channel.
+
+<!-- The description above is 343 characters; integration tests assert on this length. -->

--- a/tests/fixtures/config/description-max-length/deploy-staging/SKILL.md
+++ b/tests/fixtures/config/description-max-length/deploy-staging/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: deploy-staging
+description: Deploy the application to the staging environment, including building artifacts, running the pre-deployment validation suite, uploading the artifacts to the staging bucket, rolling the staging cluster, verifying health checks, and posting a deployment summary to the team channel. Use when the user asks to deploy, ship, or release to staging.
+---
+
+# Deploy Staging
+
+Deploy the application to the staging environment.
+
+## Steps
+
+1. Build the release artifacts with the standard build command.
+2. Run the pre-deployment validation suite.
+3. Upload the artifacts and roll the staging cluster.
+4. Verify health checks and post a summary to the team channel.

--- a/tests/fixtures/config/description-max-length/incident-handoff/SKILL.md
+++ b/tests/fixtures/config/description-max-length/incident-handoff/SKILL.md
@@ -17,3 +17,5 @@ Summarize open incidents and produce a morning handoff report.
 1. List the open incidents from the pager rotation.
 2. Collect owner, severity, and the latest status update for each.
 3. Write the handoff report with links to every incident.
+
+<!-- The description above is 303 when the folded lines are parsed characters; integration tests assert on this length. -->

--- a/tests/fixtures/config/description-max-length/incident-handoff/SKILL.md
+++ b/tests/fixtures/config/description-max-length/incident-handoff/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: incident-handoff
+description: >
+  Summarize open incidents from the pager rotation and produce a
+  morning handoff report. Use when the user asks for an incident
+  summary, a handoff report, or the current pager status. Includes
+  links to each incident, the owning team, current severity, and
+  the latest status update for every open incident.
+---
+
+# Incident Handoff
+
+Summarize open incidents and produce a morning handoff report.
+
+## Steps
+
+1. List the open incidents from the pager rotation.
+2. Collect owner, severity, and the latest status update for each.
+3. Write the handoff report with links to every incident.

--- a/tests/fixtures/config/description-max-length/incident-investigator/SKILL.md
+++ b/tests/fixtures/config/description-max-length/incident-investigator/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: incident-investigator
+description: Investigate a production incident from start to finish. Use when the user reports an outage, a spike in error rates, or asks for an incident investigation. Collects the recent deploy history, correlates it with the alert timeline, and pulls the relevant service logs for the affected window. Summarizes the most likely root causes with supporting evidence and links to the dashboards used. Prepares a draft incident report with an impact assessment, a timeline of events, and the follow-up actions the team agreed on. Posts the report to the incident channel and files tracking issues for each follow-up action so nothing is lost after the incident is closed. Keeps a record of every command it ran so the investigation can be audited or replayed later. Escalates to the on-call engineer when the evidence points at an ongoing problem rather than a resolved one. Works across the API, worker, and frontend services and understands the standard deployment topology. Never restarts services or rolls back deploys on its own; it always proposes the action and waits for confirmation. Understands maintenance windows and will not page anyone for alerts that fired inside one. Falls back to read-only analysis when it lacks credentials for a service. Reports partial findings rather than failing outright when a data source is unavailable.
+---
+
+# Incident Investigator
+
+Investigate a production incident from start to finish.
+
+## Steps
+
+1. Collect the recent deploy history and the alert timeline.
+2. Pull the relevant service logs for the affected window.
+3. Summarize likely root causes with supporting evidence.
+4. Draft the incident report and file follow-up issues.

--- a/tests/fixtures/config/description-max-length/incident-investigator/SKILL.md
+++ b/tests/fixtures/config/description-max-length/incident-investigator/SKILL.md
@@ -13,3 +13,5 @@ Investigate a production incident from start to finish.
 2. Pull the relevant service logs for the affected window.
 3. Summarize likely root causes with supporting evidence.
 4. Draft the incident report and file follow-up issues.
+
+<!-- The description above is 1334, above the spec's 1024 default characters; integration tests assert on this length. -->

--- a/tests/fixtures/config/description-max-length/release-notes/SKILL.md
+++ b/tests/fixtures/config/description-max-length/release-notes/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: release-notes
+description: Generate release notes from merged pull requests since the last tag. Use when the user asks to draft release notes, prepare a changelog, or summarize what shipped in a release. Groups entries by product area and labels any breaking changes for maintainers.
+---
+
+# Release Notes
+
+Generate release notes from merged pull requests since the last tag.
+
+## Steps
+
+1. List pull requests merged since the last tag.
+2. Group the entries by product area.
+3. Label any breaking changes for maintainers.

--- a/tests/fixtures/config/description-max-length/release-notes/SKILL.md
+++ b/tests/fixtures/config/description-max-length/release-notes/SKILL.md
@@ -12,3 +12,5 @@ Generate release notes from merged pull requests since the last tag.
 1. List pull requests merged since the last tag.
 2. Group the entries by product area.
 3. Label any breaking changes for maintainers.
+
+<!-- The description above is exactly 256 characters; integration tests assert on this length. -->

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -435,6 +435,21 @@ def test_description_folded_multiline_max_length(temp_dir):
     assert violations[0].line == 3
 
 
+def test_description_max_length_invalid_values_fall_back(temp_dir):
+    """A blank key (None), non-integer, bool, or non-positive max_length
+    falls back to the spec's 1024 default instead of crashing."""
+    skill = temp_dir / "resilient"
+    skill.mkdir()
+    desc_1100 = "x" * 1100
+    (skill / "SKILL.md").write_text(f"---\nname: resilient\ndescription: {desc_1100}\n---\n")
+
+    context = RepositoryContext(skill)
+    for bad_value in [None, "not-a-number", True, 2.5, 0, -1]:
+        violations = AgentSkillDescriptionRule(config={"max_length": bad_value}).check(context)
+        assert len(violations) == 1, f"max_length={bad_value!r} should fall back to 1024"
+        assert "1024" in violations[0].message
+
+
 def test_description_max_length_above_spec_limit_honored(temp_dir):
     """A configured max_length above 1024 wins: a 1500-char description
     does not warn at max_length 2000. The spec's own limit is validated

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -374,6 +374,82 @@ def test_description_over_limit_warns(temp_dir):
     assert violations[0].line == 3
 
 
+def test_description_default_max_length_unchanged(temp_dir):
+    """Backward compatibility: at default config a 400-char description
+    passes and only the spec's 1024 limit fires, with the same message."""
+    skill = temp_dir / "longish"
+    skill.mkdir()
+    desc_400 = "x" * 400
+    (skill / "SKILL.md").write_text(f"---\nname: longish\ndescription: {desc_400}\n---\n")
+    assert AgentSkillDescriptionRule().check(RepositoryContext(skill)) == []
+
+    over = temp_dir / "over-spec"
+    over.mkdir()
+    desc_1100 = "x" * 1100
+    (over / "SKILL.md").write_text(f"---\nname: over-spec\ndescription: {desc_1100}\n---\n")
+    violations = AgentSkillDescriptionRule().check(RepositoryContext(over))
+    assert len(violations) == 1
+    assert violations[0].message == "Description exceeds 1024 characters (1100)"
+
+
+def test_description_configured_max_length_warns(temp_dir):
+    """max_length: 256 makes a 400-char description warn with both numbers."""
+    skill = temp_dir / "budgeted"
+    skill.mkdir()
+    desc_400 = "x" * 400
+    (skill / "SKILL.md").write_text(f"---\nname: budgeted\ndescription: {desc_400}\n---\n")
+
+    context = RepositoryContext(skill)
+    violations = AgentSkillDescriptionRule(config={"max_length": 256}).check(context)
+    assert len(violations) == 1
+    assert "400" in violations[0].message
+    assert "256" in violations[0].message
+    assert violations[0].line == 3
+    assert violations[0].severity == Severity.WARNING
+
+
+def test_description_exactly_at_max_length_passes(temp_dir):
+    """Boundary: a description of exactly max_length characters is fine."""
+    skill = temp_dir / "boundary"
+    skill.mkdir()
+    exact_desc = "x" * 256
+    (skill / "SKILL.md").write_text(f"---\nname: boundary\ndescription: {exact_desc}\n---\n")
+
+    context = RepositoryContext(skill)
+    violations = AgentSkillDescriptionRule(config={"max_length": 256}).check(context)
+    assert violations == []
+
+
+def test_description_folded_multiline_max_length(temp_dir):
+    """Folded YAML descriptions are measured on the parsed string value,
+    and the line number points at the description key."""
+    skill = temp_dir / "folded"
+    skill.mkdir()
+    words = ("word " * 70).strip()  # 349 chars parsed
+    (skill / "SKILL.md").write_text(f"---\nname: folded\ndescription: >\n  {words}\n---\n")
+
+    context = RepositoryContext(skill)
+    violations = AgentSkillDescriptionRule(config={"max_length": 256}).check(context)
+    assert len(violations) == 1
+    assert "349" in violations[0].message
+    assert violations[0].line == 3
+
+
+def test_description_max_length_above_spec_limit_honored(temp_dir):
+    """A configured max_length above 1024 wins: a 1500-char description
+    does not warn at max_length 2000. The spec's own limit is validated
+    by the ecosystem at publish time."""
+    skill = temp_dir / "relaxed"
+    skill.mkdir()
+    desc_1500 = "x" * 1500
+    (skill / "SKILL.md").write_text(f"---\nname: relaxed\ndescription: {desc_1500}\n---\n")
+
+    context = RepositoryContext(skill)
+    assert AgentSkillDescriptionRule(config={"max_length": 2000}).check(context) == []
+    # sanity: the same description warns at defaults
+    assert len(AgentSkillDescriptionRule().check(context)) == 1
+
+
 # --- agentskill-structure ---
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1388,6 +1388,82 @@ class TestRequiredFieldsConfig:
         assert len(vs) == 0, f"Should have no required-field violations without config: {vs}"
 
 
+@pytest.mark.integration
+class TestDescriptionMaxLengthConfig:
+    """End-to-end tests for the configurable agentskill-description max_length.
+
+    The fixture contains four skills: deploy-staging (343-char
+    description), release-notes (exactly 256 chars), incident-handoff
+    (folded multiline description, 303 chars parsed), and
+    incident-investigator (1334 chars — above the spec's 1024 default).
+    Its .skillsaw.yaml sets max_length: 256; .skillsaw-relaxed.yaml
+    sets max_length: 2000.
+    """
+
+    FIXTURE = "config/description-max-length"
+
+    def _rule_violations(self, r):
+        return [v for v in violations(r) if v["rule_id"] == "agentskill-description"]
+
+    def test_default_behavior_unchanged(self, tmp_path):
+        """Without config only the spec's 1024 limit fires, with the
+        original message — a 343-char description passes."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        (repo / ".skillsaw.yaml").unlink()
+        (repo / ".skillsaw-relaxed.yaml").unlink()
+        r = run_lint(repo)
+        vs = self._rule_violations(r)
+        assert len(vs) == 1
+        assert "incident-investigator" in vs[0]["file_path"]
+        assert vs[0]["message"] == "Description exceeds 1024 characters (1334)"
+
+    def test_configured_max_length_fires(self, tmp_path):
+        """max_length: 256 makes a 343-char description warn with the
+        actual length, the configured limit, and the key's line."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [v for v in self._rule_violations(r) if "deploy-staging" in v["file_path"]]
+        assert len(vs) == 1
+        assert "343" in vs[0]["message"]
+        assert "256" in vs[0]["message"]
+        assert vs[0]["severity"] == "warning"
+        assert vs[0]["line"] == 3  # the description key line
+
+    def test_exactly_at_max_length_passes(self, tmp_path):
+        """Boundary: a description of exactly 256 characters does not fire."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [v for v in self._rule_violations(r) if "release-notes" in v["file_path"]]
+        assert vs == []
+
+    def test_folded_multiline_description(self, tmp_path):
+        """Folded YAML descriptions are measured on the parsed string value."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [v for v in self._rule_violations(r) if "incident-handoff" in v["file_path"]]
+        assert len(vs) == 1
+        assert "303" in vs[0]["message"]
+        # Line number points at the description key, not the folded lines
+        assert vs[0]["line"] == 3
+
+    def test_max_length_above_spec_limit_honored(self, tmp_path):
+        """max_length: 2000 lets a 1334-char description pass — the
+        configured value wins over the spec's 1024 default."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw-relaxed.yaml")
+        assert self._rule_violations(r) == []
+
+    def test_single_violation_per_description(self, tmp_path):
+        """A description over both the configured and spec limits still
+        produces exactly one agentskill-description violation."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        vs = [v for v in self._rule_violations(r) if "incident-investigator" in v["file_path"]]
+        assert len(vs) == 1
+        assert "1334" in vs[0]["message"]
+        assert "256" in vs[0]["message"]
+
+
 class TestUnlinkedInternalReferenceAutofix:
     """Integration tests for content-unlinked-internal-reference autofix via CLI."""
 


### PR DESCRIPTION
## What

Adds a `max_length` config option (integer, **default 1024** — the existing `DESCRIPTION_MAX_LENGTH`) to the `agentskill-description` rule. The length check now uses the configured value, and the violation message reports the configured limit and the actual length on the description key's line, exactly as before. The empty/whitespace-only check is untouched.

**Default behavior is exactly unchanged**: at the default 1024, output is byte-for-byte identical to today (message text included), so existing users see no difference. This is a backward-compatible config enhancement, not a behavior change.

Rule relationship, for clarity: `agentskill-valid` checks presence/type of `description`; `agentskill-description` owns the empty check and the (now configurable) length limit; there is no separate rule and no double-reporting — one description over the limit produces exactly one violation.

## Recommended setting

```yaml
rules:
  agentskill-description:
    max_length: 256
```

Skill descriptions are permanent context: they are loaded into every prompt so the agent can decide which skill to route to, meaning every character is paid on every request — and some ecosystems rank or route on only a prefix of the description. A tighter budget like 256 keeps routing context lean. This recommendation (with the config snippet) is documented in the rule docstring, the rule's docs page (`skillsaw explain agentskill-description`), and the README parameter table generated from `config_schema`.

## Values above 1024

Choice made: **the configured value wins.** Setting `max_length: 2000` means a 1500-char description does not warn. The spec's own 1024 limit is validated by the ecosystem at publish time; users raising the limit above spec are opting out of that guardrail knowingly. This is documented in the rule docs and covered by a test.

## Test coverage

- **Unit tests** (`tests/test_agentskill_rules.py`, 5 new): default parity (400-char passes; 1100-char warns with the exact original message `Description exceeds 1024 characters (1100)`); `max_length: 256` makes a 400-char description warn with both numbers and the key line; exactly-at-limit boundary passes; folded `description: >` measured on the parsed string with the line pointing at the key; `max_length: 2000` lets a 1500-char description pass while defaults still flag it.
- **Integration tests** (`tests/test_integration.py`, new `TestDescriptionMaxLengthConfig` class + static fixture `tests/fixtures/config/description-max-length/` with four realistic skills at 343 / exactly-256 / folded-303 / 1334 chars, plus `.skillsaw.yaml` at 256 and `.skillsaw-relaxed.yaml` at 2000): default behavior unchanged end to end; configured limit fires with length, limit, and line; boundary; folded multiline; above-spec override honored; single violation per over-limit description.
- Full suite: **2156 passed**. `make lint` clean; `make update` regenerated README (parameter table), `.skillsaw.yaml.example` (commented `# max_length: 1024`), and the docs site page.

## ai-helpers verification

Cloned `openshift-eng/ai-helpers` and ran this branch's build: **exit 0, 0 errors, 0 warnings** (run with `--no-plugins` to match a stock `pip install skillsaw`; the dev venv's `skillsaw-typos` plugin otherwise flags pre-existing typos in their content, identical on main). Default unchanged, so `agentskill-description` fires nowhere it didn't before.

Replaces the closed #345 (direction changed from a separate opt-in rule to making the existing rule configurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)