### PR TITLE
Contain promptfoo file:// refs to the repo root

### DIFF
--- a/src/skillsaw/formats/promptfoo.py
+++ b/src/skillsaw/formats/promptfoo.py
@@ -33,11 +33,15 @@ def is_promptfoo_config(data: object) -> bool:
     return isinstance(data, dict) and bool(PROMPTFOO_KEYS & set(data.keys()))
 
 
-def resolve_file_ref(ref: str, config_dir: Path) -> Optional[Path]:
+def resolve_file_ref(ref: str, config_dir: Path, root: Optional[Path] = None) -> Optional[Path]:
     """Resolve a file:// reference relative to config_dir.
 
     Returns the resolved path (which may or may not exist on disk).
     Returns None for glob patterns, non-YAML extensions, and remote URLs.
+
+    When ``root`` is given, refs whose resolved path (symlinks followed)
+    falls outside of it are rejected and None is returned — a config must
+    not pull files from outside the repository into the lint tree.
     """
     if not ref.startswith("file://"):
         if ref.startswith(("http://", "https://", "huggingface://")):
@@ -55,7 +59,13 @@ def resolve_file_ref(ref: str, config_dir: Path) -> Optional[Path]:
     if suffix not in (".yaml", ".yml"):
         return None
 
-    return (config_dir / raw).resolve()
+    resolved = (config_dir / raw).resolve()
+
+    # Disallow escaping the repo root (mirrors context._resolve_plugin_source)
+    if root is not None and not resolved.is_relative_to(root.resolve()):
+        return None
+
+    return resolved
 
 
 def extract_file_refs(data: dict) -> List[str]:

--- a/src/skillsaw/formats/promptfoo.py
+++ b/src/skillsaw/formats/promptfoo.py
@@ -59,10 +59,18 @@ def resolve_file_ref(ref: str, config_dir: Path, root: Optional[Path] = None) ->
     if suffix not in (".yaml", ".yml"):
         return None
 
-    resolved = (config_dir / raw).resolve()
+    # resolve() on user-controlled paths can raise (e.g. OSError on
+    # permission problems, RuntimeError on symlink loops before 3.13);
+    # a broken ref should be skipped, not crash the linter.
+    try:
+        resolved = (config_dir / raw).resolve()
 
