### PR TITLE
Honor metadata.pluginRoot when resolving marketplace plugin sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ skillsaw add hook PreToolUse
 
 skillsaw automatically detects your repo type and places files in the right location:
 
-- **Marketplace** — components go under `plugins/<name>/`
+- **Marketplace** — components go under `plugins/<name>/`, or under `metadata.pluginRoot` when marketplace.json sets one
 - **Single-plugin repo** — components go in the repo root
 - **`.claude/` repo** — components go under `.claude/`
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ marketplace/
 
 Plugins from `plugins/`, custom paths, and remote sources can coexist in one marketplace. Only local sources are validated.
 
+When marketplace.json sets `metadata.pluginRoot` (e.g. `"./plugins"`), it is prepended to relative plugin sources, so entries can use bare names like `"source": "formatter"` per the spec.
+
 ### `.claude/` Directory
 
 Repositories with a `.claude/` directory containing commands, skills, hooks, agents, or rules. When APM is present, `.claude/` is treated as compiled output and this type is not detected.

--- a/docs/rules/marketplace-json-valid.md
+++ b/docs/rules/marketplace-json-valid.md
@@ -45,8 +45,8 @@ in the violation message.
 
 Plugin entries are also validated: every entry needs a unique `name`
 and a `source`. A string source is a path relative to the marketplace
-root — it should start with `./` and must not escape the repository
-with `..`. An object source declares its type via the `source` field
+root — it should start with `./` and must not be an absolute path or
+escape the repository with `..`. An object source declares its type via the `source` field
 (`github`, `url`, `git-subdir`, or `npm`) and must carry that type's
 required fields (`repo`, `url`, `url` + `path`, or `package`
 respectively).
@@ -54,7 +54,8 @@ respectively).
 When `metadata.pluginRoot` is set, it is prepended to relative
 sources, so bare names like `"formatter"` are valid and the `./`
 style nudge does not apply. The plugin root itself must be a string
-and, like sources, must not escape the repository with `..`.
+and, like sources, must be a relative path that does not escape the
+repository with `..`.
 
 ## Configuration
 

--- a/docs/rules/marketplace-json-valid.md
+++ b/docs/rules/marketplace-json-valid.md
@@ -54,8 +54,9 @@ respectively).
 When `metadata.pluginRoot` is set, it is prepended to relative
 sources, so bare names like `"formatter"` are valid and the `./`
 style nudge does not apply. The plugin root itself must be a string
-and, like sources, must be a relative path that does not escape the
-repository with `..`.
+and, like sources, must not be an absolute path (values like
+`/tmp/plugins` are invalid) and must not escape the repository with
+`..`.
 
 ## Configuration
 

--- a/docs/rules/marketplace-json-valid.md
+++ b/docs/rules/marketplace-json-valid.md
@@ -51,6 +51,11 @@ with `..`. An object source declares its type via the `source` field
 required fields (`repo`, `url`, `url` + `path`, or `package`
 respectively).
 
