### PR TITLE
Render the custom-rule loading warning as a readable colored line

### DIFF
--- a/src/skillsaw/cli/__init__.py
+++ b/src/skillsaw/cli/__init__.py
@@ -22,6 +22,10 @@ _SUBCOMMANDS = {
 
 
 def main():
+    from ._helpers import install_warning_display
+
+    install_warning_display()
+
     # When no subcommand is given (or the first arg looks like a path/flag),
     # default to "lint" so bare `skillsaw` and `skillsaw /path` keep working.
     # `add` has its own argparse — dispatch before the main parser sees the args.

--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import warnings
 from pathlib import Path
 
 from ..context import RepositoryContext, RepositoryType
@@ -155,3 +156,35 @@ def _ansi_colors():
         "reset": "" if no_color else "\033[0m",
         "no_color": no_color,
     }
+
+
+# ---------------------------------------------------------------------------
+# Warning display
+# ---------------------------------------------------------------------------
+
+
+def install_warning_display() -> None:
+    """Render skillsaw's own warnings as one readable line on stderr.
+
+    The stock ``warnings`` formatter prints the emitting source location and
+    code line (``linter.py:95: UserWarning: ...``), which reads like a crash.
+    Skillsaw warning categories get a compact colored line instead; every
+    other warning keeps the default rendering.
+    """
+    from ..linter import CustomRuleWarning
+
+    default_showwarning = warnings.showwarning
+
+    def _showwarning(message, category, filename, lineno, file=None, line=None):
+        if isinstance(message, CustomRuleWarning):
+            c = _ansi_colors()
+            print(
+                f"{c['yellow']}⚠ Loading custom rule file:{c['reset']} "
+                f"{c['bold']}{message.path}{c['reset']} "
+                f"{c['dim']}(use --no-custom-rules to skip){c['reset']}",
+                file=sys.stderr,
+            )
+        else:
+            default_showwarning(message, category, filename, lineno, file, line)
+
+    warnings.showwarning = _showwarning

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -26,6 +26,19 @@ if TYPE_CHECKING:
     from .baseline import BaselineFile, BaselineEntry
 
 
+class CustomRuleWarning(UserWarning):
+    """Emitted just before skillsaw executes a custom rule file from the repo.
+
+    Carries ``path`` so the CLI can render the notice as a readable colored
+    line instead of the stock ``warnings`` traceback format; library callers
+    still get a normal ``UserWarning`` they can filter.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        super().__init__(f"Loading custom rule file: {path} — use --no-custom-rules to skip")
+
+
 class Linter:
     """
     Main linter that orchestrates rule checking
@@ -288,10 +301,7 @@ class Linter:
         if not path.exists():
             raise ValueError(f"Custom rule file not found: {path}")
 
-        warnings.warn(
-            f"Loading custom rule file: {path} — use --no-custom-rules to skip",
-            stacklevel=2,
-        )
+        warnings.warn(CustomRuleWarning(path), stacklevel=2)
         logger.info("Loading custom rules from %s", path)
 
         # Unique module name per file so two custom rule files cannot clobber

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2361,6 +2361,35 @@ class TestNoCustomRulesLint:
         assert (
             "Loading custom rule file" in result.stderr
         ), "Expected a warning about custom rule loading on stderr"
+        # The CLI renders the notice itself — the stock warnings format
+        # (source path, "UserWarning:", echoed code line) must not leak.
+        assert (
+            "UserWarning" not in result.stderr
+        ), "Custom-rule notice should be human-readable, not the warnings-module format"
+        assert "_load_custom_rule" not in result.stderr
+
+    def test_custom_rule_warning_colors_respect_no_color(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        sentinel = tmp_path / "sentinel.txt"
+        base_env = {**os.environ, "SKILLSAW_SENTINEL": str(sentinel)}
+        args = [sys.executable, "-m", "skillsaw", "lint", str(repo)]
+
+        env = {k: v for k, v in base_env.items() if k != "NO_COLOR"}
+        result = subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+        colored = [ln for ln in result.stderr.splitlines() if "Loading custom rule file" in ln]
+        assert colored, f"missing custom-rule notice on stderr: {result.stderr}"
+        assert "\x1b[" in colored[0], "Notice should be colored when NO_COLOR is unset"
+
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**base_env, "NO_COLOR": "1"},
+        )
+        plain = [ln for ln in result.stderr.splitlines() if "Loading custom rule file" in ln]
+        assert plain, f"missing custom-rule notice on stderr: {result.stderr}"
+        assert "\x1b[" not in plain[0], "Notice must not contain ANSI codes under NO_COLOR"
 
     def test_no_warning_when_custom_rules_skipped(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)


### PR DESCRIPTION
## Summary

The notice about loading a custom rule file went through the stock `warnings` formatter, which prints the emitting source location and echoes the code line — it read like a crash rather than a notice:

```
/home/.../skillsaw/linter.py:95: UserWarning: Loading custom rule file: /home/.../.skillsaw/plugindocs_rule.py — use --no-custom-rules to skip
  self._load_custom_rule(custom_rule_path)
```

It now renders as one human-readable line per rule file on stderr — yellow `⚠` marker, bold path, dim hint — respecting `NO_COLOR` like the rest of the CLI:

```
⚠ Loading custom rule file: /home/.../.skillsaw/plugindocs_rule.py (use --no-custom-rules to skip)
```

## Changes

- `linter.py`: the warning is now a dedicated `CustomRuleWarning(UserWarning)` carrying the rule path. Library callers still get a filterable `UserWarning` subclass with the same message text, so existing `filterwarnings` setups keep working.
- `cli/_helpers.py`: new `install_warning_display()` — a `warnings.showwarning` override that renders `CustomRuleWarning` as a compact colored line via the existing `_ansi_colors()` helper (`NO_COLOR` respected). All other warning categories keep the default rendering.
- `cli/__init__.py`: installs the override at the top of `main()` so every subcommand gets it.

## Testing

- Full suite passes (2364 tests); `make lint` and `make update` clean.
- Extended integration tests: the existing warning test now asserts the `UserWarning:`/echoed-code-line format doesn't leak, and a new test verifies ANSI codes are present by default and absent under `NO_COLOR=1`.
- Verified against `ai-helpers` (three custom rule files): clean colored one-liners, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)