### PR TITLE
Swap skillsaw-typos for skillsaw-runbooks as the example plugin

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,4 +23,4 @@ jobs:
           strict: true
           no-custom-rules: false
           plugins: |
-            skillsaw-typos==0.1.0
+            skillsaw-runbooks==0.1.0

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ docker run -v $(pwd):/workspace ghcr.io/stbenjam/skillsaw
   with:
     strict: true
     plugins: |
-      skillsaw-typos==0.1.0
+      skillsaw-runbooks==0.1.0
 
 # Allow custom rules (disabled by default for security — see THREAT_MODEL.md T1)
 - uses: stbenjam/skillsaw@v0

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: 'false'
   plugins:
-    description: 'Newline-separated list of plugin packages to install (e.g. skillsaw-typos==0.1.0)'
+    description: 'Newline-separated list of plugin packages to install (e.g. skillsaw-runbooks==0.1.0)'
     required: false
     default: ''
   verbose:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -87,7 +87,7 @@ the remaining arguments forwarded verbatim, git-style — its exit code becomes
 skillsaw's exit code:
 
 ```console
-$ skillsaw typos accept        # runs: skillsaw-typos accept
+$ skillsaw runbooks list       # runs: skillsaw-runbooks list
 ```
 
 Dispatch rules:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -88,6 +88,8 @@ skillsaw's exit code:
 
 ```console
 $ skillsaw runbooks list       # runs: skillsaw-runbooks list
+runbooks/db-failover.md: Database failover to the replica — storage-team
+runbooks/cache-flush.md: Flush the Redis cache — payments-team
 ```
 
 Dispatch rules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "black>=26,<27",
     "flake8>=6.0",
     "mypy>=1.0",
-    "skillsaw-typos==0.1.0",
+    "skillsaw-runbooks==0.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

skillsaw-typos is a poor example plugin: skills are dense with technical vocabulary, so its codespell dictionary flags legitimate terms constantly, and a dictionary-driven rule doesn't teach anyone how to write a plugin.

[skillsaw-runbooks](https://github.com/stbenjam/skillsaw-runbooks) ([PyPI](https://pypi.org/project/skillsaw-runbooks/)) replaces it everywhere skillsaw references an example plugin. It lints operational runbooks as agent content with three simple, readable rules — and it exercises **every plugin extension point**, including the new custom repo type and content path support:

- `runbook-required-sections`, `runbook-frontmatter`, `runbook-catalog` — all scoped `repo_types = {"runbook"}`, all with `config_schema`
- a `runbook` `PluginRepoType` whose `content_paths` pull `runbooks/**/*.md` into builtin `content-*` linting
- a tree contributor attaching `runbooks/catalog.json` as a `JsonConfigBlock`
- a `skillsaw-runbooks` console script, so the `skillsaw <name>` subcommand example in docs/plugins.md stays real (`skillsaw runbooks list`)

## Changes

- `pyproject.toml`: dev extra `skillsaw-typos==0.1.0` → `skillsaw-runbooks==0.1.0`
- `.github/workflows/test-action.yml`: action self-test installs the new plugin
- `README.md`, `action.yml`: plugin examples updated
- `docs/plugins.md`: subcommand example `skillsaw typos accept` → `skillsaw runbooks list`

## Testing

- `make test` — 2364 passed with skillsaw-runbooks installed in the venv (typos removed)
- `make lint` / `make update` — clean, no drift
- Action-style self-lint (`skillsaw lint --strict --no-custom-rules .`) with the plugin loaded — exit 0
- `openshift-eng/ai-helpers` — exit 0
- Plugin's own suite: 21 tests, green on Python 3.9/3.12/3.14

skillsaw-runbooks 0.1.0 is published to PyPI, so the `[dev]` extra and the action self-test resolve. The plugin is inert on repos without a `runbooks/` directory, so the self-test exercises plugin loading without new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples to reference a different plugin package and command in the README and plugin docs.
  * Clarified the action’s plugin input example to match the latest supported plugin set.

* **Chores**
  * Refreshed the test workflow and development dependency configuration to use the updated plugin package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->