### PR TITLE
content-embedded-secrets: entropy gating + placeholder allowlist (fixes placeholder FPs)

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -134,6 +134,8 @@ rules:
   content-embedded-secrets:
     enabled: auto
     severity: error
+    # entropy-threshold: 3.5
+    # additional-placeholders: []
 
   # Detect instructions that should be automated as hooks instead of prose instructions
   content-hook-candidate:

--- a/README.md
+++ b/README.md
@@ -801,6 +801,13 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 |-----------|-------------|---------|
 | `max-tokens` | Maximum estimated tokens per section before triggering a warning | `500` |
 
+**`content-embedded-secrets` parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `entropy-threshold` | Minimum Shannon entropy (bits/char) a generic key = "value" match must reach to be reported; structured tokens (AKIA…, ghp_…, private keys) are always reported | `3.5` |
+| `additional-placeholders` | Extra case-insensitive substrings that mark a generic credential value as a placeholder (suppressing the violation) | `[]` |
+
 **`content-banned-references` parameters:**
 
 | Parameter | Description | Default |

--- a/docs/rules/content-embedded-secrets.md
+++ b/docs/rules/content-embedded-secrets.md
@@ -19,6 +19,24 @@ multiple agents and users. A hardcoded API key, token, or password in an
 instruction file is a credential leak — it is visible in the git history
 even after removal and may be harvested by automated scanners.
 
+## Detection
+
+Two classes of match are handled differently:
+
+- **Structured token formats** (`AKIA…`, `ghp_…`, `sk-ant-…`, private-key
+  blocks, JWTs, …) are high-confidence and always reported.
+- **Generic credential assignments** (`password = "…"`, `api_key: "…"`,
+  `secret_key`, `access_token`) are gated to avoid flagging documentation
+  examples:
+    - *Placeholder allowlist*: values containing obvious placeholder
+      markers (`example`, `placeholder`, `dummy`, `changeme`, `your-…`,
+      `hunter2`, …), template syntax (`<your-key>`, `${VAR}`,
+      `{{ var }}`), or a single repeated character are skipped. Extend
+      the list with `additional-placeholders`.
+    - *Entropy gating*: the value's Shannon entropy must reach
+      `entropy-threshold` (default 3.5 bits/char). Real random secrets
+      pass; English-ish placeholder strings do not.
+
 ## Examples
 
 **Bad:**
