### PR TITLE
agentskill-name autofix: don't fold inline YAML comments into the rename manifest

### DIFF
--- a/src/skillsaw/rules/builtin/agentskills/name.py
+++ b/src/skillsaw/rules/builtin/agentskills/name.py
@@ -16,9 +16,13 @@ from skillsaw.utils import frontmatter_text, parse_frontmatter, replace_frontmat
 from ._helpers import NAME_PATTERN, CONSECUTIVE_HYPHENS, _to_kebab, _add_rename
 
 
-def _inline_comment(name_line: str) -> str:
-    """Return the inline YAML comment on a raw ``name: ...`` line (with its
-    leading whitespace), or ``""`` when there is none.
+def _parse_name_line(name_line: str):
+    """Parse a raw ``name: ...`` line into ``(value, comment_suffix)``.
+
+    ``value`` is the scalar parsed from the line alone (``None`` when the
+    line is not a one-line ``name`` mapping — e.g. a block-scalar indicator
+    like ``name: >-`` or an empty ``name:``).  ``comment_suffix`` is the
+    inline YAML comment with its leading whitespace, or ``""``.
 
     A ``#`` inside a quoted scalar (``name: "a#b"``) is part of the value,
     so the line is parsed as YAML rather than regex-split on ``#``.
@@ -28,20 +32,21 @@ def _inline_comment(name_line: str) -> str:
     try:
         data = ry.load(name_line)
     except _RuamelYAMLError:
-        return ""
+        return None, ""
     if not isinstance(data, CommentedMap):
-        return ""
+        return None, ""
+    value = data.get("name")
     tokens = data.ca.items.get("name")
     comment = tokens[2] if tokens and len(tokens) > 2 else None
     if comment is None:
-        return ""
+        return value, ""
     start = comment.start_mark.column
     while start > 0 and name_line[start - 1] in " \t":
         start -= 1
     suffix = name_line[start:]
     if suffix and suffix[0] not in " \t":
         suffix = " " + suffix
-    return suffix
+    return value, suffix
 
 
 class AgentSkillNameRule(Rule):
@@ -147,9 +152,27 @@ class AgentSkillNameRule(Rule):
                 continue
             fm_text = frontmatter_text(original) or ""
             line_match = re.search(r"^name[ \t]*:[^\r\n]*", fm_text, re.MULTILINE)
-            comment = _inline_comment(line_match.group(0)) if line_match else ""
+            if not line_match:
+                continue
+            line_value, comment = _parse_name_line(line_match.group(0))
+            # The rewrite replaces exactly one line, so it is only safe when
+            # the whole value lives on that line.  A block scalar
+            # (``name: >-``), a value on the following line, or a duplicate
+            # ``name:`` key (PyYAML is last-wins, the regex is first-match)
+            # all make the line value differ from the parsed value — rewriting
+            # the key line would merge the leftover continuation lines into
+            # the new scalar and corrupt the frontmatter.  Skip those.
+            if line_value != old_name:
+                continue
             fixed = replace_frontmatter_field(original, "name", f"name: {new_name}{comment}")
             if fixed is None:
+                continue
+            # Convergence guard: the rewritten frontmatter must actually
+            # parse to the new name (duplicate identical ``name:`` keys pass
+            # the line-value check above but PyYAML still resolves to the
+            # untouched later key, so the fix would churn forever).
+            new_fm, _new_body, _new_err = parse_frontmatter(fixed)
+            if not new_fm or new_fm.get("name") != new_name:
                 continue
 
             def _record_rename(root=context.root_path, old=old_name, new=new_name):

--- a/src/skillsaw/rules/builtin/agentskills/name.py
+++ b/src/skillsaw/rules/builtin/agentskills/name.py
@@ -11,7 +11,12 @@ from skillsaw.rule import Rule, RuleViolation, AutofixResult, AutofixConfidence,
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import SkillNode
 from skillsaw.rules.builtin.content_analysis import SkillBlock
-from skillsaw.utils import frontmatter_text, parse_frontmatter, replace_frontmatter_field
+from skillsaw.utils import (
+    frontmatter_text,
+    parse_frontmatter,
+    read_text,
+    replace_frontmatter_field,
+)
 
 from ._helpers import NAME_PATTERN, CONSECUTIVE_HYPHENS, _to_kebab, _add_rename
 
@@ -135,7 +140,14 @@ class AgentSkillNameRule(Rule):
         for v in violations:
             if not v.file_path or not v.file_path.exists():
                 continue
