### PR TITLE
Fix four small confirmed bugs from the #322 sweep (custom-rule abstract guard, @~/ imports, stacked disable-next-line, docs crash)

### DIFF
--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -419,7 +419,10 @@ def _build_data(docs: DocsOutput) -> Dict[str, Any]:
     """Build the data structure for embedding as JSON."""
     plugins_data: List[Dict[str, Any]] = []
 
-    sorted_plugins = sorted(docs.plugins, key=lambda p: p.name.lower())
+    # ``p.name`` is manifest-derived and may be a non-string (e.g. a numeric
+    # ``"name": 123`` in plugin.json); coerce before ``.lower()`` so ``docs``
+    # doesn't crash on inputs ``lint`` tolerates.
+    sorted_plugins = sorted(docs.plugins, key=lambda p: str(p.name or "").lower())
 
     for plugin in sorted_plugins:
         p: Dict[str, Any] = {

--- a/src/skillsaw/docs/html_renderer.py
+++ b/src/skillsaw/docs/html_renderer.py
@@ -17,6 +17,7 @@ from skillsaw.docs.models import (
     PluginDoc,
     RuleFileDoc,
     SkillDoc,
+    name_str,
 )
 
 COLOR_THEMES = {
@@ -422,7 +423,7 @@ def _build_data(docs: DocsOutput) -> Dict[str, Any]:
     # ``p.name`` is manifest-derived and may be a non-string (e.g. a numeric
     # ``"name": 123`` in plugin.json); coerce before ``.lower()`` so ``docs``
     # doesn't crash on inputs ``lint`` tolerates.
-    sorted_plugins = sorted(docs.plugins, key=lambda p: str(p.name or "").lower())
+    sorted_plugins = sorted(docs.plugins, key=lambda p: name_str(p.name).lower())
 
     for plugin in sorted_plugins:
         p: Dict[str, Any] = {

--- a/src/skillsaw/docs/markdown_renderer.py
+++ b/src/skillsaw/docs/markdown_renderer.py
@@ -53,7 +53,7 @@ def _render_marketplace(docs: DocsOutput) -> Dict[str, str]:
     assert mp is not None
     pages: Dict[str, str] = {}
 
-    sorted_plugins = sorted(mp.plugins, key=lambda p: p.name.lower())
+    sorted_plugins = sorted(mp.plugins, key=lambda p: str(p.name or "").lower())
 
     # Index
     lines: List[str] = [f"# {mp.name or docs.title}", ""]
@@ -193,7 +193,7 @@ def _append_command(lines: List[str], cmd: CommandDoc) -> None:
 def _append_skills_section(lines: List[str], skills: List[SkillDoc]) -> None:
     lines.append("## Skills")
     lines.append("")
-    for skill in sorted(skills, key=lambda s: s.name.lower()):
+    for skill in sorted(skills, key=lambda s: str(s.name or "").lower()):
         lines.append(f"### {skill.name}")
         lines.append("")
         if skill.description:

--- a/src/skillsaw/docs/markdown_renderer.py
+++ b/src/skillsaw/docs/markdown_renderer.py
@@ -15,6 +15,7 @@ from skillsaw.docs.models import (
     PluginDoc,
     RuleFileDoc,
     SkillDoc,
+    name_str,
 )
 
 
@@ -53,7 +54,7 @@ def _render_marketplace(docs: DocsOutput) -> Dict[str, str]:
     assert mp is not None
     pages: Dict[str, str] = {}
 
-    sorted_plugins = sorted(mp.plugins, key=lambda p: str(p.name or "").lower())
+    sorted_plugins = sorted(mp.plugins, key=lambda p: name_str(p.name).lower())
 
     # Index
     lines: List[str] = [f"# {mp.name or docs.title}", ""]
@@ -193,7 +194,7 @@ def _append_command(lines: List[str], cmd: CommandDoc) -> None:
 def _append_skills_section(lines: List[str], skills: List[SkillDoc]) -> None:
     lines.append("## Skills")
     lines.append("")
-    for skill in sorted(skills, key=lambda s: str(s.name or "").lower()):
+    for skill in sorted(skills, key=lambda s: name_str(s.name).lower()):
         lines.append(f"### {skill.name}")
         lines.append("")
         if skill.description:
@@ -259,5 +260,5 @@ def _plugin_filename(plugin: PluginDoc) -> str:
     # ``plugin.name`` is manifest-derived and may be a non-string (e.g. a
     # numeric ``"name": 123`` in marketplace.json); coerce before calling
     # string methods so ``docs`` doesn't crash on inputs ``lint`` tolerates.
-    safe = str(plugin.name or "").replace("/", "-").replace(" ", "-")
+    safe = name_str(plugin.name).replace("/", "-").replace(" ", "-")
     return f"{safe}.md"

--- a/src/skillsaw/docs/markdown_renderer.py
+++ b/src/skillsaw/docs/markdown_renderer.py
@@ -256,5 +256,8 @@ def _append_rule(lines: List[str], rule: RuleFileDoc) -> None:
 
 
 def _plugin_filename(plugin: PluginDoc) -> str:
-    safe = plugin.name.replace("/", "-").replace(" ", "-")
+    # ``plugin.name`` is manifest-derived and may be a non-string (e.g. a
+    # numeric ``"name": 123`` in marketplace.json); coerce before calling
+    # string methods so ``docs`` doesn't crash on inputs ``lint`` tolerates.
+    safe = str(plugin.name or "").replace("/", "-").replace(" ", "-")
     return f"{safe}.md"

--- a/src/skillsaw/docs/models.py
+++ b/src/skillsaw/docs/models.py
@@ -105,3 +105,13 @@ class DocsOutput:
     marketplace: Optional[MarketplaceDoc] = None
     plugins: List[PluginDoc] = field(default_factory=list)
     skills: List[SkillDoc] = field(default_factory=list)
+
+
+def name_str(name: Any) -> str:
+    """Coerce a manifest-derived ``name`` to ``str`` for sorting and paths.
+
+    Names come from user JSON and may be non-strings (numeric, bool) or
+    absent.  Only ``None`` maps to ``""`` -- ``str(name or "")`` would
+    collapse valid falsy names like ``0`` to the empty string.
+    """
+    return "" if name is None else str(name)

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import inspect
 import logging
 import re
 import sys
@@ -319,7 +320,12 @@ class Linter:
         try:
             for name in dir(module):
                 obj = getattr(module, name)
-                if isinstance(obj, type) and issubclass(obj, Rule) and obj is not Rule:
+                if (
+                    isinstance(obj, type)
+                    and issubclass(obj, Rule)
+                    and obj is not Rule
+                    and not inspect.isabstract(obj)
+                ):
                     rule_instance = obj()
                     self._known_rule_ids.add(rule_instance.rule_id)
                     if self._rule_ids and rule_instance.rule_id not in self._rule_ids:

--- a/src/skillsaw/rules/builtin/instructions/imports_valid.py
+++ b/src/skillsaw/rules/builtin/instructions/imports_valid.py
@@ -50,6 +50,14 @@ class InstructionImportsValidRule(Rule):
                     continue
 
                 import_path_str = match.group(1)
+
+                # Home-directory imports (Claude Code's ``@~/.claude/...``
+                # memory syntax) reference machine-local files that are not
+                # part of the repository. They're environment-specific, so
+                # existence checking is always noise in CI — skip them.
+                if import_path_str.startswith("~"):
+                    continue
+
                 target = (context.root_path / import_path_str).resolve()
 
                 try:

--- a/src/skillsaw/suppression.py
+++ b/src/skillsaw/suppression.py
@@ -292,7 +292,20 @@ def build_suppression_map(
         line_directives = directive_at.get(content_line, [])
         for d in line_directives:
             if d.kind == "disable-next-line":
-                next_line_rules = d.rule_ids
+                # Stacked ``disable-next-line`` directives on consecutive
+                # lines all target the same next content line, so merge them
+                # rather than letting the last one overwrite the earlier ones
+                # (ESLint accumulates directives the same way). An empty rule
+                # list means "all rules"; if either directive suppresses
+                # everything, so does the merged suppression.
+                if next_line_rules is None:
+                    next_line_rules = list(d.rule_ids)
+                elif not next_line_rules or not d.rule_ids:
+                    next_line_rules = []
+                else:
+                    for rid in d.rule_ids:
+                        if rid not in next_line_rules:
+                            next_line_rules.append(rid)
             elif d.kind == "disable":
                 if d.rule_ids:
                     disabled.update(d.rule_ids)

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -706,6 +706,60 @@ class BrokenRule(Rule):
         Linter(context, config)
 
 
+def test_abstract_helper_rule_does_not_abort_file(valid_plugin, temp_dir):
+    """An abstract helper Rule subclass in a custom-rules file must be skipped,
+    not instantiated — otherwise the whole file is dropped (issue #322).
+
+    The builtin and plugin loaders already skip ``inspect.isabstract`` classes;
+    the custom-rule path must match, so a concrete rule sharing the file still
+    loads and runs.
+    """
+    custom_rule_file = temp_dir / "abstract_helper_rule.py"
+    custom_rule_file.write_text("""
+from abc import abstractmethod
+from skillsaw import Rule, RuleViolation, Severity, RepositoryContext
+from typing import List
+
+
+class BaseHelperRule(Rule):
+    # Abstract helper: subclasses share this scaffolding. Instantiating it
+    # would raise TypeError, which previously aborted the entire file.
+    @abstractmethod
+    def targets(self) -> List[str]:
+        ...
+
+    @property
+    def description(self) -> str:
+        return "shared helper description"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return [self.violation("helper violation")]
+
+
+class ConcreteHelperRule(BaseHelperRule):
+    @property
+    def rule_id(self) -> str:
+        return "concrete-helper-rule"
+
+    def targets(self) -> List[str]:
+        return ["*.md"]
+""")
+
+    config = LinterConfig(custom_rules=[str(custom_rule_file)])
+    context = RepositoryContext(valid_plugin)
+
+    linter = Linter(context, config)
+
+    rule_ids = [rule.rule_id for rule in linter.rules]
+    assert "concrete-helper-rule" in rule_ids
+
+    violations = linter.run()
+    assert any(v.rule_id == "concrete-helper-rule" for v in violations)
+
+
 def test_unknown_skip_rule_raises(valid_plugin):
     """A typo in --skip-rule must error, not silently leave the rule running."""
     context = RepositoryContext(valid_plugin)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -202,6 +202,29 @@ class TestExtractor:
         assert isinstance(plugin.version, str)
         assert plugin.version == ""
 
+    def test_render_numeric_plugin_name_does_not_crash(self, temp_dir):
+        """A numeric plugin name (e.g. ``"name": 123``) must not crash the
+        docs renderers, which sort plugins by ``name.lower()`` (issue #322).
+        ``lint`` tolerates this input, so ``docs`` must too.
+        """
+        plugin_dir = temp_dir / "numeric-name"
+        plugin_dir.mkdir()
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(
+            json.dumps({"name": 123, "description": "d", "version": "1.0"})
+        )
+
+        ctx = RepositoryContext(plugin_dir)
+        docs = extract_docs(ctx)
+        assert len(docs.plugins) == 1
+
+        # Neither renderer should raise AttributeError on the int name.
+        html_pages = render_html(docs)
+        assert "index.html" in html_pages
+        md_pages = render_markdown(docs)
+        assert md_pages
+
     def test_custom_title(self, valid_plugin):
         ctx = RepositoryContext(valid_plugin)
         docs = extract_docs(ctx, title="My Custom Title")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -11,6 +11,7 @@ from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.docs.extractor import extract_docs
 from skillsaw.docs.html_renderer import render_html, COLOR_THEMES
 from skillsaw.docs.markdown_renderer import render_markdown
+from skillsaw.docs.models import DocsOutput, MarketplaceDoc, PluginDoc
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -268,6 +269,27 @@ class TestExtractor:
         assert "README.md" in md_pages
         # The numeric-named plugin still gets a per-plugin page.
         assert "123.md" in md_pages
+
+    def test_render_falsy_plugin_name_preserved(self):
+        """A falsy-but-valid plugin name (``0``) must be preserved by the
+        renderers' name coercion, not collapsed to ``""`` the way
+        ``str(name or "")`` would (review feedback on issue #322 fixes).
+        Constructed directly because the extractor's name-resolution chain
+        substitutes a fallback before falsy names reach the renderers.
+        """
+        plugin = PluginDoc(name=0, path=Path("plugins/zero"), description="d")
+        docs = DocsOutput(
+            repo_type=RepositoryType.MARKETPLACE,
+            title="t",
+            marketplace=MarketplaceDoc(name="m", plugins=[plugin]),
+            plugins=[plugin],
+        )
+        md_pages = render_markdown(docs)
+        # Preserved as "0", not collapsed to "" (which would yield ".md").
+        assert "0.md" in md_pages
+        assert ".md" not in md_pages
+        html_pages = render_html(docs)
+        assert "index.html" in html_pages
 
     def test_custom_title(self, valid_plugin):
         ctx = RepositoryContext(valid_plugin)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -225,6 +225,50 @@ class TestExtractor:
         md_pages = render_markdown(docs)
         assert md_pages
 
+    def test_render_numeric_marketplace_plugin_name_does_not_crash(self, temp_dir):
+        """A numeric plugin name in marketplace.json must not crash the docs
+        renderers either: the marketplace markdown path derives per-plugin
+        page filenames from ``plugin.name`` string methods (issue #322).
+        """
+        claude_dir = temp_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "test-marketplace",
+                    "owner": {"name": "Owner"},
+                    "plugins": [
+                        {
+                            "name": "alpha",
+                            "source": "./plugins/alpha",
+                            "description": "A well-formed plugin",
+                        },
+                        {
+                            "name": 123,
+                            "source": "./plugins/beta",
+                            "description": "Numeric name",
+                        },
+                    ],
+                }
+            )
+        )
+        for dirname, name in (("alpha", "alpha"), ("beta", 123)):
+            plugin_dir = temp_dir / "plugins" / dirname / ".claude-plugin"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "plugin.json").write_text(
+                json.dumps({"name": name, "description": "d", "version": "1.0"})
+            )
+
+        ctx = RepositoryContext(temp_dir)
+        docs = extract_docs(ctx)
+
+        html_pages = render_html(docs)
+        assert "index.html" in html_pages
+        md_pages = render_markdown(docs)
+        assert "README.md" in md_pages
+        # The numeric-named plugin still gets a per-plugin page.
+        assert "123.md" in md_pages
+
     def test_custom_title(self, valid_plugin):
         ctx = RepositoryContext(valid_plugin)
         docs = extract_docs(ctx, title="My Custom Title")