@@ -51,6 +69,11 @@ rules:
     enabled: auto  # true | false | auto
     severity: error
 ```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `entropy-threshold` | Minimum Shannon entropy (bits/char) a generic key = "value" match must reach to be reported; structured tokens (AKIA…, ghp_…, private keys) are always reported | `3.5` |
+| `additional-placeholders` | Extra case-insensitive substrings that mark a generic credential value as a placeholder (suppressing the violation) | `[]` |
 
 ## Research Basis
 

--- a/docs/rules/content-embedded-secrets.md
+++ b/docs/rules/content-embedded-secrets.md
@@ -35,7 +35,11 @@ Two classes of match are handled differently:
       the list with `additional-placeholders`.
     - *Entropy gating*: the value's Shannon entropy must reach
       `entropy-threshold` (default 3.5 bits/char). Real random secrets
-      pass; English-ish placeholder strings do not.
+      pass; English-ish placeholder strings do not. Values shorter than
+      16 characters are length-normalized before comparison (per-char
+      Shannon entropy of an n-char string is capped at log2(n), so a
+      fully random 10-char password measures only ~3.3 bits/char raw —
+      short random passwords still fire).
 
 ## Examples
 

--- a/src/skillsaw/rules/builtin/content/embedded_secrets.py
+++ b/src/skillsaw/rules/builtin/content/embedded_secrets.py
@@ -1,7 +1,8 @@
 """Content embedded secrets rule"""
 
+import math
 import re
-from typing import List
+from typing import List, Optional, Tuple
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
@@ -11,6 +12,55 @@ from skillsaw.rules.builtin.content_analysis import (
     FrontmatterField,
 )
 
+# Default minimum Shannon entropy (bits/char) a generic ``key = "value"``
+# candidate must reach before it is reported.  Random secrets (base64, hex,
+# mixed-character passwords) comfortably exceed this; English-ish placeholder
+# strings mostly do not.  Structured token formats (AKIA…, ghp_…, private-key
+# blocks) are high-confidence and are never entropy-gated.
+_DEFAULT_ENTROPY_THRESHOLD = 3.5
+
+# Case-insensitive substrings that mark a generic credential value as an
+# obvious placeholder (inspired by gitleaks/detect-secrets allowlists).
+_PLACEHOLDER_MARKERS = (
+    "example",
+    "placeholder",
+    "dummy",
+    "sample",
+    "changeme",
+    "change-me",
+    "change_me",
+    "your-",
+    "your_",
+    "hunter2",
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "test",
+    "fake",
+    "foobar",
+    "redacted",
+    "insert",
+    "todo",
+    "fixme",
+    "xxx",
+)
+
+# Template/variable syntax anywhere in the value marks it as a placeholder:
+# <your-key>, ${API_KEY}, {{ secrets.KEY }}, $VAR interpolation.
+_TEMPLATE_SYNTAX = re.compile(r"<[^>]*>|\$\{[^}]*\}|\{\{[^}]*\}\}|\$[A-Z_][A-Z0-9_]*")
+
+
+def _shannon_entropy(value: str) -> float:
+    """Shannon entropy of *value* in bits per character."""
+    if not value:
+        return 0.0
+    length = len(value)
+    counts = {}
+    for ch in value:
+        counts[ch] = counts.get(ch, 0) + 1
+    return -sum((n / length) * math.log2(n / length) for n in counts.values())
+
 
 class ContentEmbeddedSecretsRule(Rule):
     """Detect potential secrets embedded in instruction files"""
@@ -18,50 +68,86 @@ class ContentEmbeddedSecretsRule(Rule):
     formats = None
     since = "0.7.0"
 
+    config_schema = {
+        "entropy-threshold": {
+            "type": "float",
+            "default": _DEFAULT_ENTROPY_THRESHOLD,
+            "description": (
+                'Minimum Shannon entropy (bits/char) a generic key = "value" '
+                "match must reach to be reported; structured tokens (AKIA…, "
+                "ghp_…, private keys) are always reported"
+            ),
+        },
+        "additional-placeholders": {
+            "type": "list",
+            "default": [],
+            "description": (
+                "Extra case-insensitive substrings that mark a generic "
+                "credential value as a placeholder (suppressing the violation)"
+            ),
+        },
+    }
+
+    # Each entry is (compiled_pattern, description, is_generic).  Structured
+    # token formats are high-confidence and always reported.  Generic
+    # assignment patterns capture the candidate value in group 1 and are
+    # gated by the placeholder allowlist and entropy threshold.
     _PATTERNS = [
-        (re.compile(p), desc)
-        for p, desc in [
+        (re.compile(p), desc, generic)
+        for p, desc, generic in [
             # OpenAI / Anthropic
-            (r"\bsk-[a-zA-Z0-9]{20,}", "OpenAI/Anthropic API key"),
-            (r"\bsk-ant-[a-zA-Z0-9\-_]{20,}", "Anthropic API key"),
+            (r"\bsk-[a-zA-Z0-9]{20,}", "OpenAI/Anthropic API key", False),
+            (r"\bsk-ant-[a-zA-Z0-9\-_]{20,}", "Anthropic API key", False),
             # GitHub
-            (r"\bghp_[a-zA-Z0-9]{36,}", "GitHub personal access token"),
-            (r"\bghs_[a-zA-Z0-9]{36,}", "GitHub server token"),
-            (r"\bgho_[a-zA-Z0-9]{36,}", "GitHub OAuth token"),
-            (r"\bghu_[a-zA-Z0-9]{36,}", "GitHub user token"),
-            (r"\bghr_[a-zA-Z0-9]{36,}", "GitHub refresh token"),
+            (r"\bghp_[a-zA-Z0-9]{36,}", "GitHub personal access token", False),
+            (r"\bghs_[a-zA-Z0-9]{36,}", "GitHub server token", False),
+            (r"\bgho_[a-zA-Z0-9]{36,}", "GitHub OAuth token", False),
+            (r"\bghu_[a-zA-Z0-9]{36,}", "GitHub user token", False),
+            (r"\bghr_[a-zA-Z0-9]{36,}", "GitHub refresh token", False),
             # GitLab
-            (r"\bglpat-[a-zA-Z0-9\-_]{20,}", "GitLab personal access token"),
+            (r"\bglpat-[a-zA-Z0-9\-_]{20,}", "GitLab personal access token", False),
             # AWS
-            (r"\bAKIA[0-9A-Z]{16}", "AWS access key ID"),
-            (r"\bASIA[0-9A-Z]{16}", "AWS temporary access key ID"),
+            (r"\bAKIA[0-9A-Z]{16}", "AWS access key ID", False),
+            (r"\bASIA[0-9A-Z]{16}", "AWS temporary access key ID", False),
             # Slack
-            (r"\bxoxb-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack bot token"),
-            (r"\bxoxp-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack user token"),
-            (r"\bxoxa-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack app token"),
-            (r"\bxoxr-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack refresh token"),
+            (r"\bxoxb-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack bot token", False),
+            (r"\bxoxp-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack user token", False),
+            (r"\bxoxa-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack app token", False),
+            (r"\bxoxr-[0-9]{10,}-[0-9a-zA-Z\-]+", "Slack refresh token", False),
             # Stripe
-            (r"\bsk_live_[a-zA-Z0-9]{24,}", "Stripe secret key"),
-            (r"\brk_live_[a-zA-Z0-9]{24,}", "Stripe restricted key"),
+            (r"\bsk_live_[a-zA-Z0-9]{24,}", "Stripe secret key", False),
+            (r"\brk_live_[a-zA-Z0-9]{24,}", "Stripe restricted key", False),
             # Google
-            (r"\bAIza[0-9A-Za-z_\-]{35}", "Google API key"),
+            (r"\bAIza[0-9A-Za-z_\-]{35}", "Google API key", False),
             # Twilio
-            (r"\bSK[0-9a-fA-F]{32}", "Twilio API key"),
+            (r"\bSK[0-9a-fA-F]{32}", "Twilio API key", False),
             # SendGrid
-            (r"\bSG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}", "SendGrid API key"),
+            (r"\bSG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}", "SendGrid API key", False),
             # npm
-            (r"\bnpm_[a-zA-Z0-9]{36}", "npm access token"),
+            (r"\bnpm_[a-zA-Z0-9]{36}", "npm access token", False),
             # PyPI
-            (r"\bpypi-[a-zA-Z0-9]{16,}", "PyPI API token"),
+            (r"\bpypi-[a-zA-Z0-9]{16,}", "PyPI API token", False),
             # JWT (base64.base64.base64)
-            (r"\beyJ[a-zA-Z0-9_\-]*\.eyJ[a-zA-Z0-9_\-]*\.[a-zA-Z0-9_\-]+", "JSON Web Token"),
+            (
+                r"\beyJ[a-zA-Z0-9_\-]*\.eyJ[a-zA-Z0-9_\-]*\.[a-zA-Z0-9_\-]+",
+                "JSON Web Token",
+                False,
+            ),
             # Private keys
-            (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----", "Private key"),
-            # Generic patterns
-            (r"(?i)\bpassword\s*[=:]\s*['\"][^'\"]{8,}['\"]", "Hardcoded password"),
-            (r"(?i)\bapi[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded API key"),
-            (r"(?i)\bsecret[_-]?key\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded secret key"),
-            (r"(?i)\baccess[_-]?token\s*[=:]\s*['\"][^'\"]{16,}['\"]", "Hardcoded access token"),
+            (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----", "Private key", False),
+            # Generic patterns — value captured for placeholder/entropy gating
+            (r"(?i)\bpassword\s*[=:]\s*['\"]([^'\"]{8,})['\"]", "Hardcoded password", True),
+            (r"(?i)\bapi[_-]?key\s*[=:]\s*['\"]([^'\"]{16,})['\"]", "Hardcoded API key", True),
+            (
+                r"(?i)\bsecret[_-]?key\s*[=:]\s*['\"]([^'\"]{16,})['\"]",
+                "Hardcoded secret key",
+                True,
+            ),
+            (
+                r"(?i)\baccess[_-]?token\s*[=:]\s*['\"]([^'\"]{16,})['\"]",
+                "Hardcoded access token",
+                True,
+            ),
         ]
     ]
 
@@ -76,33 +162,79 @@ class ContentEmbeddedSecretsRule(Rule):
     def default_severity(self) -> Severity:
         return Severity.ERROR
 
+    def _entropy_threshold(self) -> float:
+        try:
+            return float(self.config.get("entropy-threshold", _DEFAULT_ENTROPY_THRESHOLD))
+        except (TypeError, ValueError):
+            return _DEFAULT_ENTROPY_THRESHOLD
+
+    def _placeholder_markers(self) -> Tuple[str, ...]:
+        extra = self.config.get("additional-placeholders", [])
+        if not isinstance(extra, list):
+            return _PLACEHOLDER_MARKERS
+        return _PLACEHOLDER_MARKERS + tuple(str(m).lower() for m in extra if str(m))
+
+    @staticmethod
+    def _is_placeholder(value: str, markers: Tuple[str, ...]) -> bool:
+        """True when *value* is clearly a placeholder, not a real secret."""
+        if len(set(value)) <= 1:
+            return True  # all-same-character: ********, aaaaaaaa
+        if _TEMPLATE_SYNTAX.search(value):
+            return True  # <your-key>, ${API_KEY}, {{ secrets.KEY }}, $VAR
+        lowered = value.lower()
+        return any(marker in lowered for marker in markers)
+
+    def _generic_match_reportable(
+        self, value: Optional[str], threshold: float, markers: Tuple[str, ...]
+    ) -> bool:
+        """Gate a generic ``key = "value"`` candidate: skip obvious
+        placeholders and low-entropy (English-ish) strings."""
+        if value is None:
+            return False
+        if self._is_placeholder(value, markers):
+            return False
+        return _shannon_entropy(value) >= threshold
+
+    def _scan_text(self, text: str, threshold: float, markers: Tuple[str, ...]):
+        """Yield ``(line_num, desc)`` for at most one violation per line."""
+        active = patterns_matching_anywhere(text, self._PATTERNS)
+        if not active:
+            return
+        for line_num, line in enumerate(text.splitlines(), 1):
+            for pattern, desc, is_generic in active:
+                if not is_generic:
+                    if pattern.search(line):
+                        yield line_num, desc
+                        break
+                    continue
+                if any(
+                    self._generic_match_reportable(m.group(1), threshold, markers)
+                    for m in pattern.finditer(line)
+                ):
+                    yield line_num, desc
+                    break
+
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        threshold = self._entropy_threshold()
+        markers = self._placeholder_markers()
         violations = []
         for cf in gather_all_content_blocks(context):
             body = cf.read_body(strip_code_blocks=False)
             if not body:
                 continue
-            active = patterns_matching_anywhere(body, self._PATTERNS)
-            if not active:
-                continue
-            for line_num, line in enumerate(body.splitlines(), 1):
-                for pattern, desc in active:
-                    if pattern.search(line):
-                        violations.append(
-                            self.violation(
-                                f"Potential secret detected: {desc}",
-                                block=cf,
-                                line=line_num,
-                            )
-                        )
-                        break
+            for line_num, desc in self._scan_text(body, threshold, markers):
+                violations.append(
+                    self.violation(
+                        f"Potential secret detected: {desc}",
+                        block=cf,
+                        line=line_num,
+                    )
+                )
         for fld in context.lint_tree.find(FrontmatterField):
             text = str(fld.value) if fld.value is not None else ""
             if not text:
                 continue
-            active = patterns_matching_anywhere(text, self._PATTERNS)
-            if active:
-                _pattern, desc = active[0]
+            for _line_num, desc in self._scan_text(text, threshold, markers):
                 violations.append(
                     self.violation(
                         f"Potential secret detected in frontmatter " f"field '{fld.name}': {desc}",
@@ -110,4 +242,5 @@ class ContentEmbeddedSecretsRule(Rule):
                         line=fld.field_line,
                     )
                 )
+                break
         return violations

--- a/src/skillsaw/rules/builtin/content/embedded_secrets.py
+++ b/src/skillsaw/rules/builtin/content/embedded_secrets.py
@@ -21,6 +21,16 @@ _DEFAULT_ENTROPY_THRESHOLD = 3.5
 
 # Case-insensitive substrings that mark a generic credential value as an
 # obvious placeholder (inspired by gitleaks/detect-secrets allowlists).
+#
+# Substring matching is deliberately aggressive (gitleaks stoplists the same
+# way), so every word here is a false-negative surface: a real secret that
+# happens to contain it is suppressed.  Only words with demonstrated
+# real-world placeholder value belong in this list — "password" and "token"
+# are in gitleaks' DefaultStopWords and suppress documented placeholder
+# values in real repos (e.g. password = "securePassword123"), while
+# "secret"/"passwd" were dropped because they are in neither gitleaks nor
+# detect-secrets stoplists and plausibly appear inside real credential
+# values (api_key = "app-secret-…").
 _PLACEHOLDER_MARKERS = (
     "example",
     "placeholder",
@@ -33,8 +43,6 @@ _PLACEHOLDER_MARKERS = (
     "your_",
     "hunter2",
     "password",
-    "passwd",
-    "secret",
     "token",
     "test",
     "fake",

--- a/src/skillsaw/rules/builtin/content/embedded_secrets.py
+++ b/src/skillsaw/rules/builtin/content/embedded_secrets.py
@@ -47,8 +47,35 @@ _PLACEHOLDER_MARKERS = (
 )
 
 # Template/variable syntax anywhere in the value marks it as a placeholder:
-# <your-key>, ${API_KEY}, {{ secrets.KEY }}, $VAR interpolation.
-_TEMPLATE_SYNTAX = re.compile(r"<[^>]*>|\$\{[^}]*\}|\{\{[^}]*\}\}|\$[A-Z_][A-Z0-9_]*")
+# <your-key>, ${API_KEY}, {{ secrets.KEY }}.  The angle-bracket form requires
+# word-like placeholder content (<your-api-key>, <API_KEY>, <paste token
+# here>) so that incidental <..> punctuation inside a random secret
+# ("k<9x>Km2#pQz") does not suppress it.
+_TEMPLATE_SYNTAX = re.compile(r"<[A-Za-z][A-Za-z0-9 _./-]{2,}>|\$\{[^}]*\}|\{\{[^}]*\}\}")
+
+# Bare $VAR env-var interpolation.  Matched greedily and confirmed in code:
+# the character after the match must not be a lowercase letter, otherwise
+# "$MQ2vLp8" inside a random password would be mistaken for a variable
+# reference.  A trailing negative lookahead cannot express this — the engine
+# would backtrack into a truncated accepted match (see CLAUDE.md, issue #321).
+_ENV_VAR_SYNTAX = re.compile(r"\$[A-Z_][A-Z0-9_]{2,}")
+
+
+def _has_env_var_reference(value: str) -> bool:
+    """True when *value* contains a $VAR-style env-var reference."""
+    for m in _ENV_VAR_SYNTAX.finditer(value):
+        end = m.end()
+        if end >= len(value) or not value[end].islower():
+            return True
+    return False
+
+
+# Shannon entropy per character of an n-char string is capped at log2(n),
+# so short values can never reach a threshold tuned for long ones (a fully
+# random 10-char password measures at most 3.32 bits/char).  Values shorter
+# than 16 chars are normalized to this 16-char reference (log2(16) = 4.0
+# bits) so the threshold discriminates uniformly across lengths.
+_REFERENCE_MAX_BITS = 4.0
 
 
 def _shannon_entropy(value: str) -> float:
@@ -60,6 +87,24 @@ def _shannon_entropy(value: str) -> float:
     for ch in value:
         counts[ch] = counts.get(ch, 0) + 1
     return -sum((n / length) * math.log2(n / length) for n in counts.values())
+
+
+def _length_adjusted_entropy(value: str) -> float:
+    """Shannon entropy normalized for short samples.
+
+    For values shorter than 16 characters the raw per-char entropy is scaled
+    up by ``4.0 / log2(len)`` — the ratio between the 16-char reference
+    ceiling and the value's own ceiling — so a fully random 8-char password
+    (raw max 3.0 bits/char) is comparable against the same threshold as a
+    32-char one.  Longer values are returned unscaled.
+    """
+    raw = _shannon_entropy(value)
+    if len(value) < 2:
+        return raw
+    max_bits = math.log2(len(value))
+    if max_bits >= _REFERENCE_MAX_BITS:
+        return raw
+    return raw * (_REFERENCE_MAX_BITS / max_bits)
 
 
 class ContentEmbeddedSecretsRule(Rule):
@@ -180,7 +225,9 @@ class ContentEmbeddedSecretsRule(Rule):
         if len(set(value)) <= 1:
             return True  # all-same-character: ********, aaaaaaaa
         if _TEMPLATE_SYNTAX.search(value):
-            return True  # <your-key>, ${API_KEY}, {{ secrets.KEY }}, $VAR
+            return True  # <your-key>, ${API_KEY}, {{ secrets.KEY }}
+        if _has_env_var_reference(value):
+            return True  # $API_KEY interpolation
         lowered = value.lower()
         return any(marker in lowered for marker in markers)
 
@@ -193,7 +240,7 @@ class ContentEmbeddedSecretsRule(Rule):
             return False
         if self._is_placeholder(value, markers):
             return False
-        return _shannon_entropy(value) >= threshold
+        return _length_adjusted_entropy(value) >= threshold
 
     def _scan_text(self, text: str, threshold: float, markers: Tuple[str, ...]):
         """Yield ``(line_num, desc)`` for at most one violation per line."""

--- a/src/skillsaw/rules/docs/content-embedded-secrets.md
+++ b/src/skillsaw/rules/docs/content-embedded-secrets.md
@@ -21,7 +21,11 @@ Two classes of match are handled differently:
       the list with `additional-placeholders`.
     - *Entropy gating*: the value's Shannon entropy must reach
       `entropy-threshold` (default 3.5 bits/char). Real random secrets
-      pass; English-ish placeholder strings do not.
+      pass; English-ish placeholder strings do not. Values shorter than
+      16 characters are length-normalized before comparison (per-char
+      Shannon entropy of an n-char string is capped at log2(n), so a
+      fully random 10-char password measures only ~3.3 bits/char raw —
+      short random passwords still fire).
 
 ## Examples
 

--- a/src/skillsaw/rules/docs/content-embedded-secrets.md
+++ b/src/skillsaw/rules/docs/content-embedded-secrets.md
@@ -5,6 +5,24 @@ multiple agents and users. A hardcoded API key, token, or password in an
 instruction file is a credential leak — it is visible in the git history
 even after removal and may be harvested by automated scanners.
 
+## Detection
+
+Two classes of match are handled differently:
+
+- **Structured token formats** (`AKIA…`, `ghp_…`, `sk-ant-…`, private-key
+  blocks, JWTs, …) are high-confidence and always reported.
+- **Generic credential assignments** (`password = "…"`, `api_key: "…"`,
+  `secret_key`, `access_token`) are gated to avoid flagging documentation
+  examples:
+    - *Placeholder allowlist*: values containing obvious placeholder
+      markers (`example`, `placeholder`, `dummy`, `changeme`, `your-…`,
+      `hunter2`, …), template syntax (`<your-key>`, `${VAR}`,
+      `{{ var }}`), or a single repeated character are skipped. Extend
+      the list with `additional-placeholders`.
+    - *Entropy gating*: the value's Shannon entropy must reach
+      `entropy-threshold` (default 3.5 bits/char). Real random secrets
+      pass; English-ish placeholder strings do not.
+
 ## Examples
 
 **Bad:**

--- a/tests/fixtures/single-plugin/with-secrets/commands/setup.md
+++ b/tests/fixtures/single-plugin/with-secrets/commands/setup.md
@@ -25,3 +25,15 @@ Use the following API key for the staging environment:
 ANTHROPIC_API_KEY=sk-ant-api03-reallyLongFakeKeyThatLooksLikeARealOne1234567890abcdefghijklmnop
 
 Always use this key when running integration tests against staging.
+
+## Configuration examples
+
+These are documentation placeholders and must not be flagged as secrets:
+
+```bash
+export DB_PASSWORD="your-password-here"
+api_key = "${STAGING_API_KEY}"
+secret_key = "{{ secrets.PRODUCTION_KEY }}"
+password = "hunter2placeholder"
+access_token = "<paste-access-token-here>"
+```

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -629,7 +629,7 @@ class TestContentEmbeddedSecretsRule:
         assert len(violations) == 0
 
     def test_reports_line_number(self, temp_dir):
-        content = "Line 1\nLine 2\nPassword: password='supersecretpassword123'\nLine 4\n"
+        content = "Line 1\nLine 2\nPassword: password='xK9$mQ2vLp8#nR4zW7@j'\nLine 4\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         context = RepositoryContext(temp_dir)
         violations = ContentEmbeddedSecretsRule().check(context)
@@ -702,6 +702,107 @@ class TestContentEmbeddedSecretsRule:
     def test_no_false_positive_on_short_placeholder(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text(
             "Use sk-YOUR_KEY as the token.\n" "Set password = 'short'\n"
+        )
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) == 0
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'password="hunter2placeholder"',
+            "password = 'your-password-here'",
+            'password: "aaaaaaaaaaaaaaaa"',
+            'password = "dummy-value-123"',
+            'api_key = "<your-api-key-goes-here>"',
+            'api_key = "${MY_API_KEY_FROM_ENV}"',
+            'api_key = "EXAMPLE_KEY_1234567890"',
+            'api_key = "abababababababab"',
+            'secret_key = "{{ secrets.PRODUCTION_KEY }}"',
+            'access_token = "insert-real-value-here"',
+        ],
+        ids=[
+            "hunter2",
+            "your-word",
+            "all-same-char",
+            "dummy-word",
+            "angle-bracket-template",
+            "shell-template-var",
+            "example-word",
+            "low-entropy",
+            "jinja-template",
+            "insert-word",
+        ],
+    )
+    def test_no_false_positive_on_placeholder_values(self, temp_dir, line):
+        """Generic credential assignments with obvious placeholder or
+        low-entropy values are documentation examples, not leaks (issue #322)."""
+        (temp_dir / "CLAUDE.md").write_text(f"Configure it like this: {line}\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) == 0
+
+    @pytest.mark.parametrize(
+        "line,expected_desc",
+        [
+            ('password = "xK9$mQ2vLp8#nR4z"', "Hardcoded password"),
+            ('api_key = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"', "Hardcoded API key"),
+            ('secret_key = "kJ8vQz3mN9pL2wXyRb5cDf7g"', "Hardcoded secret key"),
+        ],
+        ids=["random-password", "hex-api-key", "mixed-secret-key"],
+    )
+    def test_high_entropy_generic_values_still_fire(self, temp_dir, line, expected_desc):
+        (temp_dir / "CLAUDE.md").write_text(f"Config: {line}\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) >= 1
+        assert expected_desc in violations[0].message
+
+    def test_structured_tokens_not_entropy_gated(self, temp_dir):
+        """High-confidence token formats fire even for low-entropy bodies."""
+        (temp_dir / "CLAUDE.md").write_text("Use token ghp_" + "a" * 40 + "\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) >= 1
+        assert "GitHub personal access token" in violations[0].message
+
+    def test_entropy_threshold_configurable(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text(
+            'Config: api_key = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"\n'
+        )
+        context = RepositoryContext(temp_dir)
+        # Raising the threshold above the value's entropy suppresses it
+        rule = ContentEmbeddedSecretsRule({"entropy-threshold": 5.0})
+        assert rule.check(context) == []
+        # Lowering it lets low-entropy values through
+        (temp_dir / "CLAUDE.md").write_text('Config: api_key = "abababababababab"\n')
+        context = RepositoryContext(temp_dir)
+        rule = ContentEmbeddedSecretsRule({"entropy-threshold": 0.5})
+        assert len(rule.check(context)) == 1
+
+    def test_entropy_threshold_invalid_config_uses_default(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text('Config: password = "hunter2placeholder"\n')
+        context = RepositoryContext(temp_dir)
+        rule = ContentEmbeddedSecretsRule({"entropy-threshold": "nonsense"})
+        assert rule.check(context) == []
+
+    def test_additional_placeholders_configurable(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text('Config: api_key = "staging-key-9f8a7b6c5d4e3f2a"\n')
+        context = RepositoryContext(temp_dir)
+        # Fires by default (high entropy, no builtin placeholder marker)
+        assert len(ContentEmbeddedSecretsRule().check(context)) == 1
+        # Suppressed once the marker is allowlisted
+        rule = ContentEmbeddedSecretsRule({"additional-placeholders": ["staging-key"]})
+        assert rule.check(context) == []
+
+    def test_no_false_positive_on_placeholder_in_frontmatter(self, temp_dir):
+        skill = temp_dir / "skills" / "demo"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\n"
+            "name: demo\n"
+            'description: Set password = "your-password-here" before running\n'
+            "---\n\n# Demo\n\nA demo skill.\n"
         )
         context = RepositoryContext(temp_dir)
         violations = ContentEmbeddedSecretsRule().check(context)

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -831,24 +831,42 @@ class TestContentEmbeddedSecretsRule:
         assert "GitHub personal access token" in violations[0].message
 
     def test_entropy_threshold_configurable(self, temp_dir):
-        (temp_dir / "CLAUDE.md").write_text(
+        # Distinct repo dirs: the utils read cache is keyed by path, so
+        # rewriting the same file within a test would read stale content.
+        repo_raise = temp_dir / "raise"
+        repo_lower = temp_dir / "lower"
+        repo_raise.mkdir()
+        repo_lower.mkdir()
+        (repo_raise / "CLAUDE.md").write_text(
             'Config: api_key = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"\n'
         )
-        context = RepositoryContext(temp_dir)
         # Raising the threshold above the value's entropy suppresses it
         rule = ContentEmbeddedSecretsRule({"entropy-threshold": 5.0})
-        assert rule.check(context) == []
+        assert rule.check(RepositoryContext(repo_raise)) == []
         # Lowering it lets low-entropy values through
-        (temp_dir / "CLAUDE.md").write_text('Config: api_key = "abababababababab"\n')
-        context = RepositoryContext(temp_dir)
+        (repo_lower / "CLAUDE.md").write_text('Config: api_key = "abababababababab"\n')
         rule = ContentEmbeddedSecretsRule({"entropy-threshold": 0.5})
-        assert len(rule.check(context)) == 1
+        assert len(rule.check(RepositoryContext(repo_lower))) == 1
 
     def test_entropy_threshold_invalid_config_uses_default(self, temp_dir):
-        (temp_dir / "CLAUDE.md").write_text('Config: password = "hunter2placeholder"\n')
-        context = RepositoryContext(temp_dir)
+        """An unparseable threshold falls back to the 3.5 default: values on
+        either side of the default must behave exactly as with no config
+        (marker-free values, so the entropy gate alone decides)."""
         rule = ContentEmbeddedSecretsRule({"entropy-threshold": "nonsense"})
-        assert rule.check(context) == []
+        # Distinct repo dirs: the utils read cache is keyed by path, so
+        # rewriting the same file within a test would read stale content.
+        repo_low = temp_dir / "low"
+        repo_high = temp_dir / "high"
+        repo_low.mkdir()
+        repo_high.mkdir()
+        # Below the default threshold (1.0 bits/char): suppressed.
+        (repo_low / "CLAUDE.md").write_text('Config: api_key = "abababababababab"\n')
+        assert rule.check(RepositoryContext(repo_low)) == []
+        # Above it (hex, ~4.0 bits/char): still fires.
+        (repo_high / "CLAUDE.md").write_text(
+            'Config: api_key = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"\n'
+        )
+        assert len(rule.check(RepositoryContext(repo_high))) == 1
 
     def test_additional_placeholders_configurable(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text('Config: api_key = "staging-key-9f8a7b6c5d4e3f2a"\n')

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -720,6 +720,8 @@ class TestContentEmbeddedSecretsRule:
             'api_key = "abababababababab"',
             'secret_key = "{{ secrets.PRODUCTION_KEY }}"',
             'access_token = "insert-real-value-here"',
+            'password = "$DB_PASSWORD"',
+            'password = "helloworld"',
         ],
         ids=[
             "hunter2",
@@ -732,6 +734,8 @@ class TestContentEmbeddedSecretsRule:
             "low-entropy",
             "jinja-template",
             "insert-word",
+            "bare-env-var",
+            "english-short",
         ],
     )
     def test_no_false_positive_on_placeholder_values(self, temp_dir, line):
@@ -757,6 +761,39 @@ class TestContentEmbeddedSecretsRule:
         violations = ContentEmbeddedSecretsRule().check(context)
         assert len(violations) >= 1
         assert expected_desc in violations[0].message
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Shannon per-char entropy of an n-char string is capped at
+            # log2(n) — a raw 3.5 threshold silently exempts every 8-11 char
+            # password.  Length normalization must keep these reportable.
+            'password = "k9x2m4qp"',
+            'password = "xK9#mQ2$vL"',
+            'password = "Tr0ub4dor&3"',
+            # $ followed by uppercase inside a random value is not an
+            # env-var reference and must not suppress the finding.
+            'password = "xK9$MQ2vLp8#nR4z"',
+            # Incidental <..> punctuation inside a random value is not an
+            # angle-bracket placeholder.
+            'password = "k<9x>Km2#pQzW4vT"',
+        ],
+        ids=[
+            "short-random-8",
+            "short-random-10",
+            "short-random-11",
+            "dollar-upper-inside",
+            "angle-punct-inside",
+        ],
+    )
+    def test_realistic_secrets_not_suppressed_by_gating(self, temp_dir, line):
+        """False-negative regressions: real-shaped secrets must fire despite
+        the placeholder/entropy gates."""
+        (temp_dir / "CLAUDE.md").write_text(f"Config: {line}\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) >= 1
+        assert "Hardcoded password" in violations[0].message
 
     def test_structured_tokens_not_entropy_gated(self, temp_dir):
         """High-confidence token formats fire even for low-entropy bodies."""

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -722,6 +722,11 @@ class TestContentEmbeddedSecretsRule:
             'access_token = "insert-real-value-here"',
             'password = "$DB_PASSWORD"',
             'password = "helloworld"',
+            # "password"/"token" inside the value: gitleaks-stopword parity;
+            # these exact shapes appear as placeholders in real skill repos
+            # (auth0/agent-skills) and pass the entropy gate.
+            'password = "securePassword123"',
+            'access_token = "my-oauth-token-12345"',
         ],
         ids=[
             "hunter2",
@@ -736,6 +741,8 @@ class TestContentEmbeddedSecretsRule:
             "insert-word",
             "bare-env-var",
             "english-short",
+            "password-word-realworld",
+            "token-word",
         ],
     )
     def test_no_false_positive_on_placeholder_values(self, temp_dir, line):
@@ -794,6 +801,26 @@ class TestContentEmbeddedSecretsRule:
         violations = ContentEmbeddedSecretsRule().check(context)
         assert len(violations) >= 1
         assert "Hardcoded password" in violations[0].message
+
+    @pytest.mark.parametrize(
+        "line,expected_desc",
+        [
+            # "secret" and "passwd" are not in gitleaks/detect-secrets
+            # stoplists and plausibly occur inside real credential values —
+            # they must not act as placeholder markers.
+            ('api_key = "app-secret-x8K2mQ9zL4vN"', "Hardcoded API key"),
+            ('password = "xK2passwd9QmZ4vN"', "Hardcoded password"),
+        ],
+        ids=["secret-substring", "passwd-substring"],
+    )
+    def test_credential_noun_substrings_not_suppressed(self, temp_dir, line, expected_desc):
+        """False-negative regressions: high-entropy values containing
+        'secret'/'passwd' are real-secret-shaped, not placeholders."""
+        (temp_dir / "CLAUDE.md").write_text(f"Config: {line}\n")
+        context = RepositoryContext(temp_dir)
+        violations = ContentEmbeddedSecretsRule().check(context)
+        assert len(violations) >= 1
+        assert expected_desc in violations[0].message
 
     def test_structured_tokens_not_entropy_gated(self, temp_dir):
         """High-confidence token formats fire even for low-entropy bodies."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -218,6 +218,10 @@ class TestSinglePlugin:
         assert len(secrets) >= 1
         assert secrets[0]["line"] is not None
         assert "setup.md" in secrets[0]["file_path"]
+        # The fixture's "Configuration examples" placeholders (template
+        # vars, hunter2placeholder, <paste-…>) must not fire — only the
+        # real structured token line is a violation (issue #322).
+        assert len(secrets) == 1
 
 
 # ── Hooks JSON ──────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

The generic credential-assignment patterns in `content-embedded-secrets` (`password = "..."`, `api_key = "..."`, `secret_key`, `access_token`) fired on any quoted value of sufficient length — so obvious documentation placeholders like `password="hunter2placeholder"`, `api_key = "${MY_API_KEY}"`, or `access_token = "<paste-token-here>"` were reported as embedded secrets at ERROR severity. Skill and instruction files are full of exactly this kind of example content, making the rule noisy on real repos.

Part of #322, addresses the #147 lineage.

## Approach

Generic `key = "value"` matches are now gated by two false-positive filters (inspired by gitleaks/detect-secrets allowlist heuristics, kept simple and deterministic):

1. **Placeholder allowlist** — the captured value is skipped when it contains an obvious placeholder marker (`example`, `placeholder`, `dummy`, `sample`, `changeme`, `your-`/`your_`, `hunter2`, `password`, `secret`, `token`, `test`, `xxx`, ...), template/variable syntax (`<your-key>`, `${VAR}`, `{{ var }}`, `$VAR`), or is a single repeated character (`aaaaaaaa`, `********`).
2. **Shannon-entropy scoring** — surviving values must reach an entropy threshold (default **3.5 bits/char**) before being reported. Real random secrets (base64, hex, mixed-character passwords) comfortably pass; English-ish placeholder strings don't.

**Structured high-confidence token formats are untouched** — `AKIA...`, `ghp_...`, `sk-ant-...`, Slack/Stripe/Google/JWT patterns and private-key blocks always fire, regardless of entropy.

Entropy is computed only on post-regex candidate values (group 1 of the generic patterns), so the `patterns_matching_anywhere` prefilter fast path is unchanged and there are no per-line × per-pattern loops.

## Config options

Per the "rules should be configurable" standard, both gates are extensible via `config_schema`:

```yaml
rules:
  content-embedded-secrets:
    enabled: auto
    severity: error
    entropy-threshold: 3.5          # min bits/char for generic key = "value" matches
    additional-placeholders: []     # extra case-insensitive placeholder substrings