-            original = v.file_path.read_text(encoding="utf-8")
+            # utils.read_text strips a UTF-8 BOM (utf-8-sig); a raw
+            # read_text(encoding="utf-8") would keep the stray U+FEFF, which
+            # prevents parse_frontmatter's anchored ^--- match and silently
+            # skips the fix for BOM files.  write_text_preserving restores
+            # the BOM at apply time.
+            original = read_text(v.file_path)
+            if original is None:
+                continue
             # The old name must be the parsed YAML value the violation was
             # raised against — a raw-line slice would fold an inline comment
             # (``name: Deploy_Service # legacy``) into the rename manifest

--- a/src/skillsaw/rules/builtin/agentskills/name.py
+++ b/src/skillsaw/rules/builtin/agentskills/name.py
@@ -3,12 +3,45 @@
 import re
 from typing import List
 
+from ruamel.yaml import YAML as _RuamelYAML
+from ruamel.yaml import YAMLError as _RuamelYAMLError
+from ruamel.yaml.comments import CommentedMap
+
 from skillsaw.rule import Rule, RuleViolation, AutofixResult, AutofixConfidence, Severity
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import SkillNode
 from skillsaw.rules.builtin.content_analysis import SkillBlock
+from skillsaw.utils import frontmatter_text, parse_frontmatter, replace_frontmatter_field
 
 from ._helpers import NAME_PATTERN, CONSECUTIVE_HYPHENS, _to_kebab, _add_rename
+
+
+def _inline_comment(name_line: str) -> str:
+    """Return the inline YAML comment on a raw ``name: ...`` line (with its
+    leading whitespace), or ``""`` when there is none.
+
+    A ``#`` inside a quoted scalar (``name: "a#b"``) is part of the value,
+    so the line is parsed as YAML rather than regex-split on ``#``.
+    """
+    ry = _RuamelYAML()
+    ry.preserve_quotes = True
+    try:
+        data = ry.load(name_line)
+    except _RuamelYAMLError:
+        return ""
+    if not isinstance(data, CommentedMap):
+        return ""
+    tokens = data.ca.items.get("name")
+    comment = tokens[2] if tokens and len(tokens) > 2 else None
+    if comment is None:
+        return ""
+    start = comment.start_mark.column
+    while start > 0 and name_line[start - 1] in " \t":
+        start -= 1
+    suffix = name_line[start:]
+    if suffix and suffix[0] not in " \t":
+        suffix = " " + suffix
+    return suffix
 
 
 class AgentSkillNameRule(Rule):
@@ -98,17 +131,26 @@ class AgentSkillNameRule(Rule):
             if not v.file_path or not v.file_path.exists():
                 continue
             original = v.file_path.read_text(encoding="utf-8")
-            match = re.search(r"^name:\s*(.+)$", original, re.MULTILINE)
-            if not match:
+            # The old name must be the parsed YAML value the violation was
+            # raised against — a raw-line slice would fold an inline comment
+            # (``name: Deploy_Service # legacy``) into the rename manifest
+            # and the kebab-cased replacement (issue #322).
+            fm, _body, _err = parse_frontmatter(original)
+            old_name = fm.get("name") if fm else None
+            if not isinstance(old_name, str) or not old_name:
                 continue
-            old_name = match.group(1).strip()
             if "does not match directory" in v.message:
                 new_name = v.file_path.parent.name
             else:
                 new_name = _to_kebab(old_name)
             if new_name == old_name or not NAME_PATTERN.match(new_name):
                 continue
-            fixed = original[: match.start()] + f"name: {new_name}" + original[match.end() :]
+            fm_text = frontmatter_text(original) or ""
+            line_match = re.search(r"^name[ \t]*:[^\r\n]*", fm_text, re.MULTILINE)
+            comment = _inline_comment(line_match.group(0)) if line_match else ""
+            fixed = replace_frontmatter_field(original, "name", f"name: {new_name}{comment}")
+            if fixed is None:
+                continue
 
             def _record_rename(root=context.root_path, old=old_name, new=new_name):
                 _add_rename(root, old, new)

--- a/tests/fixtures/autofix/name-inline-comment/CLAUDE.md
+++ b/tests/fixtures/autofix/name-inline-comment/CLAUDE.md
@@ -1,0 +1,11 @@
+# Deployment Skills
+
+This repository packages the deployment automation skills our team shares
+across services. Each skill lives in its own directory with a `SKILL.md`
+describing when to use it.
+
+## Conventions
+
+- Keep skill instructions imperative and concise.
+- Update the Deploy_Service skill whenever the rollout pipeline changes.
+- Run the release#tagger skill before cutting a release branch.