+When `metadata.pluginRoot` is set, it is prepended to relative
+sources, so bare names like `"formatter"` are valid and the `./`
+style nudge does not apply. The plugin root itself must be a string
+and, like sources, must not escape the repository with `..`.
+
 ## Configuration
 
 ```yaml

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -451,12 +451,33 @@ class RepositoryContext:
         except (json.JSONDecodeError, IOError):
             return None
 
+    def marketplace_plugin_root(self) -> Optional[str]:
+        """
+        Return metadata.pluginRoot from marketplace.json, if set
+
+        Per the plugin-marketplaces spec, ``metadata.pluginRoot`` is a base
+        directory prepended to relative plugin source paths (e.g.
+        ``"./plugins"`` lets entries use ``"source": "formatter"`` instead
+        of ``"./plugins/formatter"``).
+        """
+        if not self.marketplace_data:
+            return None
+        metadata = self.marketplace_data.get("metadata")
+        if not isinstance(metadata, dict):
+            return None
+        plugin_root = metadata.get("pluginRoot")
+        if isinstance(plugin_root, str) and plugin_root:
+            return plugin_root
+        return None
+
     def _resolve_plugin_source(self, source: Any, plugin_entry: Dict[str, Any]) -> Optional[Path]:
         """
         Resolve a plugin source from marketplace.json to a local path
 
         Handles relative paths (e.g., "./", "./custom/path") and remote sources
-        (GitHub repos, git URLs). Remote sources are logged but skipped for local validation.
+        (GitHub repos, git URLs). Remote sources are logged but skipped for local
+        validation. Relative paths are resolved under metadata.pluginRoot when
+        the marketplace declares one.
 
         Args:
             source: Plugin source (string path or dict with source type)
@@ -469,7 +490,16 @@ class RepositoryContext:
 
         # Handle relative path strings
         if isinstance(source, str):
-            candidate = (self.root_path / source).resolve()
+            base = self.root_path
+            plugin_root = self.marketplace_plugin_root()
+            if plugin_root and not Path(source).is_absolute():
+                # metadata.pluginRoot is prepended to relative sources (both
+                # bare names and ./-prefixed paths). The containment check
+                # below still rejects any composed path that escapes the
+                # repository, so a traversing pluginRoot cannot smuggle a
+                # source outside the root.
+                base = base / plugin_root
+            candidate = (base / source).resolve()
 
             # Disallow escaping the repo with .. paths
             try:
@@ -629,6 +659,15 @@ class RepositoryContext:
             # Always store marketplace entry data for metadata merging
             self.marketplace_entries[resolved_path] = plugin_entry
 
+            # Store metadata for strict: false plugins without plugin.json.
+            # This must happen before the duplicate skip below so plugins the
+            # plugins/ dir scan already discovered still get their metadata.
+            is_strict = plugin_entry.get("strict", True)
+            has_plugin_json = (plugin_path / ".claude-plugin" / "plugin.json").exists()
+
+            if not is_strict and not has_plugin_json:
+                self.plugin_metadata[resolved_path] = plugin_entry
+
             # Skip duplicates for plugin discovery
             if resolved_path in discovered_paths:
                 continue
@@ -639,13 +678,6 @@ class RepositoryContext:
 
             plugins.append(plugin_path)
             discovered_paths.add(resolved_path)
-
-            # Store metadata for strict: false plugins without plugin.json
-            is_strict = plugin_entry.get("strict", True)
-            has_plugin_json = (plugin_path / ".claude-plugin" / "plugin.json").exists()
-
-            if not is_strict and not has_plugin_json:
-                self.plugin_metadata[resolved_path] = plugin_entry
 
     def get_plugin_name(self, plugin_path: Path) -> str:
         """

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -490,16 +490,21 @@ class RepositoryContext:
 
         # Handle relative path strings
         if isinstance(source, str):
-            base = self.root_path
+            candidate = (self.root_path / source).resolve()
             plugin_root = self.marketplace_plugin_root()
             if plugin_root and not Path(source).is_absolute():
                 # metadata.pluginRoot is prepended to relative sources (both
-                # bare names and ./-prefixed paths). The containment check
-                # below still rejects any composed path that escapes the
-                # repository, so a traversing pluginRoot cannot smuggle a
-                # source outside the root.
-                base = base / plugin_root
-            candidate = (base / source).resolve()
+                # bare names and ./-prefixed paths). Real-world marketplaces
+                # (e.g. jeremylongshore/claude-code-plugins-plus-skills) set
+                # pluginRoot while their sources already include that prefix,
+                # so prefer the spec composition but fall back to the
+                # root-relative path when only the latter exists. The
+                # containment check below still rejects any candidate that
+                # escapes the repository, so a traversing pluginRoot cannot
+                # smuggle a source outside the root.
+                composed = (self.root_path / plugin_root / source).resolve()
+                if composed.exists() or not candidate.exists():
+                    candidate = composed
 
             # Disallow escaping the repo with .. paths
             try:

--- a/src/skillsaw/marketplace/add.py
+++ b/src/skillsaw/marketplace/add.py
@@ -244,11 +244,15 @@ def _resolve_plugin_dir(root: Path, plugin_name: str) -> Path:
                     "cannot resolve a local plugin directory"
                 )
             # metadata.pluginRoot is prepended to relative sources, matching
-            # RepositoryContext._resolve_plugin_source.
-            base = root
+            # RepositoryContext._resolve_plugin_source: prefer the composed
+            # path, but fall back to the root-relative one when only it
+            # exists (real marketplaces set pluginRoot while their sources
+            # already include that prefix).
+            resolved = (root / source).resolve()
             if plugin_root and not Path(source).is_absolute():
-                base = root / plugin_root
-            resolved = (base / source).resolve()
+                composed = (root / plugin_root / source).resolve()
+                if composed.exists() or not resolved.exists():
+                    resolved = composed
             if not resolved.is_relative_to(root.resolve()):
                 raise ValueError(f"Plugin source {source!r} resolves outside marketplace root")
             return resolved

--- a/src/skillsaw/marketplace/add.py
+++ b/src/skillsaw/marketplace/add.py
@@ -178,6 +178,34 @@ def _marketplace_type(root: Path) -> str:
     return DEFAULT_MARKETPLACE_TYPE
 
 
+def _marketplace_plugin_root(root: Path) -> Optional[str]:
+    """Return metadata.pluginRoot from marketplace.json, if set and usable.
+
+    Mirrors ``RepositoryContext.marketplace_plugin_root()``: pluginRoot is a
+    base directory prepended to relative plugin source paths. A pluginRoot
+    that escapes the marketplace repository is ignored (marketplace-json-valid
+    flags it), so scaffolding never composes paths outside the root.
+    """
+    mp_path = root / ".claude-plugin" / "marketplace.json"
+    if not mp_path.exists():
+        return None
+    try:
+        data = json.loads(mp_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    plugin_root = metadata.get("pluginRoot")
+    if not isinstance(plugin_root, str) or not plugin_root:
+        return None
+    if not (root / plugin_root).resolve().is_relative_to(root.resolve()):
+        return None
+    return plugin_root
+
+
 def _register_plugin(root: Path, name: str, source: str, description: str) -> None:
     """Add a plugin entry to marketplace.json."""
     mp_path = root / ".claude-plugin" / "marketplace.json"
@@ -203,12 +231,24 @@ def _resolve_plugin_dir(root: Path, plugin_name: str) -> Path:
     plugins = data.get("plugins", [])
     if not isinstance(plugins, list):
         raise ValueError("Invalid marketplace.json: 'plugins' must be a list.")
+    plugin_root = _marketplace_plugin_root(root)
     for entry in plugins:
         if not isinstance(entry, dict):
             continue
         if entry.get("name") == plugin_name:
-            source = entry.get("source", f"./plugins/{plugin_name}")
-            resolved = (root / source).resolve()
+            default_source = f"./{plugin_name}" if plugin_root else f"./plugins/{plugin_name}"
+            source = entry.get("source", default_source)
+            if not isinstance(source, str):
+                raise ValueError(
+                    f"Plugin {plugin_name!r} uses a remote source; "
+                    "cannot resolve a local plugin directory"
+                )
+            # metadata.pluginRoot is prepended to relative sources, matching
+            # RepositoryContext._resolve_plugin_source.
+            base = root
+            if plugin_root and not Path(source).is_absolute():
+                base = root / plugin_root
+            resolved = (base / source).resolve()
             if not resolved.is_relative_to(root.resolve()):
                 raise ValueError(f"Plugin source {source!r} resolves outside marketplace root")
             return resolved
@@ -227,7 +267,16 @@ def add_plugin(
     """Create a new plugin with scaffold structure and register it."""
     _validate_kebab(name, "Plugin name")
     root = _find_marketplace_root(path or Path.cwd())
-    plugin_dir = root / "plugins" / name
+    # Scaffold under metadata.pluginRoot when the marketplace declares one,
+    # and register a source relative to it so the entry resolves per the
+    # plugin-marketplaces spec (pluginRoot is prepended to relative sources).
+    plugin_root = _marketplace_plugin_root(root)
+    if plugin_root:
+        plugin_dir = root / plugin_root / name
+        source = f"./{name}"
+    else:
+        plugin_dir = root / "plugins" / name
+        source = f"./plugins/{name}"
     if plugin_dir.exists():
         raise FileExistsError(f"Plugin directory already exists: {plugin_dir}")
 
@@ -256,7 +305,7 @@ def add_plugin(
     readme = apply_replacements(read_template("readme.md", mp_type), replacements)
     (plugin_dir / "README.md").write_text(readme, encoding="utf-8")
 
-    _register_plugin(root, name, f"./plugins/{name}", f"{name} plugin for Claude Code")
+    _register_plugin(root, name, source, f"{name} plugin for Claude Code")
 
     print(f"Created plugin: {name}")
     print(f"  {plugin_dir}/")

--- a/src/skillsaw/rules/builtin/marketplace/json_valid.py
+++ b/src/skillsaw/rules/builtin/marketplace/json_valid.py
@@ -19,6 +19,21 @@ def is_absolute_path(path: str) -> bool:
     return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
 
 
+def has_parent_traversal(path: str) -> bool:
+    """True when the path contains a '..' component."""
+    return ".." in path.replace("\\", "/").split("/")
+
+
+def is_valid_plugin_root(plugin_root: str) -> bool:
+    """True when metadata.pluginRoot is safe to compose with plugin sources:
+    a non-empty relative path with no '..' components."""
+    return (
+        bool(plugin_root)
+        and not is_absolute_path(plugin_root)
+        and not has_parent_traversal(plugin_root)
+    )
+
+
 # Required fields for each object source type per the plugin-marketplaces
 # docs; unknown types get a warning rather than an error so a new source
 # type added upstream never breaks existing marketplaces.
@@ -115,7 +130,7 @@ class MarketplaceJsonValidRule(Rule):
                 )
             else:
                 plugin_root = metadata["pluginRoot"]
-                if ".." in plugin_root.replace("\\", "/").split("/"):
+                if has_parent_traversal(plugin_root):
                     violations.append(
                         self.violation(
                             "metadata.pluginRoot: path contains '..' — the plugin "
@@ -199,8 +214,7 @@ class MarketplaceJsonValidRule(Rule):
                     )
                 )
                 return violations
-            parts = source.replace("\\", "/").split("/")
-            if ".." in parts:
+            if has_parent_traversal(source):
                 violations.append(
                     self.violation(
                         f"plugins[{idx}].source: path contains '..' — sources must "

--- a/src/skillsaw/rules/builtin/marketplace/json_valid.py
+++ b/src/skillsaw/rules/builtin/marketplace/json_valid.py
@@ -97,6 +97,26 @@ class MarketplaceJsonValidRule(Rule):
                 self.violation("'owner' must have a 'name' field", file_path=marketplace_file)
             )
 
+        plugin_root = None
+        metadata = marketplace.get("metadata")
+        if isinstance(metadata, dict) and "pluginRoot" in metadata:
+            if not isinstance(metadata["pluginRoot"], str):
+                violations.append(
+                    self.violation(
+                        "'metadata.pluginRoot' must be a string", file_path=marketplace_file
+                    )
+                )
+            else:
+                plugin_root = metadata["pluginRoot"]
+                if ".." in plugin_root.replace("\\", "/").split("/"):
+                    violations.append(
+                        self.violation(
+                            "metadata.pluginRoot: path contains '..' — the plugin "
+                            "root must stay within the marketplace repository",
+                            file_path=marketplace_file,
+                        )
+                    )
+
         if "plugins" not in marketplace:
             violations.append(self.violation("Missing 'plugins' array", file_path=marketplace_file))
         elif not isinstance(marketplace["plugins"], list):
@@ -143,11 +163,13 @@ class MarketplaceJsonValidRule(Rule):
                         )
                     )
                 else:
-                    violations.extend(self._check_source(entry["source"], idx, marketplace_file))
+                    violations.extend(
+                        self._check_source(entry["source"], idx, marketplace_file, plugin_root)
+                    )
 
         return violations
 
-    def _check_source(self, source, idx: int, marketplace_file) -> List[RuleViolation]:
+    def _check_source(self, source, idx: int, marketplace_file, plugin_root) -> List[RuleViolation]:
         """Validate a plugin entry's source (relative path or typed object)."""
         violations = []
 
@@ -161,7 +183,9 @@ class MarketplaceJsonValidRule(Rule):
                         file_path=marketplace_file,
                     )
                 )
-            elif not source.startswith("./"):
+            elif not source.startswith("./") and not plugin_root:
+                # With metadata.pluginRoot set, bare names (e.g. "formatter")
+                # are the documented form, so no style nudge applies.
                 violations.append(
                     self.violation(
                         f"plugins[{idx}].source: relative path '{source}' should "

--- a/src/skillsaw/rules/builtin/marketplace/json_valid.py
+++ b/src/skillsaw/rules/builtin/marketplace/json_valid.py
@@ -3,6 +3,7 @@ Rule: marketplace-json-valid
 """
 
 import re
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity
@@ -11,6 +12,12 @@ from skillsaw.lint_target import MarketplaceConfigNode
 from skillsaw.rules.builtin.utils import read_json
 
 _KEBAB_CASE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def is_absolute_path(path: str) -> bool:
+    """True for POSIX-absolute (/x) or Windows-absolute (C:\\x, \\\\share) paths."""
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
 
 # Required fields for each object source type per the plugin-marketplaces
 # docs; unknown types get a warning rather than an error so a new source
@@ -116,6 +123,15 @@ class MarketplaceJsonValidRule(Rule):
                             file_path=marketplace_file,
                         )
                     )
+                elif is_absolute_path(plugin_root):
+                    violations.append(
+                        self.violation(
+                            f"metadata.pluginRoot: absolute path '{plugin_root}' — "
+                            "the plugin root must be a relative path inside the "
+                            "marketplace repository",
+                            file_path=marketplace_file,
+                        )
+                    )
 
         if "plugins" not in marketplace:
             violations.append(self.violation("Missing 'plugins' array", file_path=marketplace_file))
@@ -174,6 +190,15 @@ class MarketplaceJsonValidRule(Rule):
         violations = []
 
         if isinstance(source, str):
+            if is_absolute_path(source):
+                violations.append(
+                    self.violation(
+                        f"plugins[{idx}].source: absolute path '{source}' — sources "
+                        "must be relative paths inside the marketplace repository",
+                        file_path=marketplace_file,
+                    )
+                )
+                return violations
             parts = source.replace("\\", "/").split("/")
             if ".." in parts:
                 violations.append(

--- a/src/skillsaw/rules/builtin/marketplace/registration.py
+++ b/src/skillsaw/rules/builtin/marketplace/registration.py
@@ -8,7 +8,7 @@ from typing import List
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import MarketplaceConfigNode, PluginNode
-from skillsaw.rules.builtin.marketplace.json_valid import is_absolute_path
+from skillsaw.rules.builtin.marketplace.json_valid import is_valid_plugin_root
 
 
 class MarketplaceRegistrationRule(Rule):
@@ -95,11 +95,7 @@ class MarketplaceRegistrationRule(Rule):
         metadata = data.get("metadata")
         if isinstance(metadata, dict) and isinstance(metadata.get("pluginRoot"), str):
             plugin_root = metadata["pluginRoot"]
-            if (
-                plugin_root
-                and not is_absolute_path(plugin_root)
-                and ".." not in plugin_root.replace("\\", "/").split("/")
-            ):
+            if is_valid_plugin_root(plugin_root):
                 source_base = (context.root_path / plugin_root).resolve()
 
         fixed_violations = []
@@ -118,11 +114,16 @@ class MarketplaceRegistrationRule(Rule):
                     try:
                         rel_source = str(plugin_node.path.relative_to(source_base))
                     except ValueError:
-                        try:
-                            rel_source = str(plugin_node.path.relative_to(context.root_path))
-                        except ValueError:
-                            pass
+                        # The plugin lives outside metadata.pluginRoot. Spec
+                        # consumers resolve every relative source under
+                        # pluginRoot and '..' is forbidden in sources, so no
+                        # correct relative source exists — skip rather than
+                        # register an entry that resolves to the wrong
+                        # location.
+                        rel_source = None
                     break
+            if rel_source is None:
+                continue
             # Relative sources must start with ./ per the marketplace spec.
             data["plugins"].append({"name": plugin_name, "source": f"./{rel_source}"})
             fixed_violations.append(v)

--- a/src/skillsaw/rules/builtin/marketplace/registration.py
+++ b/src/skillsaw/rules/builtin/marketplace/registration.py
@@ -84,6 +84,15 @@ class MarketplaceRegistrationRule(Rule):
         if not isinstance(data["plugins"], list):
             return results
 
+        # metadata.pluginRoot is prepended to relative sources when Claude
+        # Code resolves them, so generated sources must be relative to it.
+        source_base = context.root_path
+        metadata = data.get("metadata")
+        if isinstance(metadata, dict) and isinstance(metadata.get("pluginRoot"), str):
+            plugin_root = metadata["pluginRoot"]
+            if plugin_root and ".." not in plugin_root.replace("\\", "/").split("/"):
+                source_base = context.root_path / plugin_root
+
         fixed_violations = []
         for v in violations:
             if "not registered" not in v.message:
@@ -98,9 +107,12 @@ class MarketplaceRegistrationRule(Rule):
             for plugin_node in context.lint_tree.find(PluginNode):
                 if context.get_plugin_name(plugin_node.path) == plugin_name:
                     try:
-                        rel_source = str(plugin_node.path.relative_to(context.root_path))
+                        rel_source = str(plugin_node.path.relative_to(source_base))
                     except ValueError:
-                        pass
+                        try:
+                            rel_source = str(plugin_node.path.relative_to(context.root_path))
+                        except ValueError:
+                            pass
                     break
             # Relative sources must start with ./ per the marketplace spec.
             data["plugins"].append({"name": plugin_name, "source": f"./{rel_source}"})

--- a/src/skillsaw/rules/builtin/marketplace/registration.py
+++ b/src/skillsaw/rules/builtin/marketplace/registration.py
@@ -8,6 +8,7 @@ from typing import List
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import MarketplaceConfigNode, PluginNode
+from skillsaw.rules.builtin.marketplace.json_valid import is_absolute_path
 
 
 class MarketplaceRegistrationRule(Rule):
@@ -86,12 +87,20 @@ class MarketplaceRegistrationRule(Rule):
 
         # metadata.pluginRoot is prepended to relative sources when Claude
         # Code resolves them, so generated sources must be relative to it.
+        # Absolute or traversing pluginRoots are invalid (marketplace-json-valid
+        # flags them) and are ignored here. Resolve the base because
+        # plugin_node.path is fully resolved and relative_to() compares
+        # lexically.
         source_base = context.root_path
         metadata = data.get("metadata")
         if isinstance(metadata, dict) and isinstance(metadata.get("pluginRoot"), str):
             plugin_root = metadata["pluginRoot"]
-            if plugin_root and ".." not in plugin_root.replace("\\", "/").split("/"):
-                source_base = context.root_path / plugin_root
+            if (
+                plugin_root
+                and not is_absolute_path(plugin_root)
+                and ".." not in plugin_root.replace("\\", "/").split("/")
+            ):
+                source_base = (context.root_path / plugin_root).resolve()
 
         fixed_violations = []
         for v in violations:

--- a/src/skillsaw/rules/docs/marketplace-json-valid.md
+++ b/src/skillsaw/rules/docs/marketplace-json-valid.md
@@ -30,8 +30,8 @@ in the violation message.
 
 Plugin entries are also validated: every entry needs a unique `name`
 and a `source`. A string source is a path relative to the marketplace
-root — it should start with `./` and must not escape the repository
-with `..`. An object source declares its type via the `source` field
+root — it should start with `./` and must not be an absolute path or
+escape the repository with `..`. An object source declares its type via the `source` field
 (`github`, `url`, `git-subdir`, or `npm`) and must carry that type's
 required fields (`repo`, `url`, `url` + `path`, or `package`
 respectively).
@@ -39,4 +39,5 @@ respectively).
 When `metadata.pluginRoot` is set, it is prepended to relative
 sources, so bare names like `"formatter"` are valid and the `./`
 style nudge does not apply. The plugin root itself must be a string
-and, like sources, must not escape the repository with `..`.
+and, like sources, must be a relative path that does not escape the
+repository with `..`.

--- a/src/skillsaw/rules/docs/marketplace-json-valid.md
+++ b/src/skillsaw/rules/docs/marketplace-json-valid.md
@@ -39,5 +39,6 @@ respectively).
 When `metadata.pluginRoot` is set, it is prepended to relative
 sources, so bare names like `"formatter"` are valid and the `./`
 style nudge does not apply. The plugin root itself must be a string
-and, like sources, must be a relative path that does not escape the
-repository with `..`.
+and, like sources, must not be an absolute path (values like
+`/tmp/plugins` are invalid) and must not escape the repository with
+`..`.

--- a/src/skillsaw/rules/docs/marketplace-json-valid.md
+++ b/src/skillsaw/rules/docs/marketplace-json-valid.md
@@ -35,3 +35,8 @@ with `..`. An object source declares its type via the `source` field
 (`github`, `url`, `git-subdir`, or `npm`) and must carry that type's
 required fields (`repo`, `url`, `url` + `path`, or `package`
 respectively).
+
+When `metadata.pluginRoot` is set, it is prepended to relative
+sources, so bare names like `"formatter"` are valid and the `./`
+style nudge does not apply. The plugin root itself must be a string
+and, like sources, must not escape the repository with `..`.

--- a/tests/fixtures/marketplace/plugin-root-escape/.claude-plugin/marketplace.json
+++ b/tests/fixtures/marketplace/plugin-root-escape/.claude-plugin/marketplace.json
@@ -1,0 +1,8 @@
+{
+  "name": "escape-tools",
+  "owner": {"name": "ACME Corp"},
+  "metadata": {"pluginRoot": "../../shared-plugins"},
+  "plugins": [
+    {"name": "formatter", "source": "formatter", "description": "Format source files"}
+  ]
+}

--- a/tests/fixtures/marketplace/plugin-root-prefixed/.claude-plugin/marketplace.json
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/.claude-plugin/marketplace.json
@@ -1,0 +1,9 @@
+{
+  "name": "acme-prefixed-tools",
+  "owner": {"name": "ACME Corp", "url": "https://acme.example.com"},
+  "metadata": {"pluginRoot": "./plugins"},
+  "plugins": [
+    {"name": "deploy-helper", "source": "./plugins/deploy-helper", "description": "Deploy services to staging and production"},
+    {"name": "doc-checker", "source": "plugins/doc-checker", "description": "Check documentation for broken references"}
+  ]
+}

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/.claude-plugin/plugin.json
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "deploy-helper",
+  "description": "Deploy services to staging and production environments",
+  "version": "1.4.0",
+  "author": {"name": "Platform Team"}
+}

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/README.md
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/README.md
@@ -1,0 +1,7 @@
+# Deploy Helper
+
+Deploy services to staging and production environments.
+
+## Commands
+
+- `/deploy-helper:ship` — Deploy the current service to a target environment

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/commands/ship.md
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/deploy-helper/commands/ship.md
@@ -1,0 +1,23 @@
+---
+description: Deploy the current service to a target environment
+argument-hint: "[environment] [--dry-run]"
+---
+
+## Name
+deploy-helper:ship
+
+## Synopsis
+```text
+/deploy-helper:ship staging --dry-run
+```
+
+## Description
+Deploys the current service to the requested environment. A dry run prints
+the deployment plan without applying it.
+
+## Implementation
+1. Read the deployment manifest from `deploy.yaml`
+2. Validate the target environment exists in the manifest
+3. Build the release artifact and tag it with the git revision
+4. Apply the deployment, or print the plan when `--dry-run` is set
+5. Report the rollout status when the deployment completes

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/.claude-plugin/plugin.json
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "doc-checker",
+  "description": "Check documentation for broken references and stale examples",
+  "version": "0.9.2",
+  "author": {"name": "Docs Team"}
+}

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/README.md
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/README.md
@@ -1,0 +1,7 @@
+# Doc Checker
+
+Check documentation for broken references and stale examples.
+
+## Commands
+
+- `/doc-checker:scan` — Scan documentation for broken references

--- a/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/commands/scan.md
+++ b/tests/fixtures/marketplace/plugin-root-prefixed/plugins/doc-checker/commands/scan.md
@@ -1,0 +1,23 @@
+---
+description: Scan documentation for broken references
+argument-hint: "[path]"
+---
+
+## Name
+doc-checker:scan
+
+## Synopsis
+```text
+/doc-checker:scan docs/
+```
+
+## Description
+Scans the given documentation tree for broken links, references to files
+that no longer exist, and code examples that have drifted from the source.
+
+## Implementation
+1. Collect all markdown files under the given path
+2. Extract links and file references from each document
+3. Verify each reference resolves within the repository
+4. Compare fenced code examples against the referenced source files
+5. Print a report of broken references grouped by document

--- a/tests/fixtures/marketplace/plugin-root/.claude-plugin/marketplace.json
+++ b/tests/fixtures/marketplace/plugin-root/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "acme-tools",
+  "owner": {"name": "ACME Corp", "url": "https://acme.example.com"},
+  "metadata": {"pluginRoot": "./plugins"},
+  "plugins": [
+    {"name": "widget-maker", "source": "widget-maker", "description": "Build and manage widgets"},
+    {"name": "log-analyzer", "source": "./log-analyzer", "description": "Analyze application logs"},
+    {
+      "name": "release-notes",
+      "source": "release-notes",
+      "description": "Draft release notes from merged changes",
+      "version": "1.0.0",
+      "author": {"name": "Release Team"},
+      "strict": false
+    }
+  ]
+}

--- a/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/.claude-plugin/plugin.json
+++ b/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "log-analyzer",
+  "description": "Analyze application logs for errors, anomalies, and performance issues",
+  "version": "0.9.0",
+  "author": {"name": "Observability Team"}
+}

--- a/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/README.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/README.md
@@ -1,0 +1,7 @@
+# Log Analyzer
+
+Analyze application logs for errors, anomalies, and performance issues.
+
+## Commands
+
+- `/log-analyzer:search` — Search application logs with structured queries

--- a/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/commands/search.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/log-analyzer/commands/search.md
@@ -1,0 +1,28 @@
+---
+description: Search application logs with structured queries
+argument-hint: "<service> [--since 1h] [--level error]"
+---
+
+## Name
+log-analyzer:search
+
+## Synopsis
+```text
+/log-analyzer:search api-gateway --since 1h --level error
+```
+
+## Description
+Searches application logs from the specified service using structured
+query parameters. Supports filtering by time range, log level, and
+free-text patterns.
+
+Results are returned as a formatted table with timestamp, level,
+service, and message columns.
+
+## Implementation
+1. Parse the service name and query parameters from the arguments
+2. Construct a log query for the configured log backend (CloudWatch, Datadog, or local files)
+3. Execute the query with a maximum of 500 results
+4. Parse and deduplicate log entries
+5. Format results as a markdown table sorted by timestamp descending
+6. Highlight error and warning entries in the output

--- a/tests/fixtures/marketplace/plugin-root/plugins/release-notes/README.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/release-notes/README.md
@@ -1,0 +1,10 @@
+# Release Notes
+
+Draft release notes from merged pull requests since the last release tag.
+
+This plugin is published with `strict: false`, so its metadata lives in
+the marketplace catalog instead of a plugin.json manifest.
+
+## Commands
+
+- `/release-notes:draft` — Draft release notes grouped by change type

--- a/tests/fixtures/marketplace/plugin-root/plugins/release-notes/commands/draft.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/release-notes/commands/draft.md
@@ -1,0 +1,25 @@
+---
+description: Draft release notes from merged pull requests since the last tag
+argument-hint: "[--since v1.2.3]"
+---
+
+## Name
+release-notes:draft
+
+## Synopsis
+```text
+/release-notes:draft --since v1.2.3
+```
+
+## Description
+Collects merged pull requests since the last release tag and drafts
+release notes grouped by change type (features, fixes, docs).
+
+The plugin metadata for this plugin lives in marketplace.json with
+`strict: false`, so it has no plugin.json manifest of its own.
+
+## Implementation
+1. Determine the base tag from `--since` or the most recent git tag
+2. List merged pull requests since that tag using `gh pr list`
+3. Group entries by conventional-commit type
+4. Write the draft to `RELEASE_NOTES.md` for review

--- a/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/.claude-plugin/plugin.json
+++ b/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "widget-maker",
+  "description": "Build and manage widgets for the ACME platform",
+  "version": "2.1.0",
+  "author": {"name": "Widget Team"}
+}

--- a/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/README.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/README.md
@@ -1,0 +1,7 @@
+# Widget Maker
+
+Build and manage widgets for the ACME platform.
+
+## Commands
+
+- `/widget-maker:build` — Build a widget from its specification file

--- a/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/commands/build.md
+++ b/tests/fixtures/marketplace/plugin-root/plugins/widget-maker/commands/build.md
@@ -1,0 +1,23 @@
+---
+description: Build a widget from the current specification
+argument-hint: "[widget-name] [--watch]"
+---
+
+## Name
+widget-maker:build
+
+## Synopsis
+```text
+/widget-maker:build my-widget --watch
+```
+
+## Description
+Compiles a widget from its specification file into a deployable artifact.
+Supports watch mode for iterative development.
+
+## Implementation
+1. Read the widget specification from `widget.yaml`
+2. Validate all required fields are present
+3. Compile templates and assets into a single bundle
+4. Write output to `dist/` directory
+5. If `--watch` is set, monitor source files for changes and rebuild

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -208,6 +208,94 @@ def test_disallow_parent_traversal(temp_dir, caplog):
     assert any("escapes repository root" in record.message for record in caplog.records)
 
 
+def test_plugin_root_prepended_to_relative_sources(temp_dir):
+    """metadata.pluginRoot is prepended to bare and ./-prefixed relative sources"""
+    claude = temp_dir / ".claude-plugin"
+    claude.mkdir()
+    with open(claude / "marketplace.json", "w") as f:
+        json.dump(
+            {
+                "name": "test-marketplace",
+                "metadata": {"pluginRoot": "./tools"},
+                "plugins": [
+                    {"name": "bare-plugin", "source": "bare-plugin"},
+                    {"name": "dotted-plugin", "source": "./dotted-plugin"},
+                ],
+            },
+            f,
+        )
+
+    for name in ("bare-plugin", "dotted-plugin"):
+        plugin_dir = temp_dir / "tools" / name / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        with open(plugin_dir / "plugin.json", "w") as f:
+            json.dump({"name": name, "description": "A test plugin", "version": "1.0.0"}, f)
+
+    context = RepositoryContext(temp_dir)
+    assert context.repo_type == RepositoryType.MARKETPLACE
+    assert len(context.plugins) == 2
+    names = [context.get_plugin_name(p) for p in context.plugins]
+    assert "bare-plugin" in names
+    assert "dotted-plugin" in names
+
+
+def test_plugin_root_strict_false_metadata(temp_dir):
+    """strict: false metadata is found for plugins resolved through pluginRoot"""
+    claude = temp_dir / ".claude-plugin"
+    claude.mkdir()
+    with open(claude / "marketplace.json", "w") as f:
+        json.dump(
+            {
+                "name": "test-marketplace",
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [
+                    {
+                        "name": "no-manifest-plugin",
+                        "source": "no-manifest-plugin",
+                        "version": "2.0.0",
+                        "strict": False,
+                    }
+                ],
+            },
+            f,
+        )
+
+    commands = temp_dir / "plugins" / "no-manifest-plugin" / "commands"
+    commands.mkdir(parents=True)
+    (commands / "hello.md").write_text("# Hello\n\nSay hello.\n")
+
+    context = RepositoryContext(temp_dir)
+    assert len(context.plugins) == 1
+    metadata = context.get_plugin_metadata(context.plugins[0])
+    assert metadata is not None
+    assert metadata["name"] == "no-manifest-plugin"
+    assert metadata["version"] == "2.0.0"
+
+
+def test_plugin_root_traversal_rejected(temp_dir, caplog):
+    """A traversing pluginRoot must not let sources escape the repo root"""
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
+    claude = temp_dir / ".claude-plugin"
+    claude.mkdir()
+    with open(claude / "marketplace.json", "w") as f:
+        json.dump(
+            {
+                "name": "test-marketplace",
+                "metadata": {"pluginRoot": "../../shared"},
+                "plugins": [{"name": "evil-plugin", "source": "formatter"}],
+            },
+            f,
+        )
+
+    context = RepositoryContext(temp_dir)
+    assert context.repo_type == RepositoryType.MARKETPLACE
+    assert len(context.plugins) == 0
+    assert any("escapes repository root" in record.message for record in caplog.records)
+
+
 def test_dot_claude_detection(temp_dir):
     """Test detection of .claude/ directory with commands"""
     claude_dir = temp_dir / ".claude"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -272,6 +272,70 @@ def test_plugin_root_strict_false_metadata(temp_dir):
     assert metadata["version"] == "2.0.0"
 
 
+def test_plugin_root_sources_already_prefixed(temp_dir):
+    """Sources that already include the pluginRoot prefix still resolve.
+
+    Real marketplaces (e.g. jeremylongshore/claude-code-plugins-plus-skills)
+    set metadata.pluginRoot while their sources are full root-relative paths
+    like "./plugins/name". The spec composition ("plugins/plugins/name")
+    doesn't exist there, so resolution must fall back to the root-relative
+    path instead of dropping every plugin.
+    """
+    claude = temp_dir / ".claude-plugin"
+    claude.mkdir()
+    with open(claude / "marketplace.json", "w") as f:
+        json.dump(
+            {
+                "name": "test-marketplace",
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [
+                    {"name": "alpha", "source": "./plugins/alpha"},
+                    {"name": "beta", "source": "plugins/beta"},
+                ],
+            },
+            f,
+        )
+
+    for name in ("alpha", "beta"):
+        plugin_dir = temp_dir / "plugins" / name / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        with open(plugin_dir / "plugin.json", "w") as f:
+            json.dump({"name": name, "description": "A test plugin", "version": "1.0.0"}, f)
+
+    context = RepositoryContext(temp_dir)
+    assert context.repo_type == RepositoryType.MARKETPLACE
+    assert len(context.plugins) == 2
+    names = sorted(context.get_plugin_name(p) for p in context.plugins)
+    assert names == ["alpha", "beta"]
+
+
+def test_plugin_root_composed_path_wins_when_both_exist(temp_dir):
+    """When both the composed and root-relative paths exist, spec composition wins."""
+    claude = temp_dir / ".claude-plugin"
+    claude.mkdir()
+    with open(claude / "marketplace.json", "w") as f:
+        json.dump(
+            {
+                "name": "test-marketplace",
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [{"name": "plugins", "source": "plugins"}],
+            },
+            f,
+        )
+
+    # A plugin literally named "plugins" under pluginRoot: root-relative
+    # "plugins" (the pluginRoot dir itself) also exists, but the composed
+    # path plugins/plugins must win.
+    plugin_dir = temp_dir / "plugins" / "plugins" / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    with open(plugin_dir / "plugin.json", "w") as f:
+        json.dump({"name": "plugins", "description": "A test plugin", "version": "1.0.0"}, f)
+
+    context = RepositoryContext(temp_dir)
+    assert len(context.plugins) == 1
+    assert context.plugins[0].resolve() == (temp_dir / "plugins" / "plugins").resolve()
+
+
 def test_plugin_root_traversal_rejected(temp_dir, caplog):
     """A traversing pluginRoot must not let sources escape the repo root"""
     import logging

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -335,6 +335,20 @@ class TestMarketplace:
         assert "plugin-json-required" not in rule_ids(r)
         assert len(r["out"]["stats"]["plugins"]) == 3
 
+    def test_marketplace_plugin_root_prefixed_sources_resolve(self, tmp_path):
+        """Sources that already include the pluginRoot prefix still resolve.
+
+        Regression: real marketplaces (jeremylongshore/claude-code-plugins-
+        plus-skills) set pluginRoot while their sources are full root-relative
+        paths; strict spec composition dropped every plugin (0 discovered).
+        """
+        repo = copy_fixture("marketplace/plugin-root-prefixed", tmp_path)
+        r = run_lint(repo)
+        assert r["rc"] == 0
+        assert summary(r)["errors"] == 0
+        assert summary(r)["warnings"] == 0
+        assert len(r["out"]["stats"]["plugins"]) == 2
+
     def test_marketplace_plugin_root_traversal_rejected(self, tmp_path):
         """A pluginRoot escaping the repository is flagged and never resolved."""
         repo = copy_fixture("marketplace/plugin-root-escape", tmp_path)
@@ -1379,6 +1393,7 @@ CLEAN_FIXTURES = [
     "single-plugin/clean",
     "marketplace/clean",
     "marketplace/plugin-root",
+    "marketplace/plugin-root-prefixed",
     "agentskills/clean",
     "agentskills/unreferenced-clean",
     "dot-claude/clean",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -323,6 +323,26 @@ class TestMarketplace:
         assert "marketplace" in stats["repo_types"]
         assert len(stats["plugins"]) == 3
 
+    def test_marketplace_plugin_root_resolves_local_sources(self, tmp_path):
+        """metadata.pluginRoot is prepended to relative plugin sources (issue #343)."""
+        repo = copy_fixture("marketplace/plugin-root", tmp_path)
+        r = run_lint(repo)
+        assert r["rc"] == 0
+        assert summary(r)["errors"] == 0
+        assert summary(r)["warnings"] == 0
+        # The strict: false plugin resolved through pluginRoot must not be
+        # flagged for a missing plugin.json.
+        assert "plugin-json-required" not in rule_ids(r)
+        assert len(r["out"]["stats"]["plugins"]) == 3
+
+    def test_marketplace_plugin_root_traversal_rejected(self, tmp_path):
+        """A pluginRoot escaping the repository is flagged and never resolved."""
+        repo = copy_fixture("marketplace/plugin-root-escape", tmp_path)
+        r = run_lint(repo)
+        assert r["rc"] == 1
+        assert "marketplace-json-valid" in rule_ids(r)
+        assert len(r["out"]["stats"]["plugins"]) == 0
+
 
 # ── Agentskills ──────────────────────────────────────────────────
 
@@ -1358,6 +1378,7 @@ BROKEN_FIXTURES = [
 CLEAN_FIXTURES = [
     "single-plugin/clean",
     "marketplace/clean",
+    "marketplace/plugin-root",
     "agentskills/clean",
     "agentskills/unreferenced-clean",
     "dot-claude/clean",

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -869,6 +869,18 @@ class TestMalformedMarketplaceJson:
         resolved = _resolve_plugin_dir(root, "formatter")
         assert resolved == plugin_dir.resolve()
 
+    def test_resolve_plugin_dir_plugin_root_prefixed_source(self, temp_dir):
+        """Sources already including the pluginRoot prefix fall back to
+        root-relative resolution (real-world marketplaces do this)."""
+        root = self._make_plugin_root_marketplace(
+            temp_dir, "./plugins", [{"name": "formatter", "source": "./plugins/formatter"}]
+        )
+        plugin_dir = root / "plugins" / "formatter"
+        plugin_dir.mkdir(parents=True)
+
+        resolved = _resolve_plugin_dir(root, "formatter")
+        assert resolved == plugin_dir.resolve()
+
     def test_resolve_plugin_dir_traversing_plugin_root_ignored(self, temp_dir):
         """A pluginRoot escaping the repo is ignored, never composed."""
         root = self._make_plugin_root_marketplace(

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -280,6 +280,38 @@ class TestAddPlugin:
         with pytest.raises(ValueError, match="kebab-case"):
             add_plugin("MyPlugin", path=root)
 
+    def test_add_plugin_honors_plugin_root(self, temp_dir):
+        """Scaffolds under metadata.pluginRoot and registers a pluginRoot-relative source."""
+        root = self._init_mp(temp_dir)
+        mp_path = root / ".claude-plugin" / "marketplace.json"
+        data = json.loads(mp_path.read_text())
+        data["metadata"] = {"pluginRoot": "./pkgs"}
+        mp_path.write_text(json.dumps(data, indent=2) + "\n")
+
+        result = add_plugin("rooted-plugin", path=root)
+
+        assert result == root / "pkgs" / "rooted-plugin"
+        assert (result / ".claude-plugin" / "plugin.json").exists()
+        mp = json.loads(mp_path.read_text())
+        entry = next(p for p in mp["plugins"] if p["name"] == "rooted-plugin")
+        # ./rooted-plugin resolves as <root>/pkgs/rooted-plugin via pluginRoot
+        assert entry["source"] == "./rooted-plugin"
+
+    def test_add_plugin_traversing_plugin_root_falls_back(self, temp_dir):
+        """A pluginRoot escaping the repo is ignored; scaffold stays under plugins/."""
+        root = self._init_mp(temp_dir)
+        mp_path = root / ".claude-plugin" / "marketplace.json"
+        data = json.loads(mp_path.read_text())
+        data["metadata"] = {"pluginRoot": "../../escape"}
+        mp_path.write_text(json.dumps(data, indent=2) + "\n")
+
+        result = add_plugin("safe-plugin", path=root)
+
+        assert result == root / "plugins" / "safe-plugin"
+        mp = json.loads(mp_path.read_text())
+        entry = next(p for p in mp["plugins"] if p["name"] == "safe-plugin")
+        assert entry["source"] == "./plugins/safe-plugin"
+
     def test_add_plugin_sets_owner_from_config(self, temp_dir):
         root = self._init_mp(temp_dir)
         result = add_plugin("owned-plugin", path=root)
@@ -310,6 +342,33 @@ class TestAddComponents:
         content = skill_md.read_text()
         assert 'name: "my-skill"' in content
         assert "# My Skill" in content
+
+    def test_add_skill_honors_plugin_root(self, temp_dir):
+        """Skills land inside the pluginRoot-resolved plugin dir (issue #343)."""
+        root = temp_dir / "mp"
+        (root / ".claude-plugin").mkdir(parents=True)
+        (root / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "test-mp",
+                    "owner": {"name": "testuser"},
+                    "metadata": {"pluginRoot": "./pkgs"},
+                    "plugins": [{"name": "formatter", "source": "formatter"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        plugin_dir = root / "pkgs" / "formatter" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps({"name": "formatter", "description": "Formats", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+
+        result = add_skill("my-skill", "formatter", path=root)
+
+        assert result == root / "pkgs" / "formatter" / "skills" / "my-skill"
+        assert (result / "SKILL.md").exists()
 
     def test_add_command(self, temp_dir):
         root = self._init_with_plugin(temp_dir)
@@ -771,6 +830,64 @@ class TestMalformedMarketplaceJson:
         root = self._make_marketplace(temp_dir, "not-a-list")
         with pytest.raises(ValueError, match="must be a list"):
             _resolve_plugin_dir(root, "any-plugin")
+
+    def _make_plugin_root_marketplace(self, temp_dir, plugin_root, plugins_value):
+        """Create a minimal marketplace declaring metadata.pluginRoot."""
+        root = temp_dir / "mp"
+        root.mkdir()
+        (root / ".claude-plugin").mkdir()
+        data = {
+            "name": "test-mp",
+            "owner": {"name": "testuser"},
+            "metadata": {"pluginRoot": plugin_root},
+            "plugins": plugins_value,
+        }
+        (root / ".claude-plugin" / "marketplace.json").write_text(
+            json.dumps(data), encoding="utf-8"
+        )
+        return root
+
+    def test_resolve_plugin_dir_honors_plugin_root(self, temp_dir):
+        """Bare-name sources resolve under metadata.pluginRoot (issue #343)."""
+        root = self._make_plugin_root_marketplace(
+            temp_dir, "./pkgs", [{"name": "formatter", "source": "formatter"}]
+        )
+        plugin_dir = root / "pkgs" / "formatter"
+        plugin_dir.mkdir(parents=True)
+
+        resolved = _resolve_plugin_dir(root, "formatter")
+        assert resolved == plugin_dir.resolve()
+
+    def test_resolve_plugin_dir_plugin_root_dotted_source(self, temp_dir):
+        """./-prefixed sources also resolve under metadata.pluginRoot."""
+        root = self._make_plugin_root_marketplace(
+            temp_dir, "./pkgs", [{"name": "formatter", "source": "./formatter"}]
+        )
+        plugin_dir = root / "pkgs" / "formatter"
+        plugin_dir.mkdir(parents=True)
+
+        resolved = _resolve_plugin_dir(root, "formatter")
+        assert resolved == plugin_dir.resolve()
+
+    def test_resolve_plugin_dir_traversing_plugin_root_ignored(self, temp_dir):
+        """A pluginRoot escaping the repo is ignored, never composed."""
+        root = self._make_plugin_root_marketplace(
+            temp_dir, "../../escape", [{"name": "formatter", "source": "./plugins/formatter"}]
+        )
+        plugin_dir = root / "plugins" / "formatter"
+        plugin_dir.mkdir(parents=True)
+
+        resolved = _resolve_plugin_dir(root, "formatter")
+        assert resolved == plugin_dir.resolve()
+
+    def test_resolve_plugin_dir_remote_source_raises(self, temp_dir):
+        """A remote object source cannot resolve to a local directory."""
+        root = self._make_marketplace(
+            temp_dir,
+            [{"name": "remote", "source": {"source": "github", "repo": "acme/remote"}}],
+        )
+        with pytest.raises(ValueError, match="remote source"):
+            _resolve_plugin_dir(root, "remote")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -876,7 +876,46 @@ def test_marketplace_registration_fix_honors_plugin_root(temp_dir):
 
     fixes[0].file_path.write_text(fixes[0].fixed_content)
     invalidate_read_caches()
-    assert rule.check(RepositoryContext(repo)) == []
+    recheck_context = RepositoryContext(repo)
+    assert rule.check(recheck_context) == []
+    # Idempotency: a second fix pass has nothing to change.
+    assert rule.fix(recheck_context, rule.check(recheck_context)) == []
+    assert json.loads(fixes[0].file_path.read_text()) == data
+
+
+def test_marketplace_registration_fix_skips_plugin_outside_plugin_root(temp_dir):
+    """fix() must not register a plugin that lives outside metadata.pluginRoot.
+
+    Relative sources are resolved under pluginRoot by spec consumers and '..'
+    is forbidden, so no correct relative source exists for such a plugin —
+    writing a root-relative source would produce an entry that resolves to
+    the wrong location.
+    """
+    import json
+
+    repo = _marketplace_with_raw_json(
+        temp_dir,
+        json.dumps(
+            {
+                "name": "m",
+                "owner": {"name": "o"},
+                # The unregistered plugin lives at plugins/plugin-one,
+                # outside this pluginRoot.
+                "metadata": {"pluginRoot": "./pkgs"},
+                "plugins": [],
+            }
+        ),
+    )
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+
+    # No autofix is offered rather than a broken entry being written.
+    assert rule.fix(context, violations) == []
+    mp = json.loads((repo / ".claude-plugin" / "marketplace.json").read_text())
+    assert mp["plugins"] == []
 
 
 def test_marketplace_registration_fix_plugins_not_list(temp_dir):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -5,6 +5,8 @@ Tests for builtin rules
 import sys
 from pathlib import Path
 
+import pytest
+
 
 from skillsaw.context import RepositoryContext
 from skillsaw.rule import Severity
@@ -516,6 +518,36 @@ def test_marketplace_plugin_root_wrong_type_fails(temp_dir):
     repo = _marketplace_with(temp_dir, metadata={"pluginRoot": 42})
     violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
     assert any("'metadata.pluginRoot' must be a string" in v.message for v in violations)
+
+
+@pytest.mark.parametrize("plugin_root", ["/opt/plugins", "C:\\plugins"])
+def test_marketplace_plugin_root_absolute_fails(temp_dir, plugin_root):
+    """An absolute pluginRoot must be rejected — it can escape the repository."""
+    repo = _marketplace_with(
+        temp_dir,
+        metadata={"pluginRoot": plugin_root},
+        plugins=[{"name": "my-plugin", "source": "my-plugin"}],
+    )
+    violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
+    absolute = [
+        v for v in violations if "metadata.pluginRoot" in v.message and "absolute" in v.message
+    ]
+    assert len(absolute) == 1
+    assert absolute[0].severity == Severity.ERROR
+
+
+@pytest.mark.parametrize("source", ["/etc/passwd", "C:\\plugins\\tool"])
+def test_marketplace_source_absolute_path_fails(temp_dir, source):
+    """Absolute source paths are flagged, with or without pluginRoot set."""
+    repo = _marketplace_with(
+        temp_dir,
+        metadata={"pluginRoot": "./plugins"},
+        plugins=[{"name": "my-plugin", "source": source}],
+    )
+    violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
+    absolute = [v for v in violations if "absolute path" in v.message and ".source" in v.message]
+    assert len(absolute) == 1
+    assert absolute[0].severity == Severity.ERROR
 
 
 def test_marketplace_source_object_required_fields(temp_dir):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -486,6 +486,38 @@ def test_marketplace_source_missing_dot_slash_info(temp_dir):
     assert style[0].severity == Severity.INFO
 
 
+def test_marketplace_plugin_root_bare_source_no_style_nudge(temp_dir):
+    """With metadata.pluginRoot set, bare source names are the documented form."""
+    repo = _marketplace_with(
+        temp_dir,
+        metadata={"pluginRoot": "./plugins"},
+        plugins=[{"name": "my-plugin", "source": "my-plugin"}],
+    )
+    violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
+    assert not any("start with './'" in v.message for v in violations)
+
+
+def test_marketplace_plugin_root_traversal_fails(temp_dir):
+    """A pluginRoot containing '..' must be rejected."""
+    repo = _marketplace_with(
+        temp_dir,
+        metadata={"pluginRoot": "../../shared"},
+        plugins=[{"name": "my-plugin", "source": "my-plugin"}],
+    )
+    violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
+    traversal = [
+        v for v in violations if "metadata.pluginRoot" in v.message and "'..'" in v.message
+    ]
+    assert len(traversal) == 1
+    assert traversal[0].severity == Severity.ERROR
+
+
+def test_marketplace_plugin_root_wrong_type_fails(temp_dir):
+    repo = _marketplace_with(temp_dir, metadata={"pluginRoot": 42})
+    violations = MarketplaceJsonValidRule().check(RepositoryContext(repo))
+    assert any("'metadata.pluginRoot' must be a string" in v.message for v in violations)
+
+
 def test_marketplace_source_object_required_fields(temp_dir):
     """Each typed source object must carry its required fields."""
     repo = _marketplace_with(
@@ -778,6 +810,41 @@ def test_marketplace_registration_fix_registers_plugin(marketplace_repo):
     fix.file_path.write_text(fix.fixed_content)
     invalidate_read_caches()
     assert rule.check(RepositoryContext(marketplace_repo)) == []
+
+
+def test_marketplace_registration_fix_honors_plugin_root(temp_dir):
+    """fix() writes sources relative to metadata.pluginRoot when set, so the
+    generated entry round-trips through pluginRoot-aware source resolution."""
+    import json
+
+    from skillsaw.rules.builtin.utils import invalidate_read_caches
+
+    repo = _marketplace_with_raw_json(
+        temp_dir,
+        json.dumps(
+            {
+                "name": "m",
+                "owner": {"name": "o"},
+                "metadata": {"pluginRoot": "./plugins"},
+                "plugins": [],
+            }
+        ),
+    )
+    context = RepositoryContext(repo)
+    rule = MarketplaceRegistrationRule()
+
+    violations = rule.check(context)
+    assert len(violations) == 1
+
+    fixes = rule.fix(context, violations)
+    assert len(fixes) == 1
+
+    data = json.loads(fixes[0].fixed_content)
+    assert data["plugins"] == [{"name": "plugin-one", "source": "./plugin-one"}]
+
+    fixes[0].file_path.write_text(fixes[0].fixed_content)
+    invalidate_read_caches()
+    assert rule.check(RepositoryContext(repo)) == []
 
 
 def test_marketplace_registration_fix_plugins_not_list(temp_dir):


### PR DESCRIPTION
## Bug

Per the [Claude Code plugin-marketplaces spec](https://code.claude.com/docs/en/plugin-marketplaces), `metadata.pluginRoot` in marketplace.json is a "base directory prepended to relative plugin source paths" — e.g. `"metadata": {"pluginRoot": "./plugins"}` lets entries use `"source": "formatter"` instead of `"./plugins/formatter"`.

skillsaw resolved plugin sources directly against the repository root (`root_path / source`), so marketplaces using `pluginRoot` never had their local plugins resolved. That left `marketplace_entries` / `plugin_metadata` unpopulated, broke `strict: false` detection, and produced false `plugin-json-required` errors on spec-conformant marketplaces.

## Fix

- **`context.py` — `_resolve_plugin_source`**: relative string sources (both bare names and `./`-prefixed paths) now resolve as `root / pluginRoot / source`, exposed via a new `marketplace_plugin_root()` accessor. The existing containment check runs on the composed path, so a traversing `pluginRoot` (e.g. `"../../shared"`) is rejected by the same logic that rejects traversing sources — no new escape surface.
- **`context.py` — strict: false metadata**: the `plugin_metadata` store for `strict: false` entries now happens *before* the duplicate-discovery skip. In the typical pluginRoot layout all plugins live under `plugins/`, so the dir scan discovers them first and the old code skipped the metadata store entirely — leaving `plugin-json-required` firing on manifest-less `strict: false` plugins.
- **`marketplace-json-valid` (#338 rule)**: now validates `metadata.pluginRoot` (must be a string, must not contain `..`) and no longer emits the "should start with `./`" style nudge when `pluginRoot` is set, since bare names are the documented form there.
- **`marketplace-registration` autofix**: generated sources are written relative to `pluginRoot` when set, so they round-trip through pluginRoot-aware resolution instead of double-prefixing.

## Tests

- New fixture `tests/fixtures/marketplace/plugin-root`: bare-name, `./`-prefixed, and `strict: false` sources all resolved through `pluginRoot`; lints clean with zero errors/warnings and no `plugin-json-required` FP (added to `CLEAN_FIXTURES`).
- New fixture `tests/fixtures/marketplace/plugin-root-escape`: a traversing `pluginRoot` is flagged by `marketplace-json-valid` and resolves zero plugins.
- Unit tests for pluginRoot composition, strict: false metadata retrieval, traversal rejection, rule validation, and autofix round-trip.

`make test` (2254 passed), `make lint`, `make update` all clean. Dogfooded against `openshift-eng/ai-helpers`: byte-identical lint output vs. main (modulo timing line).

Part of #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marketplace `pluginRoot` paths, allowing plugin sources and generated placements to follow a custom marketplace layout.

* **Bug Fixes**
  * Improved path validation to reject absolute or escaping marketplace paths.
  * Ensured marketplace entries resolve correctly when sources are already prefixed or use relative paths.

* **Documentation**
  * Clarified marketplace path rules and how `pluginRoot` affects source resolution and component placement.

* **Tests**
  * Expanded coverage for plugin discovery, scaffolding, validation, and repository traversal cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->