### PR TITLE
Fix **-glob exclude semantics: **/templates/** now matches top-level templates/

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ exclude:
   - "node_modules/**"
 ```
 
+Patterns match against the file path relative to the lint root using
+Python `fnmatch` syntax, where `*` also crosses `/`. A leading `**/`
+additionally matches at the root of the repository, so `**/templates/**`
+excludes both a top-level `templates/` directory and any nested
+`a/templates/`.
+
 By default, skillsaw excludes `**/template/**`, `**/templates/**`, and
 `**/_template/**` directories. These defaults are replaced when you specify
 your own `exclude` list.

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ These rules validate skills against the [agentskills.io specification](https://a
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`) as referencing every file under it | `true` |
-| `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
+| `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names; a leading `**/` also matches at the skill root) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
 
 ### Plugin Structure
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,12 @@ exclude:
   - "node_modules/**"
 ```
 
+Patterns match against the file path relative to the lint root using
+Python `fnmatch` syntax, where `*` also crosses `/`. A leading `**/`
+additionally matches at the root of the repository, so `**/templates/**`
+excludes both a top-level `templates/` directory and any nested
+`a/templates/`.
+
 By default, skillsaw excludes `**/template/**`, `**/templates/**`, and
 `**/_template/**` directories. These defaults are replaced when you specify
 your own `exclude` list.

