### PR TITLE
content-broken-internal-reference: resolve percent-encoded links; never emit unparseable destinations

### DIFF
--- a/src/skillsaw/rules/builtin/content/broken_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/broken_internal_reference.py
@@ -78,8 +78,10 @@ class ContentBrokenInternalReferenceRule(Rule):
                 # Resolve relative to the file containing the link
                 try:
                     resolved = (cf.path.parent / fs_path).resolve()
-                except (ValueError, OSError):
-                    # Undecodable path (e.g. an embedded %00) cannot exist.
+                except (ValueError, OSError, RuntimeError):
+                    # Undecodable path (e.g. an embedded %00) cannot exist;
+                    # resolve() raises RuntimeError on circular symlinks on
+                    # Python <= 3.12.
                     violations.append(
                         self.violation(
                             f"Broken internal link: [{link.text}]({target}) — target does not exist",
@@ -117,7 +119,7 @@ class ContentBrokenInternalReferenceRule(Rule):
             resolved = (link_dir / rel_path).resolve()
             resolved.relative_to(root)
             return resolved.exists()
-        except (ValueError, OSError):
+        except (ValueError, OSError, RuntimeError):
             return False
 
     def _collect_repo_paths(self, root: Path) -> List[str]:
@@ -152,16 +154,24 @@ class ContentBrokenInternalReferenceRule(Rule):
         return self._fuzzy_name_cache[target_name]
 
     def _find_similar(self, root: Path, link_dir: Path, target_path: str) -> Optional[str]:
-        """Find a similar file path in the repo using fuzzy matching."""
+        """Find a similar file path in the repo using fuzzy matching.
+
+        Suggestions are markdown destinations, so they always use forward
+        slashes: ``as_posix()`` converts the ``\\`` separators that
+        ``os.path.relpath`` / ``relative_to`` produce on Windows (a raw
+        ``\\`` would be percent-encoded as ``%5C`` by the fixer). On POSIX
+        it is a no-op — a literal ``\\`` there is part of the file name and
+        must be preserved.
+        """
         index = self._path_index(root)
         target_name = Path(target_path).name
         candidates = index.get(target_name, [])
         if len(candidates) == 1:
             try:
-                return str(Path(candidates[0]).relative_to(link_dir.relative_to(root)))
+                return Path(candidates[0]).relative_to(link_dir.relative_to(root)).as_posix()
             except ValueError:
                 rel = os.path.relpath(root / candidates[0], link_dir)
-                return rel
+                return Path(rel).as_posix()
         if not candidates:
             close = self._close_name(index, target_name)
             if close is not None:
@@ -169,9 +179,9 @@ class ContentBrokenInternalReferenceRule(Rule):
         if candidates:
             try:
                 rel = os.path.relpath(root / candidates[0], link_dir)
-                return rel
+                return Path(rel).as_posix()
             except ValueError:
-                return candidates[0]
+                return Path(candidates[0]).as_posix()
         return None
 
     def fix(

--- a/src/skillsaw/rules/builtin/content/broken_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/broken_internal_reference.py
@@ -5,6 +5,7 @@ import os
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional
+from urllib.parse import quote, unquote
 
 from skillsaw.rule import AutofixConfidence, AutofixResult, Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
@@ -64,8 +65,22 @@ class ContentBrokenInternalReferenceRule(Rule):
                 target_path = target.split("#")[0]
                 if not target_path:
                     continue
+                # Decode percent-escapes (%20 etc.) for the filesystem
+                # lookup only — messages keep the original destination text.
+                fs_path = unquote(target_path)
                 # Resolve relative to the file containing the link
-                resolved = (cf.path.parent / target_path).resolve()
+                try:
+                    resolved = (cf.path.parent / fs_path).resolve()
+                except (ValueError, OSError):
+                    # Undecodable path (e.g. an embedded %00) cannot exist.
+                    violations.append(
+                        self.violation(
+                            f"Broken internal link: [{link.text}]({target}) — target does not exist",
+                            block=cf,
+                            line=link.body_line,
+                        )
+                    )
+                    continue
                 # Ensure the resolved path is within the repo root
                 try:
                     resolved.relative_to(root)
@@ -79,7 +94,7 @@ class ContentBrokenInternalReferenceRule(Rule):
                     )
                     continue
                 if not resolved.exists():
-                    suggestion = self._find_similar(root, cf.path.parent, target_path)
+                    suggestion = self._find_similar(root, cf.path.parent, fs_path)
                     msg = f"Broken internal link: [{link.text}]({target}) — target does not exist"
                     if suggestion:
                         msg += f" (did you mean '{suggestion}'?)"
@@ -189,7 +204,13 @@ class ContentBrokenInternalReferenceRule(Rule):
                     if key in used_spans:
                         continue
                     used_spans.add(key)
-                    edits.append((link.dest_file_line, span[0], span[1], suggestion + anchor))
+                    # Percent-encode the emitted destination: suggestions are
+                    # raw filesystem paths, and a raw space (or paren) inside
+                    # `](...)` is not parseable markdown — the link would be
+                    # silently destroyed. Paths without special characters
+                    # pass through unchanged.
+                    dest = quote(suggestion, safe="/")
+                    edits.append((link.dest_file_line, span[0], span[1], dest + anchor))
                     violations_fixed.append(v)
                     break
             fixed = splice(content, edits)

--- a/src/skillsaw/rules/builtin/content/broken_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/broken_internal_reference.py
@@ -68,6 +68,13 @@ class ContentBrokenInternalReferenceRule(Rule):
                 # Decode percent-escapes (%20 etc.) for the filesystem
                 # lookup only — messages keep the original destination text.
                 fs_path = unquote(target_path)
+                # A file whose literal name contains %XX sequences and is
+                # linked verbatim (e.g. `refs/x%20y.md` exists on disk)
+                # linted clean before decoding existed — keep accepting it.
+                if fs_path != target_path and self._exists_in_repo(
+                    root, cf.path.parent, target_path
+                ):
+                    continue
                 # Resolve relative to the file containing the link
                 try:
                     resolved = (cf.path.parent / fs_path).resolve()
@@ -102,6 +109,16 @@ class ContentBrokenInternalReferenceRule(Rule):
                         msg += " (reference-style link — fix the definition manually)"
                     violations.append(self.violation(msg, block=cf, line=link.body_line))
         return violations
+
+    @staticmethod
+    def _exists_in_repo(root: Path, link_dir: Path, rel_path: str) -> bool:
+        """True when ``rel_path`` resolves inside ``root`` and exists."""
+        try:
+            resolved = (link_dir / rel_path).resolve()
+            resolved.relative_to(root)
+            return resolved.exists()
+        except (ValueError, OSError):
+            return False
 
     def _collect_repo_paths(self, root: Path) -> List[str]:
         """Collect all file paths in the repo, relative to root."""

--- a/tests/fixtures/regression/broken-ref-percent-encoding/CLAUDE.md
+++ b/tests/fixtures/regression/broken-ref-percent-encoding/CLAUDE.md
@@ -5,3 +5,5 @@ This project keeps its writing conventions in the `references/` directory.
 Follow [the style guide](references/style%20guide.md) when writing docs.
 
 Check [the naming rules](references/naming%20rles.md) before renaming files.
+
+Historic [API notes](references/api%20notes.md) keep their original file name.

--- a/tests/fixtures/regression/broken-ref-percent-encoding/CLAUDE.md
+++ b/tests/fixtures/regression/broken-ref-percent-encoding/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Guide
+
+This project keeps its writing conventions in the `references/` directory.
+
+Follow [the style guide](references/style%20guide.md) when writing docs.
+
+Check [the naming rules](references/naming%20rles.md) before renaming files.

--- a/tests/fixtures/regression/broken-ref-percent-encoding/references/api%20notes.md
+++ b/tests/fixtures/regression/broken-ref-percent-encoding/references/api%20notes.md
@@ -1,0 +1,3 @@
+# API Notes
+
+Legacy notes kept under their original file name.

--- a/tests/fixtures/regression/broken-ref-percent-encoding/references/naming rules.md
+++ b/tests/fixtures/regression/broken-ref-percent-encoding/references/naming rules.md
@@ -1,0 +1,3 @@
+# Naming Rules
+
+Use kebab-case for file names. Avoid abbreviations.

--- a/tests/fixtures/regression/broken-ref-percent-encoding/references/style guide.md
+++ b/tests/fixtures/regression/broken-ref-percent-encoding/references/style guide.md
@@ -1,0 +1,3 @@
+# Style Guide
+
+Write in the imperative mood. Keep sentences short.

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -1,6 +1,7 @@
 """Tests for content intelligence rules."""
 
 import json
+import os
 import pytest
 from pathlib import Path
 import tempfile
@@ -999,6 +1000,30 @@ class TestContentBrokenInternalReferenceRule:
         violations = ContentBrokenInternalReferenceRule().check(context)
         assert len(violations) == 1
         assert "refs%00/x.md" in violations[0].message
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_circular_symlink_reports_broken_not_crash(self, temp_dir):
+        """A self-referential symlink cannot resolve — Path.resolve()
+        raises RuntimeError on Python <= 3.12; report broken instead of
+        crashing."""
+        loop = temp_dir / "loop.md"
+        loop.symlink_to(loop)
+        (temp_dir / "CLAUDE.md").write_text("See [loop](loop.md).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "does not exist" in violations[0].message
+
+    @pytest.mark.skipif(os.name == "nt", reason="backslash is a separator on Windows")
+    def test_literal_backslash_filename_suggestion_preserved(self, temp_dir):
+        """On POSIX a literal backslash is part of the file name — the
+        Windows separator normalization (as_posix) must not rewrite it."""
+        (temp_dir / "style\\guide.md").write_text("# Style\n")
+        (temp_dir / "CLAUDE.md").write_text("See [style](style-guide.md).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "did you mean 'style\\guide.md'?" in violations[0].message
 
 
 class TestContentUnlinkedInternalReferenceRule:

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -962,6 +962,44 @@ class TestContentBrokenInternalReferenceRule:
         violations = ContentBrokenInternalReferenceRule().check(context)
         assert violations == []
 
+    def test_literal_percent_sequence_in_filename_linked_verbatim(self, temp_dir):
+        """A file whose literal name contains %XX, linked verbatim, linted
+        clean before decoding existed — decoding must not break it."""
+        refs = temp_dir / "refs"
+        refs.mkdir()
+        (refs / "x%20y.md").write_text("# Literal percent\n")
+        (temp_dir / "CLAUDE.md").write_text("See [notes](refs/x%20y.md) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert violations == []
+
+    def test_double_encoded_link_to_literal_percent_filename(self, temp_dir):
+        """%2520 decodes once to %20, matching a literal %20 in the name."""
+        (temp_dir / "x%20y.md").write_text("# Literal percent\n")
+        (temp_dir / "CLAUDE.md").write_text("See [notes](x%2520y.md) for details.\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert violations == []
+
+    def test_literal_percent_not_a_valid_escape(self, temp_dir):
+        """A bare % that is not a valid escape (50%.md, w%zz.md) passes
+        through unquote unchanged and resolves literally."""
+        (temp_dir / "50%.md").write_text("# Fifty\n")
+        (temp_dir / "w%zz.md").write_text("# Malformed escape\n")
+        (temp_dir / "CLAUDE.md").write_text("See [fifty](50%.md) and [malformed](w%zz.md).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert violations == []
+
+    def test_undecodable_destination_reports_broken(self, temp_dir):
+        """An embedded %00 decodes to NUL, which cannot resolve — report
+        broken instead of crashing."""
+        (temp_dir / "CLAUDE.md").write_text("See [bad](refs%00/x.md).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "refs%00/x.md" in violations[0].message
+
 
 class TestContentUnlinkedInternalReferenceRule:
     def test_rule_metadata(self):

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -932,6 +932,36 @@ class TestContentBrokenInternalReferenceRule:
         violations = ContentBrokenInternalReferenceRule().check(context)
         assert len(violations) == 0
 
+    def test_percent_encoded_link_to_existing_file(self, temp_dir):
+        """Regression for #322: a %20 link to a real file is not broken."""
+        refs = temp_dir / "references"
+        refs.mkdir()
+        (refs / "style guide.md").write_text("# Style Guide\n")
+        (temp_dir / "CLAUDE.md").write_text(
+            "Follow [the style guide](references/style%20guide.md) for docs.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert violations == []
+
+    def test_percent_encoded_link_to_missing_file(self, temp_dir):
+        """A genuinely broken %20 link still fires, keeping the original
+        destination text in the message."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Follow [the style guide](references/style%20guide.md) for docs.\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert len(violations) == 1
+        assert "references/style%20guide.md" in violations[0].message
+
+    def test_percent_encoded_link_with_anchor(self, temp_dir):
+        (temp_dir / "style guide.md").write_text("# Style Guide\n## Voice\n")
+        (temp_dir / "CLAUDE.md").write_text("See [voice](style%20guide.md#voice).\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentBrokenInternalReferenceRule().check(context)
+        assert violations == []
+
 
 class TestContentUnlinkedInternalReferenceRule:
     def test_rule_metadata(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2537,8 +2537,10 @@ class TestMarkdownAstRegressions:
         fixed = (repo / "CLAUDE.md").read_text()
         assert "[the naming rules](references/naming%20rules.md)" in fixed
         assert "](references/naming rules.md)" not in fixed
-        # The working link is untouched.
+        # The working links are untouched — including the file whose
+        # literal name contains %20 and is linked verbatim.
         assert "[the style guide](references/style%20guide.md)" in fixed
+        assert "[API notes](references/api%20notes.md)" in fixed
         assert len(fixed.splitlines()) == before_lines
         # Idempotent: second fix is byte-identical.
         _run_fix(repo, "--suggest")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2520,6 +2520,35 @@ class TestMarkdownAstRegressions:
         ]
         assert flagged == [], f"indented code lines were scanned as prose: {flagged}"
 
+    def test_percent_encoded_link_resolves_and_fix_stays_parseable(self, tmp_path):
+        """Regression for #322: a %20 link to a real file must not be
+        flagged, and the suggest fixer must percent-encode the destination
+        it emits — a raw space inside `](...)` silently destroys the link."""
+        repo = copy_fixture("regression/broken-ref-percent-encoding", tmp_path)
+        r = run_lint(repo)
+        broken = [v for v in violations(r) if v["rule_id"] == "content-broken-internal-reference"]
+        # Only the genuinely broken link fires; the working %20 link does not.
+        assert len(broken) == 1
+        assert "references/naming%20rles.md" in broken[0]["message"]
+        assert "did you mean" in broken[0]["message"]
+
+        before_lines = len((repo / "CLAUDE.md").read_text().splitlines())
+        _run_fix(repo, "--suggest")
+        fixed = (repo / "CLAUDE.md").read_text()
+        assert "[the naming rules](references/naming%20rules.md)" in fixed
+        assert "](references/naming rules.md)" not in fixed
+        # The working link is untouched.
+        assert "[the style guide](references/style%20guide.md)" in fixed
+        assert len(fixed.splitlines()) == before_lines
+        # Idempotent: second fix is byte-identical.
+        _run_fix(repo, "--suggest")
+        assert (repo / "CLAUDE.md").read_text() == fixed
+        # Re-lint: the emitted destination parses and resolves.
+        r2 = run_lint(repo)
+        assert not [
+            v for v in violations(r2) if v["rule_id"] == "content-broken-internal-reference"
+        ]
+
     def test_suppression_directive_inside_fence_not_honored(self, tmp_path):
         """A directive shown inside a fenced code block is documentation,
         not a directive — later violations must still be reported."""


### PR DESCRIPTION
## Bug

`content-broken-internal-reference` compared link destinations against the filesystem without URL-decoding them. A **working** percent-encoded link like `[x](references/style%20guide.md)` — where `references/style guide.md` exists on disk — was flagged as "target does not exist" (false positive).

Worse, `skillsaw fix --suggest` then rewrote the destination to `references/style guide.md` with a raw unescaped space, which markdown-it no longer parses as a link — **the link was silently destroyed**, and re-lint reported 0 violations because the rule only inspects parsed links.

Part of #322.

## Fix

- **`check()` URL-decodes the destination** (`urllib.parse.unquote`) before the existence check, so `%20` and other percent-escapes resolve correctly. Decoding is used only for the filesystem lookup — violation messages keep the original destination text.
- The decoded path also feeds `_find_similar()`, so fuzzy suggestions for broken encoded links match against real file names.
- **`fix()` percent-encodes the destination it splices in** (`urllib.parse.quote(suggestion, safe="/")`): suggesting a nearby file whose name contains a space (or another markdown-hostile character) can never again emit a destination markdown cannot parse. Plain paths pass through unchanged, and edits still go through `markdown_doc.splice` at the dest token span.
- Undecodable destinations (e.g. an embedded `%00`) are reported as broken instead of crashing path resolution.

With the false positive gone, no violation fires for a working encoded link, so no fix runs — verified end-to-end that the original corruption scenario now lints clean and `fix --suggest` leaves the file untouched.

## Tests

- Unit tests (`TestContentBrokenInternalReferenceRule`): working `%20` link → zero violations; genuinely broken `%20` link → violation with the original encoded text in the message; `%20` link with anchor → clean.
- Integration regression (`tests/fixtures/regression/broken-ref-percent-encoding` + `test_percent_encoded_link_resolves_and_fix_stays_parseable`): only the broken link fires; `fix --suggest` emits `references/naming%20rules.md` (encoded, parseable), leaves the working link untouched, preserves line counts, is idempotent (second fix byte-identical), and re-lint reports 0 violations for the rule.

## Checklist

- `make test` — 2246 passed
- `make lint` — clean
- `make update` — no generated-file changes
- Dogfood vs `openshift-eng/ai-helpers`: exits 1 with 27 `typo` warnings, but output is **byte-identical on main** (verified via stash/diff) — pre-existing drift in ai-helpers content, unrelated to this change; zero `content-broken-internal-reference` findings before or after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)