--- a/tests/fixtures/autofix/name-inline-comment/deploy-service/SKILL.md
+++ b/tests/fixtures/autofix/name-inline-comment/deploy-service/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: Deploy_Service # legacy name kept for docs
+description: Use this skill when deploying a service through the rollout pipeline
+---
+
+# Deploy Service
+
+Deploys a service by rendering the rollout manifest and applying it to the
+target cluster. Verify the health checks pass before promoting the release.

--- a/tests/fixtures/autofix/name-inline-comment/release-tagger/SKILL.md
+++ b/tests/fixtures/autofix/name-inline-comment/release-tagger/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: "release#tagger" # hash is part of the quoted value, not a comment
+description: Use this skill when tagging a release for the deployment pipeline
+---
+
+# Release Tagger
+
+Tags the current commit with the next release version and pushes the tag to
+the shared remote so the deployment pipeline can pick it up.

--- a/tests/fixtures/autofix/name-multiline-scalar/CLAUDE.md
+++ b/tests/fixtures/autofix/name-multiline-scalar/CLAUDE.md
@@ -1,0 +1,10 @@
+# Pipeline Skills
+
+This repository collects the CI pipeline skills our team maintains. Each
+skill lives in its own directory with a `SKILL.md` describing when to use it.
+
+## Conventions
+
+- Keep skill instructions imperative and concise.
+- Skills that predate the naming convention are being migrated gradually;
+  do not rename a skill without updating its pipeline references.

--- a/tests/fixtures/autofix/name-multiline-scalar/dup-keys/SKILL.md
+++ b/tests/fixtures/autofix/name-multiline-scalar/dup-keys/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: First_Name
+name: Second_Name
+description: Use this skill when auditing duplicate pipeline definitions
+---
+
+# Duplicate Keys
+
+Audits the pipeline configuration for duplicate stage definitions.

--- a/tests/fixtures/autofix/name-multiline-scalar/folded-name/SKILL.md
+++ b/tests/fixtures/autofix/name-multiline-scalar/folded-name/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: >-
+  Folded_Name
+description: Use this skill when validating the folded rollout manifest
+---
+
+# Folded Name
+
+Validates the rollout manifest before it is applied to the target cluster.

--- a/tests/fixtures/autofix/name-multiline-scalar/next-line/SKILL.md
+++ b/tests/fixtures/autofix/name-multiline-scalar/next-line/SKILL.md
@@ -1,0 +1,9 @@
+---
+name:
+  Next_Line_Name
+description: Use this skill when promoting a build through the pipeline
+---
+
+# Next Line Name
+
+Promotes a build artifact through the staging pipeline to production.

--- a/tests/fixtures/autofix/safe-idempotency/skills/legacy-deploy/SKILL.md
+++ b/tests/fixtures/autofix/safe-idempotency/skills/legacy-deploy/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: Legacy_Deploy # kept from the v1 pipeline
+description: Skill that handles legacy deployment workflows
+---
+
+# Legacy Deploy
+
+Deploys legacy services using the v1 pipeline configuration.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1909,7 +1909,7 @@ class TestSafeAutofixIdempotency:
 
     EXPECTED_SAFE_VIOLATIONS = {
         "agent-frontmatter": 3,
-        "agentskill-name": 3,
+        "agentskill-name": 4,
         "agentskill-valid": 4,
         "command-frontmatter": 3,
         "content-unlinked-internal-reference": 23,
@@ -2092,6 +2092,10 @@ class TestSafeAutofixIdempotency:
                 len(name_lines) == 1
             ), f"SKILL.md in {skill_dir.name} has {len(name_lines)} name: lines"
             name_val = name_lines[0].split(":", 1)[1].strip()
+            # The fixed line may keep the user's inline YAML comment (GH-322);
+            # post-fix names are plain kebab-case scalars, so a simple split
+            # is safe here.
+            name_val = name_val.split(" #", 1)[0].strip()
             assert (
                 name_val == skill_dir.name
             ), f"SKILL.md name '{name_val}' does not match dir '{skill_dir.name}'"
@@ -2641,3 +2645,81 @@ class TestRenameRefsAutofix:
         r = run_lint(repo)
         stale = [v for v in violations(r) if v["rule_id"] == "agentskill-rename-refs"]
         assert stale == [], f"phantom rename-refs violations after dry-run: {stale}"