--- a/docs/rules/agentskill-unreferenced-files.md
+++ b/docs/rules/agentskill-unreferenced-files.md
@@ -113,7 +113,7 @@ rules:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`) as referencing every file under it | `true` |
-| `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
+| `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names; a leading `**/` also matches at the skill root) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
 
 
 *Run `skillsaw explain agentskill-unreferenced-files` to see this documentation and the rule's effective configuration in your terminal.*

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -5,9 +5,10 @@ Repository context detection and management
 from __future__ import annotations
 
 import fnmatch
+import functools
 from enum import Enum
 from pathlib import Path
-from typing import Iterator, Optional, List, Dict, Any, Set, TYPE_CHECKING
+from typing import Iterator, Optional, List, Dict, Any, Set, Tuple, TYPE_CHECKING
 import json
 import logging
 import os
@@ -23,8 +24,36 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@functools.lru_cache(maxsize=None)
+def _pattern_variants(pattern: str) -> Tuple[str, ...]:
+    """Expand *pattern* into the fnmatch patterns it is tried as.
+
+    :mod:`fnmatch` has no special handling for ``**`` — it behaves exactly
+    like ``*`` (which already crosses ``/``) — so a leading ``**/`` demands
+    at least one directory before the rest of the pattern and never matches
+    at the start of a relative path: ``**/templates/**`` misses a top-level
+    ``templates/``. To honor gitignore-style semantics where ``**/`` also
+    matches zero leading directories, a variant with the ``**/`` prefix
+    stripped is tried as well. A trailing ``/**`` needs no variant: ``*``
+    crosses ``/``, so it already matches the directory's contents at any
+    depth. The original pattern is always kept, making the expansion a
+    strict superset of plain fnmatch — every path a pattern matched before
+    still matches.
+    """
+    variants = [pattern]
+    if pattern.startswith("**/"):
+        variants.append(pattern[3:])
+    return tuple(variants)
+
+
 def path_matches_patterns(path: Path, root: Path, patterns: List[str]) -> bool:
     """True if *path*, made relative to *root*, matches any fnmatch pattern.
+
+    Patterns use :mod:`fnmatch` syntax where ``*`` crosses ``/``, extended
+    with one gitignore-style rule via :func:`_pattern_variants`: a leading
+    ``**/`` also matches at the start of the relative path, so
+    ``**/templates/**`` excludes both a top-level ``templates/`` and a
+    nested ``a/templates/``.
 
     The single exclusion predicate shared by the context, the lint tree, and
     the linter's per-rule excludes. *root* must be resolved; paths outside
@@ -36,7 +65,9 @@ def path_matches_patterns(path: Path, root: Path, patterns: List[str]) -> bool:
         rel = str(path.resolve().relative_to(root))
     except ValueError:
         return False
-    return any(fnmatch.fnmatch(rel, pat) for pat in patterns)
+    return any(
+        fnmatch.fnmatch(rel, variant) for pat in patterns for variant in _pattern_variants(pat)
+    )
 
 
 class RepositoryType(Enum):

--- a/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
+++ b/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
@@ -75,7 +75,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from skillsaw.rule import Rule, RuleViolation, Severity
-from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.context import RepositoryContext, RepositoryType, _pattern_variants
 from skillsaw.lint_target import SkillNode
 from skillsaw.markdown_doc import MarkdownDoc
 from skillsaw.blocks import ContentBlock
@@ -125,7 +125,8 @@ class AgentSkillUnreferencedFilesRule(Rule):
             "default": [],
             "description": (
                 "Additional glob patterns (matched against skill-relative "
-                "paths and bare file names) exempt from dead-file detection; "
+                "paths and bare file names; a leading `**/` also matches at "
+                "the skill root) exempt from dead-file detection; "
                 "extends the built-in exclusions (SKILL.md, README.md, "
                 "CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, "
                 "testdata/, hidden files)"
@@ -241,8 +242,12 @@ class AgentSkillUnreferencedFilesRule(Rule):
         if "testdata" in rel.split("/")[:-1]:
             return True
         for pattern in extra_patterns:
-            if fnmatch.fnmatch(rel, pattern) or fnmatch.fnmatch(name, pattern):
-                return True
+            # Same gitignore-style leading-**/ expansion as the global and
+            # per-rule excludes (see context._pattern_variants, issue #322):
+            # **/generated/** must also match a top-level generated/ dir.
+            for variant in _pattern_variants(pattern):
+                if fnmatch.fnmatch(rel, variant) or fnmatch.fnmatch(name, variant):
+                    return True
         return False
 
     # -- reachability --------------------------------------------------------

--- a/tests/fixtures/config/default-exclude-templates/changelog-writer/SKILL.md
+++ b/tests/fixtures/config/default-exclude-templates/changelog-writer/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: changelog-writer
+description: Draft changelog entries from merged pull requests since the last release tag
+compatibility: Requires git and gh CLI
+metadata:
+  author: dx-team
+  version: "1.0"
+---
+
+# Changelog Writer
+
+Draft changelog entries by summarizing merged pull requests since the
+last release tag.
+
+## When to Use This Skill
+
+Use when the user asks to prepare release notes, update CHANGELOG.md,
+or summarize what shipped since the last release.
+
+## Implementation Steps
+
+### Step 1: Find the Last Release Tag
+
+```bash
+git describe --tags --abbrev=0
+```
+
+### Step 2: List Merged PRs Since the Tag
+
+```bash
+gh pr list --state merged --search "merged:>$(git log -1 --format=%cI $(git describe --tags --abbrev=0))"
+```
+
+### Step 3: Draft Entries
+
+Group PRs into sections:
+- **Added** — new features and rules
+- **Fixed** — bug fixes
+- **Changed** — behavior changes and deprecations
+
+Write one line per PR: a user-facing summary followed by the PR number
+in parentheses. Skip PRs labeled `internal` or `ci`.

--- a/tests/fixtures/config/default-exclude-templates/templates/starter-skill/SKILL.md
+++ b/tests/fixtures/config/default-exclude-templates/templates/starter-skill/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: Starter_Skill
+---
+
+# {{SKILL_TITLE}}
+
+TODO: describe what this skill does.
+
+Please try to be helpful and maybe consider doing the thing if it seems
+appropriate. It might be a good idea to possibly check things.
+
+## Steps
+
+1. {{STEP_ONE}}
+2. {{STEP_TWO}}

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -1801,6 +1801,22 @@ def test_exclude_glob_extends_defaults(temp_dir):
     assert rule.check(RepositoryContext(skill)) == []
 
 
+def test_exclude_glob_leading_star_star_matches_skill_root(temp_dir):
+    """A leading **/ exclude must also match a top-level directory of the
+    skill, mirroring the global exclude semantics (issue #322)."""
+    skill = _make_skill(temp_dir, body="Nothing else is mentioned.")
+    (skill / "generated").mkdir()
+    (skill / "generated" / "out.md").write_text("machine output\n")
+    (skill / "nested" / "generated").mkdir(parents=True)
+    (skill / "nested" / "generated" / "deep.md").write_text("machine output\n")
+
+    # Without the exclude both files are dead weight.
+    assert len(AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))) == 2
+
+    rule = AgentSkillUnreferencedFilesRule({"exclude": ["**/generated/**"]})
+    assert rule.check(RepositoryContext(skill)) == []
+
+
 def test_skill_without_extra_files_passes(temp_dir):
     skill = _make_skill(temp_dir, body="This skill bundles no extra files.")
     assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from skillsaw.context import (
     RepositoryContext,
     RepositoryType,
+    path_matches_patterns,
     HAS_CURSOR,
     HAS_COPILOT,
     HAS_GEMINI,
@@ -631,3 +632,51 @@ def test_explicit_repo_type_override_drives_discovery(temp_dir):
     assert context.repo_types == {RepositoryType.SINGLE_PLUGIN}
     assert context.repo_type == RepositoryType.SINGLE_PLUGIN
     assert [p.resolve() for p in context.plugins] == [temp_dir.resolve()]
+
+
+class TestPathMatchesPatterns:
+    """gitignore-style ``**/`` semantics on top of fnmatch (issue #322)."""
+
+    def _match(self, temp_dir, rel, patterns):
+        root = temp_dir.resolve()
+        return path_matches_patterns(root / rel, root, patterns)
+
+    def test_leading_star_star_matches_top_level_dir(self, temp_dir):
+        """**/templates/** must exclude a templates/ dir at the repo root."""
+        assert self._match(temp_dir, "templates/x/SKILL.md", ["**/templates/**"])
+
+    def test_leading_star_star_matches_nested_dir(self, temp_dir):
+        assert self._match(temp_dir, "a/templates/x/SKILL.md", ["**/templates/**"])
+        assert self._match(temp_dir, "a/b/templates/x/SKILL.md", ["**/templates/**"])
+
+    def test_leading_star_star_requires_whole_component(self, temp_dir):
+        """The stripped variant must not turn into a substring match."""
+        assert not self._match(temp_dir, "mytemplates/x/SKILL.md", ["**/templates/**"])
+        assert not self._match(temp_dir, "templatesx/SKILL.md", ["**/templates/**"])
+        assert not self._match(temp_dir, "other/x/SKILL.md", ["**/templates/**"])
+
+    def test_trailing_star_star_matches_contents_at_any_depth(self, temp_dir):
+        assert self._match(temp_dir, "templates/SKILL.md", ["**/templates/**"])
+        assert self._match(temp_dir, "templates/deep/nested/file.md", ["**/templates/**"])
+
+    def test_default_excludes_cover_top_level_dirs(self, temp_dir):
+        from skillsaw.config import LinterConfig
+
+        patterns = LinterConfig.default().exclude_patterns
+        for d in ("template", "templates", "_template"):
+            assert self._match(temp_dir, f"{d}/starter/SKILL.md", patterns)
+
+    def test_plain_star_still_crosses_slashes(self, temp_dir):
+        """Backward compat: existing fnmatch patterns keep matching."""
+        assert self._match(temp_dir, "a/b/generated.md", ["*generated.md"])
+        assert self._match(temp_dir, "vendor/deep/file.md", ["vendor/*"])
+        assert self._match(temp_dir, "commands/generated.md", ["commands/generated.md"])
+
+    def test_no_patterns_never_matches(self, temp_dir):
+        assert not self._match(temp_dir, "templates/x/SKILL.md", [])
+
+    def test_path_outside_root_never_matches(self, temp_dir):
+        root = (temp_dir / "repo").resolve()
+        root.mkdir()
+        outside = temp_dir / "templates" / "x" / "SKILL.md"
+        assert not path_matches_patterns(outside, root, ["**/templates/**"])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1118,6 +1118,25 @@ class TestConfigFeatures:
         violated_files = {v["file_path"] for v in violations(r)}
         assert not any("generated.md" in f for f in violated_files)
 
+    def test_default_exclude_covers_top_level_templates(self, tmp_path):
+        """Default **/templates/** must exclude a templates/ dir at the repo
+        root, not just nested ones (issue #322)."""
+        repo = copy_fixture("config/default-exclude-templates", tmp_path)
+        r = run_lint(repo)
+        assert r["out"] is not None
+        violated_files = {v["file_path"] for v in violations(r)}
+        assert not any("templates/" in f for f in violated_files)
+
+    def test_top_level_templates_linted_when_defaults_overridden(self, tmp_path):
+        """Sanity check: the fixture's templates/ skill does violate rules,
+        so the previous test's empty result is due to the default excludes."""
+        repo = copy_fixture("config/default-exclude-templates", tmp_path)
+        (repo / ".skillsaw.yaml").write_text('version: "99.0.0"\nexclude:\n  - "nonexistent/**"\n')
+        r = run_lint(repo)
+        assert r["out"] is not None
+        violated_files = {v["file_path"] for v in violations(r)}
+        assert any("templates/" in f for f in violated_files)
+
     def test_per_rule_exclude(self, tmp_path):
         """Per-rule exclude suppresses one file but not another."""
         repo = copy_fixture("config/per-rule-exclude", tmp_path)


### PR DESCRIPTION
## The bug

The default exclude patterns (`**/template/**`, `**/templates/**`, `**/_template/**`) never excluded a **top-level** `templates/` directory. `path_matches_patterns` in `src/skillsaw/context.py` uses `fnmatch`, where `**` behaves exactly like `*`, so a leading `**/` demands at least one literal directory (and a `/`) before the rest of the pattern:

```python
>>> fnmatch.fnmatch('templates/x/SKILL.md', '**/templates/**')
False
>>> fnmatch.fnmatch('a/templates/x/SKILL.md', '**/templates/**')
True
```

Any user pattern written with gitignore-style `**` semantics had the same gap.

## The fix

Each pattern is expanded into the fnmatch variants it is tried as (`_pattern_variants`, lru_cached): when a pattern starts with `**/`, a variant with that prefix stripped is also tried, so the pattern matches at the start of the relative path (zero leading directories). A trailing `/**` needs no variant — `*` already crosses `/`, so it matches the directory's contents at any depth.

## Backward compatibility

The original pattern is always kept in the variant list, so the expansion is a **strict superset** of the old behavior: every path a pattern matched before still matches. In particular, plain-`*` patterns that rely on fnmatch's `*` crossing `/` (e.g. `*generated.md` matching `a/b/generated.md`) behave exactly as before — this is covered by regression tests.

## Testing

- Unit tests for `path_matches_patterns`: top-level `templates/`, nested `a/templates/`, non-matching sibling names (`mytemplates/`, `templatesx/`), trailing-`/**` depth, all three default excludes, plain-`*` slash-crossing compat, empty patterns, and paths outside the root.
- Integration test with a new fixture (`tests/fixtures/config/default-exclude-templates`): a repo with a violating skill under top-level `templates/` produces no violations there under the default excludes, plus a sanity-check test proving the same fixture *does* violate when the defaults are overridden.
- Full suite passes (2251 passed); `make lint` and `make update` clean.
- Dogfooded against `openshift-eng/ai-helpers`: violations and exit code are identical between main and this branch (27 warnings / 448 info on both).

Part of #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how exclude glob patterns are matched, including root-relative behavior and `**/` matching at the repository or skill root.
  * Updated rule docs to better explain default and user-defined exclusions.

* **Bug Fixes**
  * Improved path exclusion matching so `**/` patterns work consistently at the start of paths, not just in nested locations.
  * Fixed unreferenced-file detection to honor `**/` excludes more reliably.

* **Tests**
  * Added regression coverage for root-level and nested exclusion matching, plus default exclusion behavior and override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->