### PR TITLE
Warning display: respect the file argument in the showwarning override

### DIFF
--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -182,7 +182,7 @@ def install_warning_display() -> None:
                 f"{c['yellow']}⚠ Loading custom rule file:{c['reset']} "
                 f"{c['bold']}{message.path}{c['reset']} "
                 f"{c['dim']}(use --no-custom-rules to skip){c['reset']}",
-                file=sys.stderr,
+                file=sys.stderr if file is None else file,
             )
         else:
             default_showwarning(message, category, filename, lineno, file, line)


### PR DESCRIPTION
## Summary

Follow-up to #359, addressing the [Gemini review comment](https://github.com/stbenjam/skillsaw/pull/359#discussion_r4621421827) that landed after the merge.

The custom `_showwarning` override printed directly to `sys.stderr`, ignoring the `file` argument that `warnings.showwarning` implementations receive. Callers that redirect warnings to a file-like object (e.g. `warnings.catch_warnings`-based capture or test frameworks) would have their redirection bypassed. It now falls back to `sys.stderr` only when `file` is `None`, matching the stock implementation's contract.

## Testing

- Full suite passes (2364 tests); `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)