```

## Tests

- New parametrized regression tests: placeholder shapes (word-based, angle-bracket, `${...}`/`{{...}}` templates, all-same-char, low-entropy) produce no violation; realistic high-entropy generic values and structured tokens still fire at ERROR.
- Config coverage: raising/lowering `entropy-threshold`, `additional-placeholders`, invalid config falling back to the default, and placeholder gating in frontmatter fields.
- The `single-plugin/with-secrets` integration fixture gains a "Configuration examples" section of placeholders; `test_embedded_secrets_detected` now asserts only the real structured token fires.
- `make test` (2257 passed), `make lint`, `make update` all clean; dogfooded against `openshift-eng/ai-helpers` — lint output is identical to main's (same pre-existing strict-mode warnings, zero embedded-secrets findings).

Docs: the rule doc page (`src/skillsaw/rules/docs/content-embedded-secrets.md` and the generated `docs/rules/` page, README parameter table, `.skillsaw.yaml.example`) now describes the two-tier detection and the config options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secret detection now better distinguishes between obvious placeholders and real credentials, reducing noisy matches for generic values.
  * Added configurable options for tuning secret detection and allowing additional placeholder patterns.

* **Bug Fixes**
  * Improved handling so structured secret formats are still reported consistently.
  * YAML/frontmatter and inline examples now avoid false positives from placeholder-style values.

* **Documentation**
  * Expanded rule documentation with clearer detection behavior, default settings, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->