### PR TITLE
Makefile: drop removed vertexai/bedrock extras from venv install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 
 $(VENV)/bin/activate: pyproject.toml
 	test -d $(VENV) || python3 -m venv $(VENV)
-	$(PIP) install -e '.[dev,docs,vertexai,bedrock]'
+	$(PIP) install -e '.[dev,docs]'
 	touch $(VENV)/bin/activate
 
 venv: $(VENV)/bin/activate


### PR DESCRIPTION
## Summary

`make venv` still installed `.[dev,docs,vertexai,bedrock]`, but the `vertexai` and `bedrock` optional-dependency groups were deleted from `pyproject.toml` when the LLM fix path was removed in 0.15. This kept pulling litellm and provider SDKs into dev environments for code that no longer exists. The venv target now installs `.[dev,docs]` only.

## Verification

- Rebuilt `.venv` from scratch with the new target; `pip list` shows no vertexai, litellm, google, or boto packages.
- `make test` — 2363 passed.
- `make lint` — clean.
- `make update` — no generated-file drift.
- Ran skillsaw against a fresh clone of `openshift-eng/ai-helpers`: exits 1 with 27 `typo` warnings ("SME", "unparseable"), but this reproduces identically on main — the false positives come from the pinned external `skillsaw-typos==0.1.0` dictionary, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)