--- a/tests/test_instruction_file_rules.py
+++ b/tests/test_instruction_file_rules.py
@@ -167,6 +167,23 @@ class TestInstructionImportsValidRule:
         assert len(violations) == 1
         assert "escapes" in violations[0].message.lower()
 
+    def test_home_import_not_checked(self, temp_dir):
+        # Claude Code's ``@~/.claude/...`` memory syntax points at
+        # machine-local files that aren't in the repo. Existence checking
+        # them is always noise in CI, so they must be skipped (issue #322).
+        (temp_dir / "CLAUDE.md").write_text("# Instructions\n\n@~/.claude/my-file.md\n")
+        context = RepositoryContext(temp_dir)
+        violations = InstructionImportsValidRule().check(context)
+        assert len(violations) == 0
+
+    def test_home_import_skipped_but_relative_still_fails(self, temp_dir):
+        content = "# Instructions\n@~/.claude/env-specific.md\n@docs/missing.md\n"
+        (temp_dir / "CLAUDE.md").write_text(content)
+        context = RepositoryContext(temp_dir)
+        violations = InstructionImportsValidRule().check(context)
+        assert len(violations) == 1
+        assert "missing.md" in violations[0].message
+
     def test_import_with_leading_whitespace(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("  @nonexistent.md\n")
         context = RepositoryContext(temp_dir)

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -131,6 +131,38 @@ class TestBuildSuppressionMap:
         assert not smap.is_suppressed("content-weak-language", 3)
         assert not smap.is_suppressed("content-tautological", 3)
 
+    def test_stacked_disable_next_line_merges_rules(self):
+        """Consecutive disable-next-line directives accumulate onto the next
+        content line rather than the last overwriting the earlier (issue #322).
+        """
+        content = (
+            "<!-- skillsaw-disable-next-line content-weak-language -->\n"
+            "<!-- skillsaw-disable-next-line content-tautological -->\n"
+            "Try to write clean code.\n"
+            "Try to write clean code again.\n"
+        )
+        smap = build_suppression_map(content)
+        # Both rules are suppressed on line 3 (the next content line).
+        assert smap.is_suppressed("content-weak-language", 3)
+        assert smap.is_suppressed("content-tautological", 3)
+        # Line 4 is unaffected.
+        assert not smap.is_suppressed("content-weak-language", 4)
+        assert not smap.is_suppressed("content-tautological", 4)
+
+    def test_stacked_disable_next_line_bare_suppresses_all(self):
+        """A bare disable-next-line stacked with a specific one still suppresses
+        everything on the next line (empty rule list means 'all rules')."""
+        content = (
+            "<!-- skillsaw-disable-next-line content-weak-language -->\n"
+            "<!-- skillsaw-disable-next-line -->\n"
+            "Try to write clean code.\n"
+            "Try to write clean code again.\n"
+        )
+        smap = build_suppression_map(content)
+        assert smap.is_suppressed("content-weak-language", 3)
+        assert smap.is_suppressed("content-tautological", 3)
+        assert not smap.is_suppressed("content-weak-language", 4)
+
     def test_disable_next_line_no_rules_suppresses_all(self):
         """Bare <!-- skillsaw-disable-next-line --> suppresses all rules on the next line."""
         content = (

--- a/tests/test_suppression.py
+++ b/tests/test_suppression.py
@@ -151,17 +151,21 @@ class TestBuildSuppressionMap:
 
     def test_stacked_disable_next_line_bare_suppresses_all(self):
         """A bare disable-next-line stacked with a specific one still suppresses
-        everything on the next line (empty rule list means 'all rules')."""
-        content = (
+        everything on the next line (empty rule list means 'all rules'),
+        regardless of directive order. The bare-first order is the real
+        regression case: last-wins overwrote the suppress-all with the
+        explicit directive's rule list."""
+        for stack in (
             "<!-- skillsaw-disable-next-line content-weak-language -->\n"
+            "<!-- skillsaw-disable-next-line -->\n",
             "<!-- skillsaw-disable-next-line -->\n"
-            "Try to write clean code.\n"
-            "Try to write clean code again.\n"
-        )
-        smap = build_suppression_map(content)
-        assert smap.is_suppressed("content-weak-language", 3)
-        assert smap.is_suppressed("content-tautological", 3)
-        assert not smap.is_suppressed("content-weak-language", 4)
+            "<!-- skillsaw-disable-next-line content-weak-language -->\n",
+        ):
+            content = stack + "Try to write clean code.\nTry to write clean code again.\n"
+            smap = build_suppression_map(content)
+            assert smap.is_suppressed("content-weak-language", 3)
+            assert smap.is_suppressed("content-tautological", 3)
+            assert not smap.is_suppressed("content-weak-language", 4)
 
     def test_disable_next_line_no_rules_suppresses_all(self):
         """Bare <!-- skillsaw-disable-next-line --> suppresses all rules on the next line."""


### PR DESCRIPTION
Part of #322 — four small, independent, confirmed bugs, each a minimal guard plus a regression test.

- **Custom-rule loader aborts on abstract helper classes** (`src/skillsaw/linter.py`): the builtin and plugin loaders skip `inspect.isabstract()` classes, but the custom-rule path instantiated every `Rule` subclass. An abstract helper base in a custom-rules file raised `TypeError` and dropped the *entire* file. Fix: add the same `inspect.isabstract()` guard so abstract helpers are skipped and concrete rules in the file still load and run.

- **`instruction-imports-valid` false-positives on `@~/` home imports** (`src/skillsaw/rules/builtin/instructions/imports_valid.py`): Claude Code's documented `@~/.claude/my-file.md` memory syntax was flagged as broken because the target was resolved against the repo root. These imports reference machine-local, environment-specific files not present in CI, so existence checking is always noise. Fix: skip existence checking for `~`-prefixed imports. Regular broken relative imports still fire.

- **Consecutive `skillsaw-disable-next-line` directives — first silently discarded** (`src/skillsaw/suppression.py`): stacking two `disable-next-line` comments on consecutive lines overwrote the pending rule set with the last directive's, so the first was lost. Fix: merge (union) stacked directives onto the next content line, ESLint-style, preserving the codebase's "empty rule list means all rules" semantic (a bare directive in the stack still suppresses everything).

- **`skillsaw docs` crashes on non-string plugin name** (`src/skillsaw/docs/html_renderer.py`, `src/skillsaw/docs/markdown_renderer.py`): a numeric `"name": 123` in plugin.json raised `AttributeError` in the `sorted(..., key=lambda p: p.name.lower())` sort keys. `lint` tolerates this input; only `docs` crashed. Fix: coerce with `str(p.name or "").lower()` in all three affected sort keys (plugins in both renderers, and the markdown skills sort).

Each fix has a regression test extending the existing suites (`tests/test_custom_rules.py`, `tests/test_instruction_file_rules.py`, `tests/test_suppression.py`, `tests/test_docs.py`). Full suite (2245 tests) passes, `make lint` clean, `make update` produced no generated-file changes. Dogfooded against openshift-eng/ai-helpers: skillsaw runs without crashing and none of the touched rules fire (its non-zero exit is pre-existing `typo` warnings under its own `strict` config, unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when generating documentation so items with non-text names no longer cause crashes.
  * Fixed sorting and filename handling for documentation pages when names are numeric or otherwise non-string.
  * Made custom rule loading more robust so abstract helper rules won’t stop valid rules from being processed.
  * Updated import validation to ignore machine-local home-directory imports while still reporting real missing-file issues.
  * Corrected stacked suppression directives so multiple next-line rules combine properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->