+
+
+# ── agentskill-name autofix vs inline YAML comments (GH-322) ─────
+
+
+@pytest.mark.integration
+class TestNameAutofixInlineComment:
+    """Regression tests for GH-322: the agentskill-name autofix must record
+    the parsed YAML value of ``name`` in the rename manifest — never a raw
+    line slice that folds an inline comment into the old name — and must
+    preserve the user's inline comment on the rewritten line."""
+
+    FIXTURE = "autofix/name-inline-comment"
+
+    def test_rename_manifest_records_parsed_name(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        _run_fix(repo)
+
+        manifest = json.loads((repo / ".skillsaw-renames.json").read_text())
+        renames = {r["old"]: r["new"] for r in manifest["renames"]}
+        assert (
+            renames.get("Deploy_Service") == "deploy-service"
+        ), f"manifest must key on the parsed YAML name, got: {renames}"
+        assert not any(
+            "legacy" in old or " #" in old for old in renames
+        ), f"inline comment text leaked into the rename manifest: {renames}"
+
+    def test_inline_comment_preserved_on_rewritten_line(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        _run_fix(repo)
+
+        skill_md = (repo / "deploy-service" / "SKILL.md").read_text()
+        assert "name: deploy-service # legacy name kept for docs" in skill_md
+
+    def test_hash_inside_quoted_value_is_not_a_comment(self, tmp_path):
+        """A ``#`` inside a quoted scalar is part of the value: the manifest
+        must record ``release#tagger`` and the trailing comment must survive."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        _run_fix(repo)
+
+        skill_md = (repo / "release-tagger" / "SKILL.md").read_text()
+        assert "name: release-tagger # hash is part of the quoted value, not a comment" in skill_md
+        manifest = json.loads((repo / ".skillsaw-renames.json").read_text())
+        renames = {r["old"]: r["new"] for r in manifest["renames"]}
+        assert renames.get("release#tagger") == "release-tagger"
+
+    def test_manifest_enables_stale_reference_detection(self, tmp_path):
+        """With a clean manifest key, rename-refs can now see the stale
+        ``Deploy_Service`` reference in CLAUDE.md (the polluted key never
+        matched anything)."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        _run_fix(repo)
+
+        r = run_lint(repo)
+        stale = [
+            v
+            for v in violations(r)
+            if v["rule_id"] == "agentskill-rename-refs" and "Deploy_Service" in v["message"]
+        ]
+        assert stale, "rename-refs should detect the stale Deploy_Service reference"
+
+    def test_fix_is_idempotent_and_converges(self, tmp_path):
+        """Fix twice: byte-identical content, and re-lint shows zero
+        remaining agentskill-name violations."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        _run_fix(repo)
+        baseline = _snapshot_contents(repo)
+
+        _run_fix(repo)
+        assert _snapshot_contents(repo) == baseline, "second fix run changed content"
+
+        r = run_lint(repo)
+        remaining = [v for v in violations(r) if v["rule_id"] == "agentskill-name"]
+        assert remaining == [], f"agentskill-name violations remain after fix: {remaining}"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2723,3 +2723,60 @@ class TestNameAutofixInlineComment:
         r = run_lint(repo)
         remaining = [v for v in violations(r) if v["rule_id"] == "agentskill-name"]
         assert remaining == [], f"agentskill-name violations remain after fix: {remaining}"
+
+
+# ── agentskill-name autofix vs multi-line scalars & duplicate keys ─────
+
+
+@pytest.mark.integration
+class TestNameAutofixMultilineScalar:
+    """The one-line ``name:`` rewrite is only safe when the whole value lives
+    on that line.  Block scalars (``name: >-``), values on the following
+    line, and duplicate ``name:`` keys must be skipped verbatim — rewriting
+    just the key line merges the leftover continuation lines into the new
+    plain scalar, and the fix loop then re-kebabs the merged value on every
+    pass, growing the name unboundedly and poisoning the rename manifest."""
+
+    FIXTURE = "autofix/name-multiline-scalar"
+
+    def test_exotic_scalars_are_left_byte_identical(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        before = _snapshot_contents(repo)
+
+        _run_fix(repo)
+
+        after = _snapshot_contents(repo)
+        skills = [k for k in before if k.endswith("SKILL.md")]
+        assert skills, "fixture must contain SKILL.md files"
+        changed = [k for k in skills if before[k] != after.get(k)]
+        assert changed == [], f"fixer rewrote multi-line/duplicate name scalars: {changed}"
+
+    def test_no_manifest_entries_for_skipped_fixes(self, tmp_path):
+        """A skipped fix must not record a rename — especially not one whose
+        old name is a runaway concatenation of continuation lines."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        _run_fix(repo)
+
+        manifest_path = repo / ".skillsaw-renames.json"
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text())
+            olds = [r["old"] for r in manifest.get("renames", [])]
+            assert olds == [], f"skipped fixes recorded renames: {olds}"
+
+    def test_fix_converges_and_violations_still_reported(self, tmp_path):
+        """Skipped shapes stay skipped: a second fix run changes nothing, and
+        the violations remain for the user to resolve manually."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        _run_fix(repo)
+        baseline = _snapshot_contents(repo)
+
+        result = _run_fix(repo)
+        assert _snapshot_contents(repo) == baseline, "second fix run changed content"
+        assert "No auto-fixable violations found" in result.stdout
+
+        r = run_lint(repo)
+        remaining = {v["file_path"] for v in violations(r) if v["rule_id"] == "agentskill-name"}
+        assert any("folded-name" in f for f in remaining)
+        assert any("next-line" in f for f in remaining)
+        assert any("dup-keys" in f for f in remaining)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1890,6 +1890,29 @@ class TestEncodingPreservingAutofix:
         assert r["rc"] == 0
         assert "agentskill-valid" not in rule_ids(r)
 
+    def test_bom_name_fix_applies_and_preserves_bom(self, tmp_path):
+        """agentskill-name's fix must read via the BOM-stripping utils
+        reader: a raw utf-8 read keeps U+FEFF, parse_frontmatter's anchored
+        ^--- match fails, and the fix silently skips BOM files while the
+        violation stays reported."""
+        repo = tmp_path / "bom-name"
+        skill_dir = repo / ".claude" / "skills" / "deploy-service"
+        skill_dir.mkdir(parents=True)
+        target = skill_dir / "SKILL.md"
+        target.write_bytes(
+            b"\xef\xbb\xbf---\nname: Deploy_Service # legacy\n"
+            b"description: a deploy skill for bom testing purposes\n---\nbody\n"
+        )
+
+        _run_fix(repo)
+
+        raw = target.read_bytes()
+        assert raw.startswith(b"\xef\xbb\xbf")  # BOM preserved
+        assert b"name: deploy-service # legacy" in raw  # fixed, comment kept
+        # Converges: re-lint is clean for the rule.
+        r = run_lint(repo, "--rule", "agentskill-name")
+        assert "agentskill-name" not in rule_ids(r)
+
 
 @pytest.mark.integration
 class TestSafeAutofixIdempotency:


### PR DESCRIPTION
## The bug

The `agentskill-name` fixer re-extracted the raw frontmatter line with `re.search(r"^name:\s*(.+)$", ...)` and took `match.group(1).strip()` as the old name. Given:

```yaml
name: Deploy_Service # legacy
```

it recorded `"Deploy_Service # legacy"` as the old name in `.skillsaw-renames.json`, kebab-cased the comment text into the replacement value, and silently deleted the user's comment. Because the manifest key was polluted, `agentskill-rename-refs` could never match real stale references to `Deploy_Service`.

## The fix

- The old name now comes from the **parsed YAML frontmatter** (`parse_frontmatter`) — the same value `check()` raised the violation against — never a raw-line slice.
- The rewritten line **preserves the inline comment**: `name: Deploy_Service # legacy` becomes `name: deploy-service # legacy`. Comment extraction parses the line with ruamel instead of splitting on `#`, so a hash inside a quoted scalar (`name: "release#tagger"`) is correctly kept as part of the value.
- The line replacement is now scoped to the frontmatter via `replace_frontmatter_field()` instead of a whole-file `MULTILINE` search, so a `name:` line in the body can no longer be clobbered.

## Tests

- Added an inline-comment skill to the `safe-idempotency` fixture (guarded by `TestSafeAutofixIdempotency`; `EXPECTED_SAFE_VIOLATIONS` for `agentskill-name` bumped 3 → 4).
- New `TestNameAutofixInlineComment` regression suite with the `autofix/name-inline-comment` fixture: manifest records the clean parsed name, comment survives the rewrite, quoted `#` is not treated as a comment, `agentskill-rename-refs` now detects stale references through the clean manifest, and fix is idempotent (fix twice → byte-identical) and converges.

`make test` (2248 passed), `make lint`, `make update` all clean. Dogfooded against `openshift-eng/ai-helpers`: lint output identical to main (same violations, same exit code — the nonzero exit is pre-existing on main from typo warnings under its `strict: true` config).

Part of #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic `agentskill-name` renaming to preserve UTF-8 BOM prefixes and keep inline comments intact.
  * Made the rename logic safer by avoiding rewrites for complex frontmatter shapes (e.g., multiline/block scalars, continuation values, duplicate `name` entries) and preventing incorrect parsing.
  * Ensured autofixes converge reliably without repeated churn.

* **Tests**
  * Added broader integration coverage for BOM/encoding preservation, inline-comment behavior, quoted `#` handling, and safe-idempotency expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->