-    # Disallow escaping the repo root (mirrors context._resolve_plugin_source)
-    if root is not None and not resolved.is_relative_to(root.resolve()):
+        # Disallow escaping the repo root (mirrors
+        # context._resolve_plugin_source).  root is re-resolved because this
+        # helper is standalone and callers may pass an unresolved root.
+        if root is not None and not resolved.is_relative_to(root.resolve()):
+            return None
+    except (OSError, RuntimeError):
         return None
 
     return resolved

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -387,7 +387,7 @@ def _build_promptfoo_nodes(
             continue
         config_dir = config_node.path.parent
         for ref in extract_file_refs(data):
-            resolved = resolve_file_ref(ref, config_dir)
+            resolved = resolve_file_ref(ref, config_dir, root=context.root_path)
             if resolved is None or resolved in seen:
                 continue
             if not resolved.exists() or _is_excluded(Path(resolved)):

--- a/tests/test_promptfoo_rules.py
+++ b/tests/test_promptfoo_rules.py
@@ -117,6 +117,42 @@ def test_resolve_file_ref_remote_skipped(tmp_path):
     assert _resolve_file_ref("huggingface://datasets/foo", tmp_path) is None
 
 
+def test_resolve_file_ref_relative_escape_rejected_with_root(tmp_path):
+    root = tmp_path / "repo"
+    (root / "evals").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secrets.yaml").write_text("password: hunter2")
+    result = _resolve_file_ref("file://../../outside/secrets.yaml", root / "evals", root=root)
+    assert result is None
+
+
+def test_resolve_file_ref_absolute_escape_rejected_with_root(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "secrets.yaml"
+    outside.write_text("password: hunter2")
+    assert _resolve_file_ref(f"file://{outside}", root, root=root) is None
+
+
+def test_resolve_file_ref_symlink_escape_rejected_with_root(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "secrets.yaml"
+    outside.write_text("password: hunter2")
+    (root / "link.yaml").symlink_to(outside)
+    assert _resolve_file_ref("file://link.yaml", root, root=root) is None
+
+
+def test_resolve_file_ref_inside_root_still_resolves(tmp_path):
+    root = tmp_path / "repo"
+    (root / "evals").mkdir(parents=True)
+    target = root / "evals" / "tests.yaml"
+    target.write_text("[]")
+    result = _resolve_file_ref("file://tests.yaml", root / "evals", root=root)
+    assert result == target.resolve()
+
+
 def test_extract_file_refs_string_tests():
     assert _extract_file_refs({"tests": "file://tests.yaml"}) == ["file://tests.yaml"]
 
@@ -290,6 +326,60 @@ def test_fragment_node_as_child_of_config(temp_dir):
     assert len(configs) == 1
     assert len(fragments) == 1
     assert fragments[0].parent is configs[0]
+
+
+def test_fragment_escaping_repo_root_not_in_tree(temp_dir):
+    """A file:// ref with .. escaping the repo root must not become a fragment."""
+    outside = temp_dir / "outside"
+    _write_yaml(outside / "secrets.yaml", [{"description": "leaked", "vars": {"prompt": "hi"}}])
+    repo = temp_dir / "repo"
+    _write_yaml(
+        repo / "evals" / "promptfooconfig.yaml",
+        {
+            "providers": [{"id": "test"}],
+            "tests": ["file://../../outside/secrets.yaml"],
+        },
+    )
+    context = RepositoryContext(repo)
+    nodes = context.lint_tree.find(PromptfooConfigNode)
+    assert len([n for n in nodes if not n.is_fragment]) == 1
+    assert [n for n in nodes if n.is_fragment] == []
+
+
+def test_fragment_absolute_path_outside_repo_not_in_tree(temp_dir):
+    """An absolute file:// ref pointing outside the repo must not become a fragment."""
+    outside = temp_dir / "secrets.yaml"
+    _write_yaml(outside, [{"description": "leaked", "vars": {"prompt": "hi"}}])
+    repo = temp_dir / "repo"
+    _write_yaml(
+        repo / "evals" / "promptfooconfig.yaml",
+        {
+            "providers": [{"id": "test"}],
+            "tests": [f"file://{outside}"],
+        },
+    )
+    context = RepositoryContext(repo)
+    nodes = context.lint_tree.find(PromptfooConfigNode)
+    assert [n for n in nodes if n.is_fragment] == []
+
+
+def test_fragment_symlink_escaping_repo_root_not_in_tree(temp_dir):
+    """A symlink inside the repo pointing outside must not become a fragment."""
+    outside = temp_dir / "secrets.yaml"
+    _write_yaml(outside, [{"description": "leaked", "vars": {"prompt": "hi"}}])
+    repo = temp_dir / "repo"
+    (repo / "evals").mkdir(parents=True)
+    (repo / "evals" / "link.yaml").symlink_to(outside)
+    _write_yaml(
+        repo / "evals" / "promptfooconfig.yaml",
+        {
+            "providers": [{"id": "test"}],
+            "tests": ["file://link.yaml"],
+        },
+    )
+    context = RepositoryContext(repo)
+    nodes = context.lint_tree.find(PromptfooConfigNode)
+    assert [n for n in nodes if n.is_fragment] == []
 
 
 def test_non_promptfoo_yaml_not_in_tree(temp_dir):

--- a/tests/test_promptfoo_rules.py
+++ b/tests/test_promptfoo_rules.py
@@ -144,6 +144,17 @@ def test_resolve_file_ref_symlink_escape_rejected_with_root(tmp_path):
     assert _resolve_file_ref("file://link.yaml", root, root=root) is None
 
 
+def test_resolve_file_ref_symlink_loop_does_not_crash(tmp_path):
+    # Path.resolve() raises RuntimeError/OSError on symlink loops before
+    # Python 3.13; a broken ref must be skipped, never crash the linter.
+    root = tmp_path / "repo"
+    root.mkdir()
+    loop = root / "loop.yaml"
+    loop.symlink_to(loop)
+    result = _resolve_file_ref("file://loop.yaml", root, root=root)
+    assert result is None or result.is_relative_to(root)
+
+
 def test_resolve_file_ref_inside_root_still_resolves(tmp_path):
     root = tmp_path / "repo"
     (root / "evals").mkdir(parents=True)


### PR DESCRIPTION
## The bug

Promptfoo `file://` references escaped the repository root. A promptfoo config containing e.g.

```yaml
tests: file://../outside/secrets.yaml
```

was resolved by `resolve_file_ref()` in `src/skillsaw/formats/promptfoo.py` via `(config_dir / raw).resolve()` with no containment check, and the outside file was attached to the lint tree as a `promptfoo-fragment` node — `skillsaw tree` displayed a file from outside the checkout. Absolute paths outside the repo and symlinks inside the repo pointing outside were accepted the same way.

## The fix

`resolve_file_ref()` gains an optional `root` parameter: when given, any ref whose resolved path (symlinks followed, via `Path.resolve()`) falls outside `root` is rejected with `None`, mirroring the existing escape check in `context._resolve_plugin_source()`. The lint-tree builder (`_build_promptfoo_nodes` in `src/skillsaw/lint_tree.py`) passes `context.root_path` (already resolved in `RepositoryContext.__init__`), so escaping refs are silently skipped exactly like other unresolvable refs (globs, remote URLs, non-YAML extensions). The signature is backward compatible; rule-level callers are unchanged.

## Tests

- Unit tests for `resolve_file_ref` with `root=`: relative `..` escape, absolute path outside the repo, and an in-repo symlink pointing outside are all rejected; an in-repo ref still resolves.
- Lint-tree regression tests proving none of the three escape variants produce a fragment node, while the existing `test_fragment_node_as_child_of_config` covers legitimate in-repo refs still resolving.

Verified end-to-end with `skillsaw tree` on a repro repo: the escaping ref no longer appears in the tree, legitimate refs still do. Full suite passes (2246 tests), `make lint` clean, dogfooded against `openshift-eng/ai-helpers` (identical results to main).

Part of #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)