### PR TITLE
Pre-0.15.0 bug sweep: plugin fault isolation, autofix corruption, rule accuracy

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -26,7 +26,7 @@ rules:
     enabled: false
     severity: warning
 
-  # Skill name must be lowercase with hyphens and match directory name
+  # Skill name must be lowercase letters, numbers, and hyphens and match directory name
   agentskill-name:
     enabled: auto
     severity: error

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ These rules validate skills against the [agentskills.io specification](https://a
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
 | `agentskill-valid` | SKILL.md must have valid frontmatter with name and description | error (auto) | auto |
-| `agentskill-name` | Skill name must be lowercase with hyphens and match directory name | error (auto) | auto |
+| `agentskill-name` | Skill name must be lowercase letters, numbers, and hyphens and match directory name | error (auto) | auto |
 | `agentskill-rename-refs` | Update stale skill name references after a rename | warning (auto) | auto |
 | `agentskill-description` | Skill description should be meaningful and within length limits | warning (auto) | - |
 | `agentskill-structure` | Skill directories should only contain recognized subdirectories (stricter than spec) | warning (disabled) | - |
@@ -650,7 +650,7 @@ These rules validate skills against the [agentskills.io specification](https://a
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`) as referencing every file under it | `true` |
+| `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`, `./canvas-fonts`, or `assets/fonts` when the directory exists) as referencing every file under it | `true` |
 | `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names; a leading `**/` also matches at the skill root) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
 
 ### Plugin Structure

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -161,7 +161,7 @@ skillsaw discovers plugins through the `skillsaw.plugins` entry point group:
 name = "skillsaw-acme-rules"
 version = "0.1.0"
 requires-python = ">=3.9"
-dependencies = ["skillsaw>=0.14"]
+dependencies = ["skillsaw>=0.15"]
 
 [project.entry-points."skillsaw.plugins"]
 acme = "skillsaw_acme_rules"

--- a/docs/rules/agentskill-name.md
+++ b/docs/rules/agentskill-name.md
@@ -3,7 +3,7 @@
 
 # agentskill-name
 
-Skill name must be lowercase with hyphens and match directory name
+Skill name must be lowercase letters, numbers, and hyphens and match directory name
 
 | | |
 |---|---|
@@ -41,7 +41,8 @@ name: deploy-staging
 ## How to fix
 
 Rename the `name` field in SKILL.md frontmatter to match the skill's
-directory name, using lowercase letters and hyphens. `skillsaw fix`
+directory name, using lowercase letters, numbers, and hyphens (a
+leading digit is allowed, e.g. `1password`). `skillsaw fix`
 can correct the name automatically.
 
 ## Configuration

--- a/docs/rules/agentskill-unreferenced-files.md
+++ b/docs/rules/agentskill-unreferenced-files.md
@@ -46,14 +46,33 @@ code blocks (`python scripts/run.py`), and plain prose:
 
 - Relative paths count: `scripts/run.py`, `./scripts/run.py`, or
   `img/logo.png` from a file in the same directory.
+- Matching is case-insensitive: SKILL.md saying `FORMS.md` covers a
+  `forms.md` on disk — such references work on case-insensitive
+  filesystems.
 - Bare filenames count: a mention of `run.py` anywhere marks
   `scripts/run.py` as referenced. Skills routinely refer to bundled
   scripts by name alone, so requiring full paths would flag
   heavily-referenced files.
 - Directory mentions cover their contents (configurable): "read the
   files in `references/`" marks everything under `references/` as
-  referenced. Prose and code mentions need the trailing slash; links
-  may target the bare directory.
+  referenced. Prose and code mentions must be path-ish — a trailing
+  slash (`references/`), a `./` prefix (`./canvas-fonts`), or an
+  interior `/` (`assets/fonts`); the slash-less forms only count when
+  the directory actually exists in the skill, and a bare word with no
+  path markers never covers anything. Links may target the bare
+  directory.
+- Python imports are followed: when a reachable file is a `.py` file,
+  its imports are resolved within the skill (relative to the skill
+  root and to the importing file's directory, including relative
+  imports), so SKILL.md → `scripts/recalc.py` → `from office.soffice
+  import ...` covers `scripts/office/soffice.py`. Imported modules
+  join the traversal, so files they mention (a schema referenced from
+  a docstring) are covered too. `from a.b import c` covers `a/b/c.py`
+  when it exists, otherwise the `a.b` module; package `__init__.py`
+  files along the path are covered as well. Imports shown inside
+  python-labeled (or unlabeled) fenced code blocks of reachable
+  markdown count the same way: a SKILL.md fence teaching `from
+  core.gif_builder import GIFBuilder` covers `core/gif_builder.py`.
 
 Never flagged: SKILL.md itself, README.md, CHANGELOG.md, LICENSE* and
 NOTICE* files (any suffix, e.g. `LICENSE-MIT`), files under `evals/`
@@ -112,7 +131,7 @@ rules:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`) as referencing every file under it | `true` |
+| `directory_mention_covers` | Treat a mention of a directory (e.g. `references/`, `./canvas-fonts`, or `assets/fonts` when the directory exists) as referencing every file under it | `true` |
 | `exclude` | Additional glob patterns (matched against skill-relative paths and bare file names; a leading `**/` also matches at the skill root) exempt from dead-file detection; extends the built-in exclusions (SKILL.md, README.md, CHANGELOG.md, LICENSE*, NOTICE*, evals/, tests/, test_*.py, testdata/, hidden files) | `[]` |
 
 

--- a/docs/rules/agentskills.md
+++ b/docs/rules/agentskills.md
@@ -8,7 +8,7 @@ These rules validate skills against the [agentskills.io specification](https://a
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
 | [`agentskill-valid`](agentskill-valid.md) | SKILL.md must have valid frontmatter with name and description | error (auto) | auto |
-| [`agentskill-name`](agentskill-name.md) | Skill name must be lowercase with hyphens and match directory name | error (auto) | auto |
+| [`agentskill-name`](agentskill-name.md) | Skill name must be lowercase letters, numbers, and hyphens and match directory name | error (auto) | auto |
 | [`agentskill-rename-refs`](agentskill-rename-refs.md) | Update stale skill name references after a rename | warning (auto) | auto |
 | [`agentskill-description`](agentskill-description.md) | Skill description should be meaningful and within length limits | warning (auto) | - |
 | [`agentskill-structure`](agentskill-structure.md) | Skill directories should only contain recognized subdirectories (stricter than spec) | warning (disabled) | - |

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -27,7 +27,7 @@ organized into the following categories:
 | Rule ID | Description | Default Severity | Autofix | Category |
 |---------|-------------|------------------|---------|----------|
 | [`agentskill-valid`](agentskill-valid.md) | SKILL.md must have valid frontmatter with name and description | error (auto) | auto | agentskills.io |
-| [`agentskill-name`](agentskill-name.md) | Skill name must be lowercase with hyphens and match directory name | error (auto) | auto | agentskills.io |
+| [`agentskill-name`](agentskill-name.md) | Skill name must be lowercase letters, numbers, and hyphens and match directory name | error (auto) | auto | agentskills.io |
 | [`agentskill-rename-refs`](agentskill-rename-refs.md) | Update stale skill name references after a rename | warning (auto) | auto | agentskills.io |
 | [`agentskill-description`](agentskill-description.md) | Skill description should be meaningful and within length limits | warning (auto) | - | agentskills.io |
 | [`agentskill-structure`](agentskill-structure.md) | Skill directories should only contain recognized subdirectories (stricter than spec) | warning (disabled) | - | agentskills.io |

--- a/examples/plugins/skillsaw-example-plugin/pyproject.toml
+++ b/examples/plugins/skillsaw-example-plugin/pyproject.toml
@@ -9,7 +9,7 @@ description = "Example skillsaw plugin: flags TODO/FIXME comments in instruction
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "skillsaw>=0.14",
+    "skillsaw>=0.15",
 ]
 
 # This is what makes the package a skillsaw plugin: skillsaw scans the

--- a/skills/skillsaw-create-plugin/SKILL.md
+++ b/skills/skillsaw-create-plugin/SKILL.md
@@ -76,7 +76,7 @@ version = "0.1.0"
 description = "<one line: what the rules enforce>"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["skillsaw>=0.14"]
+dependencies = ["skillsaw>=0.15"]
 
 [project.entry-points."skillsaw.plugins"]
 <name> = "skillsaw_<name>"

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -732,9 +732,12 @@ class RepositoryContext:
             try:
                 with open(plugin_json, "r") as f:
                     data = json.load(f)
-                    name = data.get("name")
-                    if name and isinstance(name, str):
-                        return name
+                    # A malformed plugin.json can hold any JSON type, not
+                    # just an object.
+                    if isinstance(data, dict):
+                        name = data.get("name")
+                        if name and isinstance(name, str):
+                            return name
             except (json.JSONDecodeError, IOError):
                 pass
 

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -724,20 +724,25 @@ class RepositoryContext:
         """
         resolved_path = plugin_path.resolve()
 
-        # Try plugin.json
+        # Try plugin.json. Non-string names (invalid, flagged by validation
+        # rules) fall through to the directory-name fallback rather than
+        # propagating a TypeError into rules that expect a string.
         plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
         if plugin_json.exists():
             try:
                 with open(plugin_json, "r") as f:
                     data = json.load(f)
-                    if name := data.get("name"):
+                    name = data.get("name")
+                    if name and isinstance(name, str):
                         return name
             except (json.JSONDecodeError, IOError):
                 pass
 
         # Try marketplace metadata
         if resolved_path in self.plugin_metadata:
-            return self.plugin_metadata[resolved_path].get("name", plugin_path.name)
+            name = self.plugin_metadata[resolved_path].get("name", plugin_path.name)
+            if isinstance(name, str):
+                return name
 
         # Fall back to directory name
         return plugin_path.name

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -272,7 +272,17 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     # User-configured content paths plus globs contributed by detected
     # plugin repo types; the ``seen`` set dedupes any overlap.
     for glob_pattern in [*context.content_paths, *context.plugin_content_paths]:
-        for extra in sorted(context.root_path.glob(glob_pattern)):
+        try:
+            matches = sorted(context.root_path.glob(glob_pattern))
+        except (NotImplementedError, ValueError) as e:
+            # Path.glob() rejects absolute patterns (NotImplementedError)
+            # and some malformed ones (ValueError). The tree builds lazily
+            # inside each rule's check(), so an invalid pattern — from user
+            # config ``content-paths`` or a plugin repo type — would
+            # otherwise surface as one rule-execution-error per rule.
+            logger.warning("Ignoring invalid content path glob %r: %s", glob_pattern, e)
+            continue
+        for extra in matches:
             if extra.is_file():
                 _add_block(root, extra, ExtraBlock)
 

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -172,6 +172,10 @@ class Linter:
             for rule_class in plugin.rule_classes:
                 try:
                     rule_instance = rule_class()
+                    # rule_id is a plugin-controlled property: a raising
+                    # implementation must be fault-isolated exactly like a
+                    # failing constructor, or one bad plugin aborts the lint.
+                    rid = rule_instance.rule_id
                 except Exception as e:
                     self._plugin_load_violations.append(
                         RuleViolation(
@@ -179,14 +183,13 @@ class Linter:
                             severity=Severity.ERROR,
                             message=(
                                 f"Plugin '{plugin.name}': rule class "
-                                f"{rule_class.__name__} could not be instantiated: "
+                                f"{rule_class.__name__} could not be loaded: "
                                 f"{e.__class__.__name__}: {e}"
                             ),
                         )
                     )
                     continue
 
-                rid = rule_instance.rule_id
                 if rid in self._known_rule_ids:
                     # First loader wins (builtins, then earlier plugins); a
                     # shadowing rule would silently change what a rule ID means.
@@ -233,14 +236,31 @@ class Linter:
                 # or "auto") is supplied directly. Semantics match builtins:
                 # "auto" follows repo_types/formats detection, False is
                 # opt-in via config.
-                if self._rule_ids or self.config.is_rule_enabled(
-                    rid,
-                    self.context,
-                    rule_instance.repo_types,
-                    rule_instance.formats,
-                    since_version=rule_instance.since,
-                    default_enabled=rule_instance.default_enabled,
-                ):
+                try:
+                    # repo_types/formats/since/default_enabled are read from
+                    # the plugin's class here — same fault isolation as above.
+                    enabled = bool(self._rule_ids) or self.config.is_rule_enabled(
+                        rid,
+                        self.context,
+                        rule_instance.repo_types,
+                        rule_instance.formats,
+                        since_version=rule_instance.since,
+                        default_enabled=rule_instance.default_enabled,
+                    )
+                except Exception as e:
+                    self._plugin_load_violations.append(
+                        RuleViolation(
+                            rule_id="plugin-load-error",
+                            severity=Severity.ERROR,
+                            message=(
+                                f"Plugin '{plugin.name}': rule '{rid}' raised "
+                                f"while evaluating enablement: "
+                                f"{e.__class__.__name__}: {e}"
+                            ),
+                        )
+                    )
+                    continue
+                if enabled:
                     rule_instance._source = f"plugin:{plugin.name}"
                     self.rules.append(rule_instance)
                     logger.info("Rule %-30s enabled (plugin: %s)", rid, plugin.name)

--- a/src/skillsaw/plugins.py
+++ b/src/skillsaw/plugins.py
@@ -32,7 +32,7 @@ import re
 import types
 from dataclasses import dataclass, field
 from importlib import metadata
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable, Iterable, List, Optional, Set, Type
 
 from .rule import Rule
@@ -91,6 +91,16 @@ class PluginRepoType:
             raise TypeError(
                 f"PluginRepoType '{self.name}': content_paths must be a list of glob strings"
             )
+        for pattern in self.content_paths:
+            # Path.glob() raises NotImplementedError on absolute patterns;
+            # reject them at load time (both POSIX and Windows forms) so the
+            # plugin fails with one clear error instead of crashing every rule.
+            if PurePosixPath(pattern).is_absolute() or PureWindowsPath(pattern).is_absolute():
+                raise ValueError(
+                    f"PluginRepoType '{self.name}': content_paths pattern "
+                    f"{pattern!r} is absolute — glob patterns must be "
+                    "relative to the repository root"
+                )
 
 
 @dataclass

--- a/src/skillsaw/rules/builtin/agentskills/name.py
+++ b/src/skillsaw/rules/builtin/agentskills/name.py
@@ -72,7 +72,7 @@ class AgentSkillNameRule(Rule):
 
     @property
     def description(self) -> str:
-        return "Skill name must be lowercase with hyphens and match directory name"
+        return "Skill name must be lowercase letters, numbers, and hyphens and match directory name"
 
     def default_severity(self) -> Severity:
         return Severity.ERROR

--- a/src/skillsaw/rules/builtin/agentskills/rename_refs.py
+++ b/src/skillsaw/rules/builtin/agentskills/rename_refs.py
@@ -9,7 +9,10 @@ from skillsaw.rule import Rule, RuleViolation, AutofixResult, AutofixConfidence,
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.lint_target import SkillNode
 from skillsaw.markdown_doc import splice
-from skillsaw.rules.builtin.content_analysis import gather_all_content_blocks
+from skillsaw.rules.builtin.content_analysis import (
+    gather_all_content_blocks,
+    patterns_matching_anywhere,
+)
 
 from ._helpers import (
     _read_renames_manifest,
@@ -64,6 +67,7 @@ class AgentSkillRenameRefsRule(Rule):
         violations = []
         old_names = {r["old"] for r in renames}
         patterns = {r["old"]: _name_pattern(r["old"]) for r in renames}
+        pattern_specs = [(patterns[r["old"]], r) for r in renames]
         referenced_olds: set[str] = set()
 
         for block in gather_all_content_blocks(context):
@@ -71,10 +75,15 @@ class AgentSkillRenameRefsRule(Rule):
                 content = block.path.read_text(encoding="utf-8")
             except OSError:
                 continue
+            # Whole-text prefilter (C-speed literal check) so the per-line
+            # regex loop only runs for renames actually present in the block;
+            # results-identical to scanning every line with every pattern.
+            active = patterns_matching_anywhere(content, pattern_specs)
+            if not active:
+                continue
             lines = content.splitlines()
-            for rename in renames:
+            for pattern, rename in active:
                 old, new = rename["old"], rename["new"]
-                pattern = patterns[old]
                 for line_no, line in enumerate(lines, 1):
                     if not pattern.search(line):
                         continue

--- a/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
+++ b/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
@@ -35,6 +35,11 @@ scripts/run.py``) rather than linked:
   ``text_segments()`` accessor surfaces (and additionally covers YAML
   frontmatter), with no per-line markdown parsing.
 
+**Matching is case-insensitive.**  SKILL.md saying ``FORMS.md`` covers a
+``forms.md`` on disk: such references work on case-insensitive
+filesystems, so flagging them would be false positives.  Each source
+blob is lowered once and scanned with lowered needles.
+
 **Bare filenames count.**  A mention of ``run.py`` anywhere marks
 ``scripts/run.py`` as referenced.  Skills routinely refer to bundled
 scripts by name alone ("run helper.py from the scripts directory"), so
@@ -46,9 +51,29 @@ warning-severity hygiene rule.
 **Directory mentions cover their contents** (``directory_mention_covers``,
 default true): when SKILL.md says "read the files in ``references/``",
 every file under ``references/`` counts as referenced.  Prose/code
-directory mentions require the trailing slash (so the English word
-"references" is not a directory mention); links may target the bare
-directory path.
+directory mentions must be path-ish: a trailing slash (``references/``),
+a ``./`` prefix (``./canvas-fonts``), or an interior ``/``
+(``assets/fonts``) — and slash-less forms only count when they resolve
+to a directory that actually exists in the skill.  A bare word with no
+path markers (the English word "references") is never a directory
+mention.  Links may target the bare directory path.
+
+**Python imports are followed.**  When a reachable file is a ``.py``
+file, its imports are parsed (``ast.parse``, with a line-based regex
+fallback for sources the parser rejects) and dotted module paths are
+resolved to files within the skill — relative to the skill root and to
+the importing file's directory, including relative imports (``from .
+import x``, ``from ..pkg import y``).  ``from a.b import c`` marks
+``a/b/c.py`` when it exists, otherwise the ``a.b`` module itself;
+package ``__init__.py`` files along the dotted path are marked too.
+Imported modules join the traversal, so their own text mentions and
+imports are followed in turn (SKILL.md -> ``scripts/recalc.py`` ->
+``from office.soffice import ...`` -> ``scripts/office/soffice.py`` ->
+``schemas/foo.xsd``).  Imports inside python-labeled (or unlabeled)
+fenced code blocks of reachable markdown files are followed the same
+way — instructional SKILL.md fences like ``from core.gif_builder
+import GIFBuilder`` reference the module as surely as a script's own
+import does.
 
 Built-in exclusions (never flagged): SKILL.md itself, README.md,
 CHANGELOG.md, LICENSE* / NOTICE* (any suffix), everything under evals/
@@ -67,9 +92,11 @@ SKILL.md: it is standard human-facing documentation, so a bundled file
 documented there is neither dead weight nor hidden from review.
 """
 
+import ast
 import fnmatch
 import os
 import re
+import textwrap
 from collections import deque
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple
@@ -92,12 +119,30 @@ _FILE_AFTER = r"(?![A-Za-z0-9_-]|\.[A-Za-z0-9])"
 # of the whole references/ directory.  "references/*" or "references/`"
 # still count.
 _DIR_AFTER = r"(?![A-Za-z0-9_.-])"
+# A slash-less directory mention ("./canvas-fonts", "assets/fonts") must
+# not be followed by more path characters either — "./canvas-fonts/x.ttf"
+# is a file mention, and "assets/fonts/extra" mentions a subdirectory, not
+# assets/fonts.
+_DIR_BARE_AFTER = r"(?![A-Za-z0-9_./-])"
 
 _EXTERNAL_LINK_PREFIXES = ("http://", "https://", "#", "mailto:")
 
 # Referenced files above this size never become traversal sources — a
 # multi-megabyte data blob mentioning a filename is not documentation.
 _SOURCE_SIZE_LIMIT = 1024 * 1024
+
+# Fallback import-line scan for Python sources ast.parse rejects (e.g.
+# Python 2 scripts).  Matches "import a.b, c" and "from .pkg import x as y, z".
+_IMPORT_LINE_RE = re.compile(
+    r"^[ \t]*(?:from[ \t]+([.\w]+)[ \t]+import[ \t]+([^\n#;]+)" r"|import[ \t]+([\w. \t,]+))",
+    re.MULTILINE,
+)
+
+# Fenced code blocks whose info string (first word, lowercased) is one of
+# these get import parsing.  Unlabeled fences are included: instructional
+# markdown frequently omits the language tag, and non-Python fence content
+# simply yields no resolvable imports.
+_PY_FENCE_INFOS = {"", "python", "py", "python3"}
 
 
 class AgentSkillUnreferencedFilesRule(Rule):
@@ -116,8 +161,9 @@ class AgentSkillUnreferencedFilesRule(Rule):
             "type": "bool",
             "default": True,
             "description": (
-                "Treat a mention of a directory (e.g. `references/`) as "
-                "referencing every file under it"
+                "Treat a mention of a directory (e.g. `references/`, "
+                "`./canvas-fonts`, or `assets/fonts` when the directory "
+                "exists) as referencing every file under it"
             ),
         },
         "exclude": {
@@ -262,7 +308,9 @@ class AgentSkillUnreferencedFilesRule(Rule):
     ) -> Set[Path]:
         """Files referenced from the roots, following every referenced local file."""
         skill_resolved = skill_path.resolve()
-        rel_of = {f: f.resolve().relative_to(skill_resolved).as_posix() for f in all_files}
+        resolved_of = {f: f.resolve() for f in all_files}
+        resolved_files = set(resolved_of.values())
+        rel_of = {f: resolved_of[f].relative_to(skill_resolved).as_posix() for f in all_files}
         all_dirs = self._candidate_dirs(rel_of.values())
         block_by_path = {block.path.resolve(): block for block in skill_node.find(ContentBlock)}
 
@@ -281,24 +329,43 @@ class AgentSkillUnreferencedFilesRule(Rule):
             text = read_text(source)
             if text is None or "\0" in text:
                 continue  # unreadable or binary content is never a source
+            # Mention matching is case-insensitive (SKILL.md saying FORMS.md
+            # covers forms.md — such references work on case-insensitive
+            # filesystems).  The blob is lowered once per source, outside
+            # the per-candidate loop.
+            text_lower = text.lower()
 
             newly_referenced: List[Path] = []
 
             # Markdown links, resolved relative to the linking file.  Link
             # syntax only means anything in markdown sources; scripts and
-            # data files contribute raw-text mentions below.
-            link_files: Set[Path] = set()
-            if source.suffix.lower() == ".md":
+            # data files contribute raw-text mentions below.  Python sources
+            # additionally reference the modules they import.
+            direct_targets: Set[Path] = set()
+            suffix = source.suffix.lower()
+            if suffix == ".md":
                 block = block_by_path.get(resolved_source)
                 doc = block.markdown if block is not None else MarkdownDoc(text)
                 link_files, link_dirs = self._link_targets(doc, source.parent, skill_resolved)
+                direct_targets.update(link_files)
                 if directory_covers:
                     covered_dirs.update(link_dirs)
+                direct_targets.update(
+                    self._fence_import_targets(
+                        doc, text, resolved_source.parent, skill_resolved, resolved_files
+                    )
+                )
+            elif suffix == ".py":
+                direct_targets.update(
+                    self._python_import_targets(
+                        text, resolved_source.parent, skill_resolved, resolved_files
+                    )
+                )
             for candidate in all_files:
                 if candidate in referenced:
                     continue
-                if candidate.resolve() in link_files or self._text_mentions(
-                    text, candidate, rel_of[candidate], source.parent, skill_resolved
+                if resolved_of[candidate] in direct_targets or self._text_mentions(
+                    text_lower, candidate, rel_of[candidate], source.parent, skill_resolved
                 ):
                     referenced.add(candidate)
                     newly_referenced.append(candidate)
@@ -306,7 +373,7 @@ class AgentSkillUnreferencedFilesRule(Rule):
             # Directory mentions in prose/code cover their contents.
             if directory_covers:
                 for rel_dir in all_dirs - covered_dirs:
-                    if self._dir_mentioned(text, rel_dir, source.parent, skill_resolved):
+                    if self._dir_mentioned(text_lower, rel_dir, source.parent, skill_resolved):
                         covered_dirs.add(rel_dir)
                 for candidate in all_files:
                     if candidate in referenced:
@@ -321,7 +388,7 @@ class AgentSkillUnreferencedFilesRule(Rule):
             # (SKILL.md -> check.py -> allowed-repos.txt).  Oversized files
             # are skipped; binary content is rejected when dequeued.
             for candidate in newly_referenced:
-                if candidate.resolve() in processed:
+                if resolved_of[candidate] in processed:
                     continue
                 try:
                     if candidate.stat().st_size > _SOURCE_SIZE_LIMIT:
@@ -367,31 +434,200 @@ class AgentSkillUnreferencedFilesRule(Rule):
                 files.add(resolved)
         return files, dirs
 
-    def _text_mentions(
+    # -- python imports -------------------------------------------------------
+
+    def _fence_import_targets(
+        self,
+        doc: MarkdownDoc,
+        text: str,
+        source_dir: Path,
+        skill_resolved: Path,
+        resolved_files: Set[Path],
+    ) -> Set[Path]:
+        """Imports taught inside python (or unlabeled) fenced code blocks.
+
+        Instructional markdown routinely shows agents how to use bundled
+        modules via fences (```` ```python\\nfrom core.gif_builder import
+        GIFBuilder ````), which references the module as surely as a
+        script's own import does.  Fence spans come from the markdown-it
+        AST (:meth:`MarkdownDoc.fences`); the content is sliced from the
+        raw file text via the fence's file line range.
+        """
+        targets: Set[Path] = set()
+        lines: Optional[List[str]] = None
+        for fence in doc.fences():
+            lang = fence.info.split()[0].lower() if fence.info else ""
+            if lang not in _PY_FENCE_INFOS:
+                continue
+            if lines is None:  # split the blob once, only when needed
+                lines = text.split("\n")
+            if fence.indented:
+                start, end = fence.file_line_start - 1, fence.file_line_end
+            else:  # fenced ranges include the ``` delimiter lines
+                start, end = fence.file_line_start, fence.file_line_end - 1
+            body = textwrap.dedent("\n".join(lines[start:end]))
+            if not body.strip():
+                continue
+            targets.update(
+                self._python_import_targets(body, source_dir, skill_resolved, resolved_files)
+            )
+        return targets
+
+    def _python_import_targets(
         self,
         text: str,
+        source_dir: Path,
+        skill_resolved: Path,
+        resolved_files: Set[Path],
+    ) -> Set[Path]:
+        """Bundled files reachable through this Python source's imports.
+
+        Dotted module paths are resolved within the skill relative to the
+        skill root and to the importing file's directory (bundled scripts
+        are invoked from either); relative imports resolve against the
+        importing file's package.  Containment is enforced by membership
+        in *resolved_files* — modules outside the skill are never marked.
+        """
+        targets: Set[Path] = set()
+        for module, names, level in self._parse_imports(text):
+            parts = module.split(".") if module else []
+            if level:
+                base = source_dir
+                for _ in range(level - 1):
+                    base = base.parent
+                bases = [base]
+            else:
+                bases = [skill_resolved]
+                if source_dir != skill_resolved:
+                    bases.append(source_dir)
+            for base in bases:
+                self._mark_module(base, parts, names, resolved_files, targets)
+        return targets
+
+    @staticmethod
+    def _parse_imports(text: str) -> List[Tuple[str, List[str], int]]:
+        """(module, imported names, relative level) for every import in *text*.
+
+        Uses ``ast.parse``; sources the parser rejects (Python 2 scripts,
+        templates) fall back to a line-based scan of import statements.
+        """
+        imports: List[Tuple[str, List[str], int]] = []
+        try:
+            tree = ast.parse(text)
+        except (SyntaxError, ValueError):
+            for match in _IMPORT_LINE_RE.finditer(text):
+                if match.group(3) is not None:  # import a.b, c
+                    for module in match.group(3).split(","):
+                        module = module.strip()
+                        if module:
+                            imports.append((module, [], 0))
+                else:  # from [.]a.b import c as d, e
+                    module = match.group(1)
+                    level = len(module) - len(module.lstrip("."))
+                    names = [
+                        name.strip().split(" as ")[0].strip() for name in match.group(2).split(",")
+                    ]
+                    imports.append(
+                        (module.lstrip("."), [n for n in names if n.isidentifier()], level)
+                    )
+            return imports
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports.append((alias.name, [], 0))
+            elif isinstance(node, ast.ImportFrom):
+                imports.append((node.module or "", [a.name for a in node.names], node.level))
+        return imports
+
+    @staticmethod
+    def _mark_module(
+        base: Path,
+        parts: List[str],
+        names: List[str],
+        resolved_files: Set[Path],
+        targets: Set[Path],
+    ) -> None:
+        """Mark the bundled files a dotted import resolves to under *base*.
+
+        ``import a.b`` marks ``a/b.py`` or ``a/b/__init__.py``; ``from a.b
+        import c`` marks ``a/b/c.py`` when it exists, else the ``a.b``
+        module itself.  Package ``__init__.py`` files along the dotted
+        path execute on import, so they are marked too.  Pure set
+        membership — no filesystem access.
+        """
+
+        def mark(prefix: Path) -> bool:
+            module = prefix.parent / (prefix.name + ".py")
+            if module in resolved_files:
+                targets.add(module)
+                return True
+            init = prefix / "__init__.py"
+            if init in resolved_files:
+                targets.add(init)
+                return True
+            return False
+
+        prefix = base
+        for part in parts:
+            prefix = prefix / part
+            init = prefix / "__init__.py"
+            if init in resolved_files:
+                targets.add(init)
+
+        if not names:
+            mark(prefix)
+            return
+        for name in names:
+            # `from a.b import c`: c may be a submodule or a symbol in a.b.
+            if not mark(prefix / name):
+                mark(prefix)
+
+    def _text_mentions(
+        self,
+        text_lower: str,
         candidate: Path,
         rel: str,
         source_dir: Path,
         skill_resolved: Path,
     ) -> bool:
-        needles = {rel, candidate.name}
+        """Whether the (pre-lowered) source text mentions *candidate*.
+
+        Matching is case-insensitive: needles are lowered against the
+        caller's once-per-source lowered blob, so ``FORMS.md`` in prose
+        covers ``forms.md`` on disk.
+        """
+        needles = {rel.lower(), candidate.name.lower()}
         source_rel = self._relative_needle(candidate, source_dir, skill_resolved)
         if source_rel:
-            needles.add(source_rel)
+            needles.add(source_rel.lower())
         return any(
-            needle in text and self._pattern(needle, _FILE_AFTER).search(text) for needle in needles
+            needle in text_lower and self._pattern(needle, _FILE_AFTER).search(text_lower)
+            for needle in needles
         )
 
     def _dir_mentioned(
-        self, text: str, rel_dir: str, source_dir: Path, skill_resolved: Path
+        self, text_lower: str, rel_dir: str, source_dir: Path, skill_resolved: Path
     ) -> bool:
-        needles = {rel_dir + "/"}
+        """Whether the (pre-lowered) source text mentions the directory.
+
+        Case-insensitive, like ``_text_mentions``.
+        """
+        rels = {rel_dir.lower()}
         source_rel = self._relative_needle(skill_resolved / rel_dir, source_dir, skill_resolved)
         if source_rel:
-            needles.add(source_rel + "/")
+            rels.add(source_rel.lower())
+        needles: Set[Tuple[str, str]] = set()
+        for rel in rels:
+            needles.add((rel + "/", _DIR_AFTER))
+            # Slash-less path-ish forms of an existing directory also count:
+            # "Search the ./canvas-fonts directory" or a nested "assets/fonts".
+            # A bare word with no path markers ("data") never covers data/.
+            needles.add(("./" + rel, _DIR_BARE_AFTER))
+            if "/" in rel:
+                needles.add((rel, _DIR_BARE_AFTER))
         return any(
-            needle in text and self._pattern(needle, _DIR_AFTER).search(text) for needle in needles
+            needle in text_lower and self._pattern(needle, after).search(text_lower)
+            for needle, after in needles
         )
 
     @staticmethod

--- a/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
+++ b/src/skillsaw/rules/builtin/agentskills/unreferenced_files.py
@@ -456,7 +456,8 @@ class AgentSkillUnreferencedFilesRule(Rule):
         targets: Set[Path] = set()
         lines: Optional[List[str]] = None
         for fence in doc.fences():
-            lang = fence.info.split()[0].lower() if fence.info else ""
+            info_words = fence.info.split() if fence.info else []
+            lang = info_words[0].lower() if info_words else ""
             if lang not in _PY_FENCE_INFOS:
                 continue
             if lines is None:  # split the blob once, only when needed

--- a/src/skillsaw/rules/builtin/commands/frontmatter.py
+++ b/src/skillsaw/rules/builtin/commands/frontmatter.py
@@ -4,7 +4,7 @@ from typing import List
 
 from skillsaw.rule import Rule, RuleViolation, Severity, AutofixResult, AutofixConfidence
 from skillsaw.context import RepositoryContext
-from skillsaw.rules.builtin.utils import insert_frontmatter_fields
+from skillsaw.rules.builtin.utils import insert_frontmatter_fields, read_text
 
 
 class CommandFrontmatterRule(Rule):
@@ -59,7 +59,13 @@ class CommandFrontmatterRule(Rule):
         for v in violations:
             if not v.file_path or not v.file_path.exists():
                 continue
-            original = v.file_path.read_text(encoding="utf-8")
+            # BOM-stripping read: a raw utf-8 read would keep a leading U+FEFF
+            # and the "Missing frontmatter" fix below would embed it mid-file
+            # after the prepended block (write_text_preserving restores the
+            # original BOM at file start).
+            original = read_text(v.file_path)
+            if original is None:
+                continue
             if "Missing frontmatter" in v.message:
                 fixed = f"---\ndescription: \n---\n{original}"
                 results.append(

--- a/src/skillsaw/rules/builtin/marketplace/json_valid.py
+++ b/src/skillsaw/rules/builtin/marketplace/json_valid.py
@@ -173,7 +173,15 @@ class MarketplaceJsonValidRule(Rule):
                             file_path=marketplace_file,
                         )
                     )
-                elif isinstance(entry["name"], str):
+                elif not isinstance(entry["name"], str):
+                    violations.append(
+                        self.violation(
+                            f"plugins[{idx}] plugin name must be a string, "
+                            f"got {entry['name']!r}",
+                            file_path=marketplace_file,
+                        )
+                    )
+                else:
                     name = entry["name"]
                     if name in seen_names:
                         violations.append(

--- a/src/skillsaw/rules/docs/agentskill-name.md
+++ b/src/skillsaw/rules/docs/agentskill-name.md
@@ -26,5 +26,6 @@ name: deploy-staging
 ## How to fix
 
 Rename the `name` field in SKILL.md frontmatter to match the skill's
-directory name, using lowercase letters and hyphens. `skillsaw fix`
+directory name, using lowercase letters, numbers, and hyphens (a
+leading digit is allowed, e.g. `1password`). `skillsaw fix`
 can correct the name automatically.

--- a/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
+++ b/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
@@ -31,14 +31,33 @@ code blocks (`python scripts/run.py`), and plain prose:
 
 - Relative paths count: `scripts/run.py`, `./scripts/run.py`, or
   `img/logo.png` from a file in the same directory.
+- Matching is case-insensitive: SKILL.md saying `FORMS.md` covers a
+  `forms.md` on disk — such references work on case-insensitive
+  filesystems.
 - Bare filenames count: a mention of `run.py` anywhere marks
   `scripts/run.py` as referenced. Skills routinely refer to bundled
   scripts by name alone, so requiring full paths would flag
   heavily-referenced files.
 - Directory mentions cover their contents (configurable): "read the
   files in `references/`" marks everything under `references/` as
-  referenced. Prose and code mentions need the trailing slash; links
-  may target the bare directory.
+  referenced. Prose and code mentions must be path-ish — a trailing
+  slash (`references/`), a `./` prefix (`./canvas-fonts`), or an
+  interior `/` (`assets/fonts`); the slash-less forms only count when
+  the directory actually exists in the skill, and a bare word with no
+  path markers never covers anything. Links may target the bare
+  directory.
+- Python imports are followed: when a reachable file is a `.py` file,
+  its imports are resolved within the skill (relative to the skill
+  root and to the importing file's directory, including relative
+  imports), so SKILL.md → `scripts/recalc.py` → `from office.soffice
+  import ...` covers `scripts/office/soffice.py`. Imported modules
+  join the traversal, so files they mention (a schema referenced from
+  a docstring) are covered too. `from a.b import c` covers `a/b/c.py`
+  when it exists, otherwise the `a.b` module; package `__init__.py`
+  files along the path are covered as well. Imports shown inside
+  python-labeled (or unlabeled) fenced code blocks of reachable
+  markdown count the same way: a SKILL.md fence teaching `from
+  core.gif_builder import GIFBuilder` covers `core/gif_builder.py`.
 
 Never flagged: SKILL.md itself, README.md, CHANGELOG.md, LICENSE* and
 NOTICE* files (any suffix, e.g. `LICENSE-MIT`), files under `evals/`

--- a/src/skillsaw/utils.py
+++ b/src/skillsaw/utils.py
@@ -173,7 +173,12 @@ def write_text_preserving(file_path: Path, content: str) -> None:
 
     has_bom = original.startswith(b"\xef\xbb\xbf")
     sample = original[3:] if has_bom else original
-    uses_crlf = b"\r\n" in sample
+    # Use the DOMINANT line ending: a single stray CRLF in an otherwise-LF
+    # file must not flip every line to CRLF (and vice versa).  Ties and
+    # lone-CR (classic Mac) files normalize to LF.
+    crlf_count = sample.count(b"\r\n")
+    bare_lf_count = sample.count(b"\n") - crlf_count
+    uses_crlf = crlf_count > bare_lf_count
 
     # Normalize whatever the caller produced back to BOM-free LF first, so
     # re-applying the original shape is idempotent even when a fix path read
@@ -251,13 +256,17 @@ def commented_item_line(node: Any, index: int) -> Optional[int]:
     return None
 
 
-def _fast_top_level_key_lines(text: str) -> Optional[Dict[str, int]]:
-    """Map top-level mapping keys to 0-based lines using PyYAML's composer.
+def _fast_top_level_key_nodes(
+    text: str,
+) -> Optional[Dict[str, Tuple[yaml.Node, yaml.Node]]]:
+    """Map top-level mapping keys to their ``(key_node, value_node)`` pair
+    using PyYAML's composer (libyaml-backed when available).
 
-    Much faster than a ruamel round-trip parse (libyaml-backed when
-    available).  Returns ``None`` when the document needs the ruamel
-    fallback to preserve exact behavior: parse errors, non-string keys,
-    or duplicate keys (which ruamel rejects).
+    The nodes carry ``start_mark`` / ``end_mark`` positions, so callers can
+    locate the exact character span a key and its value occupy.  Returns
+    ``None`` when the document needs the ruamel fallback to preserve exact
+    behavior: parse errors, non-string keys, or duplicate keys (which
+    ruamel rejects).
     """
     loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
     try:
@@ -266,14 +275,28 @@ def _fast_top_level_key_lines(text: str) -> Optional[Dict[str, int]]:
         return None
     if node is None or not isinstance(node, yaml.MappingNode):
         return {}
-    result: Dict[str, int] = {}
-    for key_node, _value_node in node.value:
+    result: Dict[str, Tuple[yaml.Node, yaml.Node]] = {}
+    for key_node, value_node in node.value:
         if not isinstance(key_node, yaml.ScalarNode) or key_node.tag != "tag:yaml.org,2002:str":
             return None
         if key_node.value in result:
             return None
-        result[key_node.value] = key_node.start_mark.line
+        result[key_node.value] = (key_node, value_node)
     return result
+
+
+def _fast_top_level_key_lines(text: str) -> Optional[Dict[str, int]]:
+    """Map top-level mapping keys to 0-based lines using PyYAML's composer.
+
+    Much faster than a ruamel round-trip parse (libyaml-backed when
+    available).  Returns ``None`` when the document needs the ruamel
+    fallback to preserve exact behavior: parse errors, non-string keys,
+    or duplicate keys (which ruamel rejects).
+    """
+    nodes = _fast_top_level_key_nodes(text)
+    if nodes is None:
+        return None
+    return {key: key_node.start_mark.line for key, (key_node, _value) in nodes.items()}
 
 
 @_file_cache.cached
@@ -353,22 +376,98 @@ def prepend_frontmatter_fields(content: str, additions: List[str]) -> Optional[s
 
 
 def replace_frontmatter_field(content: str, key: str, replacement_line: str) -> Optional[str]:
-    """Replace an existing top-level ``key:`` line inside the frontmatter.
+    """Replace an existing top-level ``key:`` field inside the frontmatter.
 
-    Returns the new content, or ``None`` when *content* has no parseable
-    frontmatter block or no top-level ``key:`` line to replace.  Only the
-    first occurrence is replaced, and the line ending is preserved.
+    The true top-level key is located with the same libyaml-backed composer
+    that powers :func:`frontmatter_key_line` — a bare ``^key:`` regex also
+    matches column-0 *continuation* lines of another structure (e.g. the
+    second line of ``metadata: {tags: [x],\\nname: legacy-tag}``) and
+    replacing those corrupts previously-valid YAML (issue: agentskill-valid
+    SAFE-fix corruption).
+
+    Returns:
+        - the new content, with the key line **and its full value span**
+          replaced by *replacement_line* (a value continuing on following
+          lines — flow collection, block scalar, multi-line plain scalar —
+          is collapsed so no orphaned continuation lines remain);
+        - ``None`` when *content* has no parseable frontmatter block or no
+          genuine top-level ``key`` to replace (callers may then safely
+          insert the field instead);
+        - *content* unchanged when the key exists but the span cannot be
+          verified (exotic frontmatter: duplicate keys, non-string keys,
+          flow-style or quoted key lines) — a no-op beats corruption.
     """
     m = _FRONTMATTER_RE.match(content)
     if not m:
         return None
+    fm_text = m.group(1)
     key_re = re.compile(rf"^{re.escape(key)}[ \t]*:[^\r\n]*", re.MULTILINE)
-    km = key_re.search(m.group(1))
-    if km is None:
+    nodes = _fast_top_level_key_nodes(fm_text)
+    if nodes is None:
+        # Exotic frontmatter (duplicate keys, non-string keys, parse error):
+        # fall back to ruamel for key membership only.
+        data = _ruamel_load(fm_text)
+        if isinstance(data, CommentedMap):
+            if key not in data:
+                return None
+        elif key_re.search(fm_text) is None:
+            # Undeterminable structure and not even a key-shaped line: there
+            # is nothing to replace.
+            return None
+        # Key present (or structure undeterminable): a blind line splice
+        # could hit a continuation line, so leave the content untouched.
+        return content
+    if key not in nodes:
+        # Any regex hit would be a continuation line of another structure,
+        # not a top-level key.
         return None
-    start = m.start(1) + km.start()
-    end = m.start(1) + km.end()
-    return content[:start] + replacement_line + content[end:]
+    key_node, value_node = nodes[key]
+    if key_node.start_mark.column != 0:
+        # Flow-style top-level mapping ({key: ...}): no key *line* to splice.
+        return content
+
+    # 0-based offsets of each line start within fm_text (fm_text always ends
+    # with a newline, so line N's start exists for every mark line N).
+    line_starts = [0]
+    idx = fm_text.find("\n")
+    while idx != -1:
+        line_starts.append(idx + 1)
+        idx = fm_text.find("\n", idx + 1)
+
+    key_line = key_node.start_mark.line
+    if key_line >= len(line_starts):
+        return content
+    line_start = line_starts[key_line]
+    km = key_re.match(fm_text, line_start)
+    if km is None:
+        # Quoted or otherwise decorated key line the callers' replacement
+        # format does not cover.
+        return content
+
+    if value_node.end_mark.line <= key_line:
+        # Single-line inline value (or empty/null value): replace just the
+        # key line, preserving the original line ending.
+        start = m.start(1) + km.start()
+        end = m.start(1) + km.end()
+        return content[:start] + replacement_line + content[end:]
+
+    # Multi-line value: replace the whole span from the key line through the
+    # value's end mark so no orphaned continuation lines remain.
+    end_line = value_node.end_mark.line
+    end_col = value_node.end_mark.column
+    if end_line >= len(line_starts):
+        return content
+    end_off = line_starts[end_line] + end_col
+    if end_off > len(fm_text):
+        return content
+    replacement = replacement_line
+    if end_col == 0:
+        # The value consumed its final line break (block scalars end at the
+        # start of the following line); restore the newline.
+        replacement += _frontmatter_newline(m.group(0))
+    start = m.start(1) + line_start
+    end = m.start(1) + end_off
+    return content[:start] + replacement + content[end:]
 
 
 def parse_frontmatter(content: str) -> Tuple[Optional[Dict[str, Any]], str, Optional[int]]:

--- a/tests/fixtures/autofix/safe-idempotency/skills/flow-name/SKILL.md
+++ b/tests/fixtures/autofix/safe-idempotency/skills/flow-name/SKILL.md
@@ -1,0 +1,12 @@
+---
+metadata: {tags: [legacy],
+name: legacy-tag}
+description: Skill whose only name lives inside a flow-mapping continuation line
+---
+
+# Flow Name Skill
+
+The `name: legacy-tag}` line is a column-0 continuation of the `metadata`
+flow mapping, not a top-level key. The fix must not splice that line (it
+would destroy the closing brace); it must insert a real top-level name
+instead.

--- a/tests/fixtures/autofix/safe-idempotency/skills/multiline-name/SKILL.md
+++ b/tests/fixtures/autofix/safe-idempotency/skills/multiline-name/SKILL.md
@@ -1,0 +1,11 @@
+---
+name:
+  []
+description: Skill whose name value is an empty flow sequence on the next line
+---
+
+# Multiline Name Skill
+
+This skill's `name:` key holds a falsy value that lives on the following
+line. The fix must replace the whole value span in place — replacing only
+the key line would orphan the continuation and corrupt the frontmatter.

--- a/tests/fixtures/marketplace/nonstring-name/.claude-plugin/marketplace.json
+++ b/tests/fixtures/marketplace/nonstring-name/.claude-plugin/marketplace.json
@@ -1,0 +1,8 @@
+{
+  "name": "acme-analytics",
+  "owner": {"name": "ACME Analytics Team", "url": "https://analytics.acme.example.com"},
+  "plugins": [
+    {"name": "report-builder", "source": "./plugins/report-builder", "description": "Generate analytics reports"},
+    {"name": 123, "source": "./plugins/metrics-collector", "description": "Collect runtime metrics", "strict": false}
+  ]
+}

--- a/tests/fixtures/marketplace/nonstring-name/plugins/metrics-collector/README.md
+++ b/tests/fixtures/marketplace/nonstring-name/plugins/metrics-collector/README.md
@@ -1,0 +1,7 @@
+# Metrics Collector
+
+Collect runtime metrics from running applications.
+
+## Commands
+
+- `/metrics-collector:collect` — Sample runtime metrics at an interval

--- a/tests/fixtures/marketplace/nonstring-name/plugins/metrics-collector/commands/collect.md
+++ b/tests/fixtures/marketplace/nonstring-name/plugins/metrics-collector/commands/collect.md
@@ -1,0 +1,22 @@
+---
+description: Collect runtime metrics from the running application
+argument-hint: "[interval-seconds]"
+---
+
+## Name
+metrics-collector:collect
+
+## Synopsis
+```text
+/metrics-collector:collect 30
+```
+
+## Description
+Samples runtime metrics (CPU, memory, request latency) from the running
+application at the given interval and streams them to the metrics warehouse.
+
+## Implementation
+1. Connect to the application's metrics endpoint
+2. Sample metrics at the requested interval
+3. Batch samples and forward them to the warehouse ingestion API
+4. Report a summary of collected samples when interrupted

--- a/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/.claude-plugin/plugin.json
+++ b/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "report-builder",
+  "description": "Generate analytics reports from collected metrics",
+  "version": "1.4.0",
+  "author": {"name": "Analytics Team"}
+}

--- a/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/README.md
+++ b/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/README.md
@@ -1,0 +1,7 @@
+# Report Builder
+
+Generate analytics reports from collected metrics.
+
+## Commands
+
+- `/report-builder:generate` — Generate an analytics report for a time range

--- a/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/commands/generate.md
+++ b/tests/fixtures/marketplace/nonstring-name/plugins/report-builder/commands/generate.md
@@ -1,0 +1,23 @@
+---
+description: Generate an analytics report for a given time range
+argument-hint: "[range] [--format html|pdf]"
+---
+
+## Name
+report-builder:generate
+
+## Synopsis
+```text
+/report-builder:generate last-7-days --format html
+```
+
+## Description
+Builds an analytics report from the metrics warehouse for the requested
+time range and renders it in the chosen output format.
+
+## Implementation
+1. Parse the requested time range and validate it against retention limits
+2. Query the metrics warehouse for matching data points
+3. Aggregate results into report sections
+4. Render the report with the selected format template
+5. Write the output to `reports/` and print its path

--- a/tests/fixtures/plugin-dist-abspath/skillsaw_abspath-0.1.0.dist-info/METADATA
+++ b/tests/fixtures/plugin-dist-abspath/skillsaw_abspath-0.1.0.dist-info/METADATA
@@ -1,0 +1,4 @@
+Metadata-Version: 2.1
+Name: skillsaw-abspath
+Version: 0.1.0
+Summary: skillsaw plugin fixture with an absolute content_paths glob

--- a/tests/fixtures/plugin-dist-abspath/skillsaw_abspath-0.1.0.dist-info/entry_points.txt
+++ b/tests/fixtures/plugin-dist-abspath/skillsaw_abspath-0.1.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[skillsaw.plugins]
+abspath = skillsaw_abspath

--- a/tests/fixtures/plugin-dist-abspath/skillsaw_abspath/__init__.py
+++ b/tests/fixtures/plugin-dist-abspath/skillsaw_abspath/__init__.py
@@ -1,0 +1,20 @@
+"""Plugin fixture declaring an absolute content_paths glob.
+
+Regression fixture: ``Path.glob()`` raises NotImplementedError on absolute
+patterns, and the lint tree builds lazily inside every rule's check() — an
+unvalidated absolute glob used to produce one rule-execution-error per rule.
+It must instead be rejected at load time as a single plugin-load-error.
+"""
+
+from skillsaw.plugins import PluginRepoType
+
+SKILLSAW_RULES = []
+
+SKILLSAW_REPO_TYPES = [
+    PluginRepoType(
+        name="abspath",
+        description="Fixture repo type with an absolute content_paths glob",
+        detect=lambda root: True,
+        content_paths=["/etc/*.conf"],
+    ),
+]

--- a/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id-0.1.0.dist-info/METADATA
+++ b/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id-0.1.0.dist-info/METADATA
@@ -1,0 +1,4 @@
+Metadata-Version: 2.1
+Name: skillsaw-raising-id
+Version: 0.1.0
+Summary: skillsaw plugin fixture with a rule whose rule_id property raises

--- a/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id-0.1.0.dist-info/entry_points.txt
+++ b/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id-0.1.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[skillsaw.plugins]
+raising-id = skillsaw_raising_id

--- a/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id/__init__.py
+++ b/tests/fixtures/plugin-dist-raising-id/skillsaw_raising_id/__init__.py
@@ -1,0 +1,31 @@
+"""Plugin fixture whose rule's rule_id property raises.
+
+Regression fixture: a plugin-controlled ``rule_id`` property that raises
+must surface as a ``plugin-load-error`` violation, never as an unhandled
+traceback that aborts the lint.
+"""
+
+from typing import List
+
+from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
+
+
+class RaisingIdRule(Rule):
+    """A rule whose rule_id property raises when accessed."""
+
+    @property
+    def rule_id(self) -> str:
+        raise RuntimeError("rule_id exploded (fixture)")
+
+    @property
+    def description(self) -> str:
+        return "Rule with a raising rule_id property (fixture)"
+
+    def default_severity(self) -> Severity:
+        return Severity.WARNING
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        return []
+
+
+SKILLSAW_RULES = [RaisingIdRule]

--- a/tests/fixtures/unreferenced-reachability/SKILL.md
+++ b/tests/fixtures/unreferenced-reachability/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: unreferenced-reachability
+description: Generates styled spreadsheet reports with custom fonts and validates the output against the bundled schema. Use when the user asks for a formatted report file.
+---
+
+# Report Generator
+
+Generate a styled report, then recalculate its formulas before returning
+it to the user.
+
+## Fonts
+
+Search the `./fonts` directory for a typeface matching the user's request
+and embed it in the report. Do not download fonts from the network.
+
+## Recalculating
+
+Formula cells are stored as strings until recalculated. Always run:
+
+```bash
+python scripts/main.py report.xlsx
+```
+
+The script rewrites the workbook in place and prints a summary of the
+cells it updated.

--- a/tests/fixtures/unreferenced-reachability/data/schema.xsd
+++ b/tests/fixtures/unreferenced-reachability/data/schema.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="report">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="cell" type="xs:string" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/tests/fixtures/unreferenced-reachability/fonts/bold.ttf
+++ b/tests/fixtures/unreferenced-reachability/fonts/bold.ttf
@@ -1,0 +1,1 @@
+placeholder font payload (bold)

--- a/tests/fixtures/unreferenced-reachability/fonts/regular.ttf
+++ b/tests/fixtures/unreferenced-reachability/fonts/regular.ttf
@@ -1,0 +1,1 @@
+placeholder font payload (regular)

--- a/tests/fixtures/unreferenced-reachability/legacy/cleanup.py
+++ b/tests/fixtures/unreferenced-reachability/legacy/cleanup.py
@@ -1,0 +1,7 @@
+"""Left over from an earlier version of the skill; nothing references it."""
+
+import shutil
+
+
+def wipe(path: str) -> None:
+    shutil.rmtree(path, ignore_errors=True)

--- a/tests/fixtures/unreferenced-reachability/pkg/helper.py
+++ b/tests/fixtures/unreferenced-reachability/pkg/helper.py
@@ -1,0 +1,14 @@
+"""Workbook recalculation helpers.
+
+Output is validated against the bundled data/schema.xsd before the
+workbook is rewritten.
+"""
+
+
+def recalc(path: str) -> int:
+    """Recalculate every formula cell in the workbook at *path*."""
+    # Placeholder implementation for the fixture: a real skill would
+    # evaluate formulas here and validate against the schema.
+    with open(path, "rb") as handle:
+        handle.read(1)
+    return 0

--- a/tests/fixtures/unreferenced-reachability/scripts/main.py
+++ b/tests/fixtures/unreferenced-reachability/scripts/main.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Recalculate formula cells in a report workbook."""
+
+import sys
+
+from pkg.helper import recalc
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: main.py <workbook>", file=sys.stderr)
+        return 2
+    updated = recalc(sys.argv[1])
+    print(f"updated {updated} cells")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -21,6 +21,16 @@ from skillsaw.rules.builtin.agentskills import (
     AgentSkillUnreferencedFilesRule,
 )
 
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def copy_fixture(name, tmp_path):
+    src = FIXTURES / name
+    dst = tmp_path / name.replace("/", "_")
+    shutil.copytree(src, dst)
+    return dst
+
+
 # --- Detection tests ---
 
 
@@ -2013,9 +2023,7 @@ def test_unreferenced_reachability_fixture(temp_dir):
     """End-to-end fixture: slash-less `./fonts` dir mention, a Python import
     chain (SKILL.md -> scripts/main.py -> pkg/helper.py -> data/schema.xsd),
     and one genuinely dead file that stays flagged."""
-    fixture = Path(__file__).parent / "fixtures" / "unreferenced-reachability"
-    skill = temp_dir / "unreferenced-reachability"
-    shutil.copytree(fixture, skill)
+    skill = copy_fixture("unreferenced-reachability", temp_dir)
 
     violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
     assert [v.file_path for v in violations] == [skill / "legacy" / "cleanup.py"]

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -3,6 +3,7 @@ Tests for agentskills.io rules and detection
 """
 
 import json
+import shutil
 from pathlib import Path
 
 from skillsaw.context import RepositoryContext, RepositoryType
@@ -1887,3 +1888,226 @@ def test_symlink_escaping_skill_dir_is_ignored(temp_dir):
     # although mentioned by SKILL.md — is not read: the out-of-tree mention
     # of scripts/orphan.py must not mark it referenced.
     assert flagged == {skill / "scripts" / "orphan.py"}
+
+
+# --- Unreferenced files: directory mentions without a trailing slash ---
+
+
+def test_dot_slash_directory_mention_covers_contents(temp_dir):
+    """`./canvas-fonts`-style mentions (no trailing slash) cover the directory."""
+    skill = _make_skill(temp_dir, body="Search the `./fonts` directory for a matching typeface.")
+    fonts = skill / "fonts"
+    fonts.mkdir()
+    (fonts / "regular.ttf").write_text("font\n")
+    (fonts / "bold.ttf").write_text("font\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_interior_slash_directory_mention_covers_contents(temp_dir):
+    """A nested path-ish mention (`assets/fonts`, no trailing slash) covers the directory."""
+    skill = _make_skill(temp_dir, body="Pick any typeface from assets/fonts and embed it.")
+    fonts = skill / "assets" / "fonts"
+    fonts.mkdir(parents=True)
+    (fonts / "regular.ttf").write_text("font\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_slashless_dir_mention_does_not_cover_file_paths_inside(temp_dir):
+    """`./fonts/regular.ttf` is a file mention, not a mention of fonts/."""
+    skill = _make_skill(temp_dir, body="Embed `./fonts/regular.ttf` in the report.")
+    fonts = skill / "fonts"
+    fonts.mkdir()
+    (fonts / "regular.ttf").write_text("font\n")
+    (fonts / "bold.ttf").write_text("font\n")
+
+    violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
+    assert [v.file_path for v in violations] == [fonts / "bold.ttf"]
+
+
+def test_slashless_dir_mention_respects_directory_covers_disabled(temp_dir):
+    skill = _make_skill(temp_dir, body="Search the `./fonts` directory for a typeface.")
+    fonts = skill / "fonts"
+    fonts.mkdir()
+    (fonts / "regular.ttf").write_text("font\n")
+
+    rule = AgentSkillUnreferencedFilesRule({"directory_mention_covers": False})
+    violations = rule.check(RepositoryContext(skill))
+    assert [v.file_path for v in violations] == [fonts / "regular.ttf"]
+
+
+# --- Unreferenced files: Python imports are followed ---
+
+
+def test_python_import_marks_module_relative_to_script_dir(temp_dir):
+    """SKILL.md -> scripts/recalc.py -> `from office.soffice import x` covers
+    scripts/office/soffice.py (module resolved relative to the importing file)."""
+    skill = _make_skill(temp_dir, body="Recalculate with `python scripts/recalc.py out.xlsx`.")
+    office = skill / "scripts" / "office"
+    office.mkdir(parents=True)
+    (skill / "scripts" / "recalc.py").write_text(
+        "from office.soffice import get_soffice_env\n\nprint(get_soffice_env())\n"
+    )
+    (office / "__init__.py").write_text("")
+    (office / "soffice.py").write_text("def get_soffice_env():\n    return {}\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_python_relative_import_reference(temp_dir):
+    """`from . import util` and `from ..pkg import mod` resolve within the skill."""
+    skill = _make_skill(temp_dir, body="Run `python scripts/main.py` to build the report.")
+    scripts = skill / "scripts"
+    scripts.mkdir()
+    pkg = skill / "pkg"
+    pkg.mkdir()
+    (scripts / "main.py").write_text(
+        "from . import util\nfrom ..pkg import renderer\n\nutil.go()\n"
+    )
+    (scripts / "util.py").write_text("def go():\n    pass\n")
+    (pkg / "__init__.py").write_text("")
+    (pkg / "renderer.py").write_text("def render():\n    pass\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_python_from_import_symbol_marks_module(temp_dir):
+    """`from pkg.helper import a_symbol` marks pkg/helper.py even though
+    a_symbol is not itself a module."""
+    skill = _make_skill(temp_dir, body="Run `python scripts/main.py` before replying.")
+    (skill / "scripts").mkdir()
+    (skill / "pkg").mkdir()
+    (skill / "scripts" / "main.py").write_text("from pkg.helper import recalc\n\nrecalc()\n")
+    (skill / "pkg" / "__init__.py").write_text("")
+    (skill / "pkg" / "helper.py").write_text("def recalc():\n    return 0\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_python_import_in_unreferenced_script_does_not_count(temp_dir):
+    """Imports only propagate from scripts that are themselves reachable."""
+    skill = _make_skill(temp_dir, body="No bundled files are mentioned here.")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "orphan.py").write_text("import helper\n\nhelper.go()\n")
+    (skill / "scripts" / "helper.py").write_text("def go():\n    pass\n")
+
+    violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
+    flagged = {v.file_path for v in violations}
+    assert flagged == {skill / "scripts" / "orphan.py", skill / "scripts" / "helper.py"}
+
+
+def test_python_import_fallback_on_syntax_error(temp_dir):
+    """Sources ast.parse rejects still contribute imports via the line scan."""
+    skill = _make_skill(temp_dir, body="Run `python2 scripts/legacy.py` if asked.")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "legacy.py").write_text(
+        "import helper\n\nprint 'python 2 syntax breaks ast.parse'\n"
+    )
+    (skill / "scripts" / "helper.py").write_text("def go():\n    pass\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_unreferenced_reachability_fixture(temp_dir):
+    """End-to-end fixture: slash-less `./fonts` dir mention, a Python import
+    chain (SKILL.md -> scripts/main.py -> pkg/helper.py -> data/schema.xsd),
+    and one genuinely dead file that stays flagged."""
+    fixture = Path(__file__).parent / "fixtures" / "unreferenced-reachability"
+    skill = temp_dir / "unreferenced-reachability"
+    shutil.copytree(fixture, skill)
+
+    violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
+    assert [v.file_path for v in violations] == [skill / "legacy" / "cleanup.py"]
+
+
+# --- Unreferenced files: case-insensitive mentions ---
+
+
+def test_case_insensitive_file_mention(temp_dir):
+    """SKILL.md saying FORMS.md covers forms.md on disk (case-insensitive
+    filesystems make such references work), and the covered file still
+    becomes a traversal source."""
+    skill = _make_skill(temp_dir, body="To fill a PDF form, read FORMS.md and follow it.")
+    (skill / "forms.md").write_text("# Forms\n\nRun `python scripts/fill.py form.pdf` first.\n")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "fill.py").write_text("print('fill')\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_case_insensitive_directory_mention(temp_dir):
+    """`Templates/` in prose covers a templates/ directory on disk."""
+    skill = _make_skill(temp_dir, body="Copy a starting point from `Templates/` first.")
+    templates = skill / "templates"
+    templates.mkdir()
+    (templates / "report.md").write_text("# Report skeleton\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_mention_boundaries_still_apply_case_insensitively(temp_dir):
+    """Case folding must not loosen token boundaries: Redeploy.SHELL still
+    does not reference deploy.sh."""
+    skill = _make_skill(temp_dir, body="Use the Redeploy.SHELL workflow for rollouts.")
+    (skill / "scripts").mkdir()
+    (skill / "scripts" / "deploy.sh").write_text("#!/bin/sh\n")
+
+    violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
+    assert [v.file_path for v in violations] == [skill / "scripts" / "deploy.sh"]
+
+
+# --- Unreferenced files: imports in markdown fences ---
+
+
+def test_fenced_python_import_reference(temp_dir):
+    """A ```python fence teaching `from core.gif_builder import GIFBuilder`
+    covers core/gif_builder.py."""
+    skill = _make_skill(
+        temp_dir,
+        body=(
+            "Build the GIF like this:\n\n"
+            "```python\n"
+            "from core.gif_builder import GIFBuilder\n"
+            "builder = GIFBuilder()\n"
+            "```"
+        ),
+    )
+    core = skill / "core"
+    core.mkdir()
+    (core / "gif_builder.py").write_text("class GIFBuilder:\n    pass\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_fenced_import_chain_is_transitive(temp_dir):
+    """The module reached through a fence import becomes a traversal source."""
+    skill = _make_skill(
+        temp_dir,
+        body="Compose frames:\n\n```python\nfrom core.frames import compose\n```",
+    )
+    core = skill / "core"
+    core.mkdir()
+    (core / "frames.py").write_text(
+        '"""Frame helpers; palettes load from data/palette.json."""\n\n'
+        "def compose():\n    pass\n"
+    )
+    (skill / "data").mkdir()
+    (skill / "data" / "palette.json").write_text("{}\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []
+
+
+def test_non_python_fence_imports_are_ignored(temp_dir):
+    """Import-looking lines in a fence labeled with another language do not
+    mark modules referenced."""
+    skill = _make_skill(
+        temp_dir,
+        body=("Example configuration:\n\n" "```text\n" "from core.hidden import backdoor\n" "```"),
+    )
+    core = skill / "core"
+    core.mkdir()
+    (core / "hidden.py").write_text("def backdoor():\n    pass\n")
+
+    violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
+    assert [v.file_path for v in violations] == [core / "hidden.py"]

--- a/tests/test_agentskill_rules.py
+++ b/tests/test_agentskill_rules.py
@@ -2111,3 +2111,19 @@ def test_non_python_fence_imports_are_ignored(temp_dir):
 
     violations = AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill))
     assert [v.file_path for v in violations] == [core / "hidden.py"]
+
+
+def test_whitespace_only_fence_info_does_not_crash(temp_dir):
+    """A fence opener with only trailing whitespace after the backticks is
+    treated as an unlabeled fence whose imports are followed. markdown-it
+    strips the info string per CommonMark, and the language check guards
+    against a whitespace-only info regardless."""
+    skill = _make_skill(
+        temp_dir,
+        body=("Build it:\n\n" "```   \n" "from core.frames import compose\n" "```"),
+    )
+    core = skill / "core"
+    core.mkdir()
+    (core / "frames.py").write_text("def compose():\n    pass\n")
+
+    assert AgentSkillUnreferencedFilesRule().check(RepositoryContext(skill)) == []

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -230,6 +230,8 @@ class TestExtractor:
         """A numeric plugin name in marketplace.json must not crash the docs
         renderers either: the marketplace markdown path derives per-plugin
         page filenames from ``plugin.name`` string methods (issue #322).
+        Non-string names are invalid (marketplace-json-valid flags them), so
+        name resolution degrades to the plugin's directory name.
         """
         claude_dir = temp_dir / ".claude-plugin"
         claude_dir.mkdir()
@@ -267,8 +269,9 @@ class TestExtractor:
         assert "index.html" in html_pages
         md_pages = render_markdown(docs)
         assert "README.md" in md_pages
-        # The numeric-named plugin still gets a per-plugin page.
-        assert "123.md" in md_pages
+        # The numeric-named plugin still gets a per-plugin page, keyed by
+        # its directory name (the fallback for invalid non-string names).
+        assert "beta.md" in md_pages
 
     def test_render_falsy_plugin_name_preserved(self):
         """A falsy-but-valid plugin name (``0``) must be preserved by the

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1972,6 +1972,37 @@ class TestEncodingPreservingAutofix:
         r = run_lint(repo, "--rule", "agentskill-name")
         assert "agentskill-name" not in rule_ids(r)
 
+    def test_bom_crlf_command_missing_frontmatter_fix_single_bom(self, tmp_path):
+        """command-frontmatter's missing-frontmatter fix must read via the
+        BOM-stripping utils reader: a raw utf-8 read keeps U+FEFF, and
+        prepending the frontmatter block embeds a second BOM mid-file
+        (``\\ufeff# Deploy``) that breaks heading parsing on later lints."""
+        repo = tmp_path / "bom-cmd"
+        cmd_dir = repo / ".claude" / "commands"
+        cmd_dir.mkdir(parents=True)
+        target = cmd_dir / "deploy.md"
+        target.write_bytes(
+            b"\xef\xbb\xbf# Deploy\r\n\r\n" b"Deploy the application to production.\r\n"
+        )
+
+        _run_fix(repo)
+
+        raw = target.read_bytes()
+        # Exactly one BOM, at offset 0 — never a second one mid-file.
+        assert raw.startswith(b"\xef\xbb\xbf")
+        assert raw.count(b"\xef\xbb\xbf") == 1
+        # Frontmatter was prepended directly after the BOM.
+        assert raw[3:].startswith(b"---\r\n")
+        assert b"description:" in raw
+        # Every line ending is still CRLF (no bare LF introduced).
+        assert raw.count(b"\n") == raw.count(b"\r\n")
+        # Idempotent: a second fix run changes nothing.
+        _run_fix(repo)
+        assert target.read_bytes() == raw
+        # Converges: the missing-frontmatter violation is gone.
+        r = run_lint(repo, "--rule", "command-frontmatter")
+        assert not any("Missing frontmatter" in v.get("message", "") for v in violations(r))
+
 
 @pytest.mark.integration
 class TestSafeAutofixIdempotency:
@@ -1992,10 +2023,10 @@ class TestSafeAutofixIdempotency:
     EXPECTED_SAFE_VIOLATIONS = {
         "agent-frontmatter": 3,
         "agentskill-name": 4,
-        "agentskill-valid": 4,
+        "agentskill-valid": 6,
         "command-frontmatter": 3,
         "content-unlinked-internal-reference": 23,
-        "skill-frontmatter": 2,
+        "skill-frontmatter": 3,
     }
 
     def test_fixture_violation_counts(self, tmp_path):
@@ -2062,6 +2093,10 @@ class TestSafeAutofixIdempotency:
             "no-desc-",
             "no-name-",
             "missing-name/",
+            # Replacing a multi-line falsy ``name:`` value collapses the
+            # continuation line; inserting a missing top-level name adds one.
+            "multiline-name/",
+            "flow-name/",
             ".skillsaw-renames.json",
         }
         changed: List[str] = []
@@ -2169,7 +2204,17 @@ class TestSafeAutofixIdempotency:
                 "\n---\n" in content[4:]
             ), f"SKILL.md in {skill_dir.name} missing closing frontmatter delimiter"
             lines = content.splitlines()
-            name_lines = [line for line in lines if line.startswith("name:")]
+            # Count only genuine top-level ``name:`` key lines inside the
+            # frontmatter: a column-0 continuation line of a flow mapping
+            # (skills/flow-name fixture) also starts with ``name:`` but is
+            # part of another key's value, not a duplicate key.
+            fm_end = lines[1:].index("---") + 1
+            flow_depth = 0
+            name_lines = []
+            for line in lines[1:fm_end]:
+                if flow_depth == 0 and line.startswith("name:"):
+                    name_lines.append(line)
+                flow_depth += line.count("{") + line.count("[") - line.count("}") - line.count("]")
             assert (
                 len(name_lines) == 1
             ), f"SKILL.md in {skill_dir.name} has {len(name_lines)} name: lines"

--- a/tests/test_integration_plugins.py
+++ b/tests/test_integration_plugins.py
@@ -20,6 +20,8 @@ import pytest
 FIXTURES = Path(__file__).parent / "fixtures"
 PLUGIN_DIST = FIXTURES / "plugin-dist"
 BROKEN_DIST = FIXTURES / "plugin-dist-broken"
+RAISING_ID_DIST = FIXTURES / "plugin-dist-raising-id"
+ABSPATH_DIST = FIXTURES / "plugin-dist-abspath"
 
 
 def copy_fixture(name, tmp_path):
@@ -137,6 +139,49 @@ def test_broken_plugin_reports_error_but_lint_completes(tmp_path):
     assert "broken" in errors[0]["message"]
     assert r["rc"] == 1
     # The healthy plugin still ran alongside the broken one.
+    assert len(plugin_violations(r)) == 1
+
+
+def test_plugin_rule_with_raising_rule_id_reports_error_not_traceback(tmp_path):
+    """A plugin rule whose rule_id property raises must not crash the lint."""
+    repo = copy_fixture("plugin-target", tmp_path)
+    r = run_cli("lint", str(repo), dists=(PLUGIN_DIST, RAISING_ID_DIST), fmt="json")
+    assert r["out"] is not None, r["stdout"] + r["stderr"]
+    assert "Traceback" not in r["stderr"]
+    errors = [v for v in r["out"]["violations"] if v["rule_id"] == "plugin-load-error"]
+    assert len(errors) == 1
+    assert "RaisingIdRule" in errors[0]["message"]
+    assert "rule_id exploded" in errors[0]["message"]
+    assert r["rc"] == 1  # the load error is an error-severity violation
+    # The healthy plugin still ran alongside the broken one.
+    assert len(plugin_violations(r)) == 1
+
+
+def test_plugin_absolute_content_paths_single_load_error(tmp_path):
+    """An absolute content_paths glob is one plugin-load-error, not 28 crashes."""
+    repo = copy_fixture("plugin-target", tmp_path)
+    r = run_cli("lint", str(repo), dists=(ABSPATH_DIST,), fmt="json")
+    assert r["out"] is not None, r["stdout"] + r["stderr"]
+    assert "Traceback" not in r["stderr"]
+    load_errors = [v for v in r["out"]["violations"] if v["rule_id"] == "plugin-load-error"]
+    exec_errors = [v for v in r["out"]["violations"] if v["rule_id"] == "rule-execution-error"]
+    assert len(load_errors) == 1
+    assert "absolute" in load_errors[0]["message"]
+    assert exec_errors == []
+
+
+def test_user_config_absolute_content_path_does_not_crash(tmp_path):
+    """An absolute glob in user config content-paths is skipped gracefully."""
+    repo = copy_fixture("plugin-target", tmp_path)
+    (repo / ".skillsaw.yaml").write_text(
+        'version: "1.0"\ncontent-paths: ["/etc/*.conf"]\n', encoding="utf-8"
+    )
+    r = run_cli("lint", str(repo), fmt="json")
+    assert r["out"] is not None, r["stdout"] + r["stderr"]
+    assert "Traceback" not in r["stderr"]
+    exec_errors = [v for v in r["out"]["violations"] if v["rule_id"] == "rule-execution-error"]
+    assert exec_errors == []
+    # Linting still worked: the healthy plugin rule fired as usual.
     assert len(plugin_violations(r)) == 1
 
 

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1183,6 +1183,22 @@ class TestNonStringPluginName:
         context = RepositoryContext(plugin_dir)
         assert context.get_plugin_name(plugin_dir) == "my-plugin"
 
+    def test_get_plugin_name_nondict_plugin_json(self, tmp_path):
+        """A plugin.json holding a non-object JSON document (list, string,
+        number, null) degrades to the directory name instead of raising
+        AttributeError."""
+        from skillsaw.context import RepositoryContext
+
+        payloads = ('["not", "an", "object"]', '"just-a-string"', "42", "null")
+        for i, payload in enumerate(payloads):
+            plugin_dir = tmp_path / f"plugin-{i}"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / "commands").mkdir()
+            (plugin_dir / ".claude-plugin" / "plugin.json").write_text(payload)
+
+            context = RepositoryContext(plugin_dir)
+            assert context.get_plugin_name(plugin_dir) == plugin_dir.name
+
     def test_duplicate_detection_with_nonstring_names(self, tmp_path):
         """Duplicate detection must not crash on non-string names: each one is
         flagged as a type error, and string duplicates are still caught."""

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -1,6 +1,7 @@
 """Tests for the skillsaw marketplace command group."""
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -1092,3 +1093,126 @@ class TestInteractive:
             mock_stdin.isatty.return_value = False
             with pytest.raises(ValueError, match="Multiple plugins"):
                 _handle_multi_plugin(exc, add_skill, name="x", path=temp_dir)
+
+
+# ---------------------------------------------------------------------------
+# Non-string plugin names in marketplace.json (regression for
+# rule-execution-error crash in plugin-naming via get_plugin_name)
+# ---------------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _copy_fixture(name, tmp_path):
+    dst = tmp_path / name.replace("/", "_")
+    shutil.copytree(FIXTURES / name, dst)
+    return dst
+
+
+def _run_lint_json(path):
+    result = subprocess.run(
+        [sys.executable, "-m", "skillsaw", "lint", "--format", "json", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    output = json.loads(result.stdout) if result.stdout.strip() else None
+    return result, output
+
+
+class TestNonStringPluginName:
+    """A non-string plugin 'name' in marketplace.json must produce a
+    marketplace-json-valid ERROR, not a rule-execution-error crash."""
+
+    def test_marketplace_json_valid_reports_error(self, tmp_path):
+        repo = _copy_fixture("marketplace/nonstring-name", tmp_path)
+        result, output = _run_lint_json(repo)
+
+        messages = [
+            v["message"] for v in output["violations"] if v["rule_id"] == "marketplace-json-valid"
+        ]
+        assert any(
+            "plugins[1] plugin name must be a string" in m and "123" in m for m in messages
+        ), f"expected non-string name error, got: {messages}"
+        errors = [
+            v
+            for v in output["violations"]
+            if v["rule_id"] == "marketplace-json-valid" and v["severity"] == "error"
+        ]
+        assert errors, "non-string plugin name must be reported at ERROR severity"
+
+    def test_no_rule_execution_error(self, tmp_path):
+        repo = _copy_fixture("marketplace/nonstring-name", tmp_path)
+        result, output = _run_lint_json(repo)
+
+        crashed = [v for v in output["violations"] if v["rule_id"] == "rule-execution-error"]
+        assert crashed == [], f"rules crashed: {[v['message'] for v in crashed]}"
+
+    def test_exit_is_normal_lint_failure(self, tmp_path):
+        repo = _copy_fixture("marketplace/nonstring-name", tmp_path)
+        result, output = _run_lint_json(repo)
+
+        # Normal lint failure (violations found), not an internal error.
+        assert (
+            result.returncode == 1
+        ), f"expected exit 1, got {result.returncode}; stderr: {result.stderr}"
+        assert output is not None, "lint must still emit JSON output"
+        assert "Traceback" not in result.stderr
+
+    def test_get_plugin_name_falls_back_to_directory_name(self, tmp_path):
+        """A non-string marketplace name must not propagate out of
+        get_plugin_name — it degrades to the directory name."""
+        from skillsaw.context import RepositoryContext
+
+        repo = _copy_fixture("marketplace/nonstring-name", tmp_path)
+        context = RepositoryContext(repo)
+        plugin_path = repo / "plugins" / "metrics-collector"
+        assert context.get_plugin_name(plugin_path) == "metrics-collector"
+
+    def test_get_plugin_name_nonstring_plugin_json_name(self, tmp_path):
+        """A non-string name in plugin.json also degrades to the directory name."""
+        from skillsaw.context import RepositoryContext
+
+        plugin_dir = tmp_path / "my-plugin"
+        (plugin_dir / ".claude-plugin").mkdir(parents=True)
+        (plugin_dir / "commands").mkdir()
+        (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": 123, "description": "bad name type"})
+        )
+
+        context = RepositoryContext(plugin_dir)
+        assert context.get_plugin_name(plugin_dir) == "my-plugin"
+
+    def test_duplicate_detection_with_nonstring_names(self, tmp_path):
+        """Duplicate detection must not crash on non-string names: each one is
+        flagged as a type error, and string duplicates are still caught."""
+        from skillsaw.context import RepositoryContext
+        from skillsaw.rules.builtin.marketplace import MarketplaceJsonValidRule
+
+        claude_dir = tmp_path / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "dupes-marketplace",
+                    "owner": {"name": "Owner"},
+                    "plugins": [
+                        {"name": 123, "source": "./plugins/a"},
+                        {"name": 123, "source": "./plugins/b"},
+                        {"name": "tool", "source": "./plugins/c"},
+                        {"name": "tool", "source": "./plugins/d"},
+                    ],
+                }
+            )
+        )
+
+        context = RepositoryContext(tmp_path)
+        violations = MarketplaceJsonValidRule().check(context)
+        messages = [v.message for v in violations]
+
+        type_errors = [m for m in messages if "plugin name must be a string" in m]
+        assert len(type_errors) == 2, messages
+        assert any("duplicate plugin name 'tool'" in m for m in messages), messages
+        # Non-string names are excluded from duplicate comparison — no
+        # duplicate report should mention 123.
+        assert not any("duplicate" in m and "123" in m for m in messages), messages

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -302,6 +302,65 @@ def test_broken_plugin_surfaces_error_and_lint_continues(fake_plugin, repo):
     assert any(getattr(r, "_source", "") == "builtin" for r in linter.rules)
 
 
+def test_plugin_rule_with_raising_rule_id_is_isolated(fake_plugin, repo):
+    """A plugin rule whose rule_id property raises must not abort the lint."""
+
+    class RaisingIdRule(Rule):
+        @property
+        def rule_id(self) -> str:
+            raise RuntimeError("boom from rule_id")
+
+        @property
+        def description(self) -> str:
+            return "broken rule (test)"
+
+        def default_severity(self) -> Severity:
+            return Severity.WARNING
+
+        def check(self, context):
+            return []
+
+    fake_plugin(
+        "fake_raising_id",
+        module_attrs={"SKILLSAW_RULES": [RaisingIdRule, AlwaysFiresRule]},
+    )
+    linter, violations = _lint(repo)
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert len(errors) == 1
+    assert errors[0].severity == Severity.ERROR
+    assert "RaisingIdRule" in errors[0].message
+    assert "boom from rule_id" in errors[0].message
+    # The plugin's healthy rule and the builtins still ran.
+    assert "plugin-always-fires" in {r.rule_id for r in linter.rules}
+    assert any(getattr(r, "_source", "") == "builtin" for r in linter.rules)
+
+
+def test_plugin_rule_raising_during_enablement_is_isolated(fake_plugin, repo):
+    """A plugin rule whose repo_types access raises is fault-isolated too."""
+
+    class RaisingRepoTypesRule(AlwaysFiresRule):
+        @property
+        def rule_id(self) -> str:
+            return "plugin-raising-repo-types"
+
+        @property
+        def repo_types(self):
+            raise RuntimeError("boom from repo_types")
+
+    fake_plugin(
+        "fake_raising_rt",
+        module_attrs={"SKILLSAW_RULES": [RaisingRepoTypesRule]},
+    )
+    linter, violations = _lint(repo)
+    errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    assert len(errors) == 1
+    assert errors[0].severity == Severity.ERROR
+    assert "plugin-raising-repo-types" in errors[0].message
+    assert "boom from repo_types" in errors[0].message
+    assert "plugin-raising-repo-types" not in {r.rule_id for r in linter.rules}
+    assert any(getattr(r, "_source", "") == "builtin" for r in linter.rules)
+
+
 def test_rule_id_collision_with_builtin_is_skipped(fake_plugin, repo):
     fake_plugin("fake_shadow", module_attrs={"SKILLSAW_RULES": [ShadowsBuiltinRule]})
     linter, violations = _lint(repo)
@@ -602,6 +661,57 @@ def test_invalid_repo_type_name_fails_plugin(fake_plugin):
     (plugin,) = load_plugins()
     assert plugin.error is not None
     assert "kebab-case" in plugin.error
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ["/etc/*.conf", "C:\\agents\\*.md", "C:/agents/*.md", "//server/share/*.md"],
+)
+def test_repo_type_absolute_content_path_fails_plugin(fake_plugin, pattern):
+    """Absolute content_paths globs (POSIX or Windows) are rejected at load."""
+    fake_plugin(
+        "fake_rt_abs",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type(content_paths=[pattern])],
+        },
+    )
+    (plugin,) = load_plugins()
+    assert plugin.error is not None
+    assert "absolute" in plugin.error
+    assert "relative to the repository root" in plugin.error
+
+
+def test_repo_type_absolute_content_path_single_load_error(fake_plugin, acme_repo):
+    """An absolute glob yields one plugin-load-error, not a crash per rule."""
+    fake_plugin(
+        "fake_rt_abs_lint",
+        module_attrs={
+            "SKILLSAW_RULES": [],
+            "SKILLSAW_REPO_TYPES": [acme_repo_type(content_paths=["/etc/*.conf"])],
+        },
+    )
+    linter, violations = _lint(acme_repo)
+    load_errors = [v for v in violations if v.rule_id == "plugin-load-error"]
+    exec_errors = [v for v in violations if v.rule_id == "rule-execution-error"]
+    assert len(load_errors) == 1
+    assert load_errors[0].severity == Severity.ERROR
+    assert "absolute" in load_errors[0].message
+    assert exec_errors == []
+    # Builtin rules still ran despite the rejected plugin.
+    assert any(getattr(r, "_source", "") == "builtin" for r in linter.rules)
+
+
+def test_user_config_absolute_content_path_glob_is_skipped(repo):
+    """An absolute glob in user config content-paths is ignored, not a crash."""
+    config = LinterConfig.default()
+    config.content_paths = ["/etc/*.conf"]
+    linter, violations = _lint(repo, config=config, no_plugins=True)
+    exec_errors = [v for v in violations if v.rule_id == "rule-execution-error"]
+    assert exec_errors == []
+    # The tree still built: CLAUDE.md is present and lintable.
+    tree_paths = {node.path.name for node in linter.context.lint_tree.walk()}
+    assert "CLAUDE.md" in tree_paths
 
 
 def test_tree_contributor_adds_block(fake_plugin, acme_repo):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,67 @@ def test_write_text_preserving_bom_and_crlf(temp_dir):
     assert f.read_bytes() == b"\xef\xbb\xbfone\r\nEDITED\r\n"
 
 
+def test_write_text_preserving_mixed_endings_lf_dominant(temp_dir):
+    """A single stray CRLF in an otherwise-LF file must not flip the whole
+    file to CRLF — the DOMINANT line ending wins."""
+    from skillsaw.utils import write_text_preserving, invalidate_read_caches
+
+    f = temp_dir / "mixed.md"
+    f.write_bytes(b"l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nstray\r\n")
+    invalidate_read_caches()
+    write_text_preserving(f, "l1\nEDITED\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nstray\n")
+    raw = f.read_bytes()
+    assert b"\r" not in raw
+    assert raw == b"l1\nEDITED\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nstray\n"
+
+
+def test_write_text_preserving_mixed_endings_crlf_dominant(temp_dir):
+    """Majority-CRLF files keep CRLF even with a stray bare LF."""
+    from skillsaw.utils import write_text_preserving, invalidate_read_caches
+
+    f = temp_dir / "mixedcrlf.md"
+    f.write_bytes(b"l1\r\nl2\r\nl3\r\nstray\n")
+    invalidate_read_caches()
+    write_text_preserving(f, "l1\nEDITED\nl3\nstray\n")
+    assert f.read_bytes() == b"l1\r\nEDITED\r\nl3\r\nstray\r\n"
+
+
+def test_write_text_preserving_mixed_endings_tie_goes_to_lf(temp_dir):
+    """An exact CRLF/LF tie normalizes to LF."""
+    from skillsaw.utils import write_text_preserving, invalidate_read_caches
+
+    f = temp_dir / "tie.md"
+    f.write_bytes(b"a\r\nb\n")
+    invalidate_read_caches()
+    write_text_preserving(f, "a\nEDITED\n")
+    assert f.read_bytes() == b"a\nEDITED\n"
+
+
+def test_write_text_preserving_lone_cr_becomes_lf(temp_dir):
+    """Classic-Mac lone-CR files normalize to LF (no CRLF majority)."""
+    from skillsaw.utils import write_text_preserving, invalidate_read_caches
+
+    f = temp_dir / "cr.md"
+    f.write_bytes(b"one\rtwo\r")
+    invalidate_read_caches()
+    write_text_preserving(f, "one\nEDITED\n")
+    assert f.read_bytes() == b"one\nEDITED\n"
+
+
+def test_write_text_preserving_mixed_endings_idempotent(temp_dir):
+    """Writing the same content twice through the mixed-ending path is stable."""
+    from skillsaw.utils import write_text_preserving, invalidate_read_caches
+
+    f = temp_dir / "idem.md"
+    f.write_bytes(b"l1\nl2\nl3\nstray\r\n")
+    invalidate_read_caches()
+    write_text_preserving(f, "l1\nl2\nl3\nstray\n")
+    first = f.read_bytes()
+    invalidate_read_caches()
+    write_text_preserving(f, "l1\nl2\nl3\nstray\n")
+    assert f.read_bytes() == first
+
+
 def test_read_json_parses_valid(temp_dir):
     f = temp_dir / "data.json"
     f.write_text('{"key": "value"}', encoding="utf-8")
@@ -556,3 +617,104 @@ class TestFrontmatterHelpers:
         assert err is None
         assert fm == {"name": "x"}
         assert body == "body text\r\n"
+
+
+class TestReplaceFrontmatterField:
+    """replace_frontmatter_field must only splice genuine top-level keys and
+    never orphan continuation lines (agentskill-valid SAFE-fix corruption)."""
+
+    def test_replaces_single_line_value(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        out = replace_frontmatter_field("---\nname: old\nd: x\n---\nbody\n", "name", "name: new")
+        assert out == "---\nname: new\nd: x\n---\nbody\n"
+
+    def test_replaces_empty_null_value_in_place(self):
+        """An empty/null value still has a ``name:`` key line — replacing it
+        in place (not prepending a duplicate) is the issue #321 invariant."""
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        out = replace_frontmatter_field("---\nname:\nd: x\n---\n", "name", "name: new")
+        assert out == "---\nname: new\nd: x\n---\n"
+        out = replace_frontmatter_field('---\nname: ""\nd: x\n---\n', "name", "name: new")
+        assert out == "---\nname: new\nd: x\n---\n"
+
+    def test_missing_key_returns_none(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        assert replace_frontmatter_field("---\nd: x\n---\n", "name", "name: new") is None
+
+    def test_no_frontmatter_returns_none(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        assert replace_frontmatter_field("# heading\n", "name", "name: new") is None
+
+    def test_multiline_falsy_value_replaced_without_orphaned_continuation(self):
+        """``name:\\n  []`` — replacing only the key line used to orphan the
+        ``[]`` continuation line, corrupting the value.  The whole value
+        span must be replaced instead."""
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field, parse_frontmatter
+
+        content = "---\nname:\n  []\ndescription: d\n---\nbody\n"
+        out = replace_frontmatter_field(content, "name", "name: my-skill")
+        assert out == "---\nname: my-skill\ndescription: d\n---\nbody\n"
+        fm, _body, err = parse_frontmatter(out)
+        assert err is None
+        assert fm == {"name": "my-skill", "description": "d"}
+
+    def test_flow_mapping_continuation_line_not_replaced(self):
+        """A column-0 continuation line of a flow mapping matches a naive
+        ``^name:`` regex but is NOT a top-level key — replacing it destroyed
+        the closing ``}`` and made valid frontmatter unparseable."""
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field, parse_frontmatter
+
+        content = "---\nmetadata: {tags: [x],\nname: legacy-tag}\ndescription: d\n---\nbody\n"
+        out = replace_frontmatter_field(content, "name", "name: my-skill")
+        # No genuine top-level ``name`` key: callers fall back to inserting
+        # the field, which is safe here.
+        assert out is None
+        # The documented fallback path must produce valid YAML.
+        from skillsaw.rules.builtin.utils import prepend_frontmatter_fields
+
+        fixed = prepend_frontmatter_fields(content, ["name: my-skill"])
+        fm, _body, err = parse_frontmatter(fixed)
+        assert err is None
+        assert fm["name"] == "my-skill"
+        assert fm["metadata"] == {"tags": ["x"], "name": "legacy-tag"}
+
+    def test_block_scalar_value_fully_replaced(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        content = "---\nname: >-\n  Foo Bar\nd: x\n---\n"
+        out = replace_frontmatter_field(content, "name", "name: new")
+        assert out == "---\nname: new\nd: x\n---\n"
+
+    def test_multiline_plain_scalar_fully_replaced(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        content = "---\nname: foo\n  bar\nd: x\n---\n"
+        out = replace_frontmatter_field(content, "name", "name: new")
+        assert out == "---\nname: new\nd: x\n---\n"
+
+    def test_crlf_multiline_value(self):
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        content = "---\r\nname:\r\n  []\r\nd: x\r\n---\r\n"
+        out = replace_frontmatter_field(content, "name", "name: new")
+        assert out == "---\r\nname: new\r\nd: x\r\n---\r\n"
+
+    def test_flow_style_top_level_mapping_is_noop(self):
+        """A flow-style top-level mapping has no key *line* to splice —
+        the content must come back untouched rather than corrupted."""
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        content = "---\n{name: x, d: y}\n---\n"
+        assert replace_frontmatter_field(content, "name", "name: new") == content
+
+    def test_duplicate_keys_are_noop(self):
+        """Duplicate top-level keys are undeterminable (ruamel rejects them);
+        the content must come back untouched rather than half-replaced."""
+        from skillsaw.rules.builtin.utils import replace_frontmatter_field
+
+        content = "---\nname: a\nname: b\n---\n"
+        assert replace_frontmatter_field(content, "name", "name: new") == content


### PR DESCRIPTION
## Summary

A multi-perspective pre-release review of the v0.14.1..HEAD range (bugs, security, performance, feature verification, docs) surfaced seven confirmed bugs with runtime reproductions plus a handful of smaller issues. This PR fixes all of them except the secrets entropy-gate false-negative trade-off, which is deliberate and stays documented as a known issue.

## Fixes

**Plugin architecture robustness**
- A plugin rule whose `rule_id` property (or `repo_types`/enablement attributes) raises now produces a single `plugin-load-error` violation and the lint continues, instead of crashing with a raw traceback — honoring the "a broken plugin never aborts the lint" contract.
- Absolute `content_paths` globs from plugins (POSIX and Windows forms) are rejected at plugin load, and the lint-tree glob site is guarded so an invalid pattern — from a plugin *or* user config `content-paths` (pre-existing crash) — is skipped with a warning instead of producing one `rule-execution-error` per rule.

**SAFE autofix corruption**
- `commands/frontmatter.py` read files raw, keeping the BOM and embedding a second U+FEFF mid-file when prepending frontmatter to a BOM'd command file. It now uses the BOM-stripping read like the other frontmatter fixes; byte-level regression test included.
- `replace_frontmatter_field()` matched any column-0 `key:` line, letting the SAFE `agentskill-valid` fix corrupt multi-line values (`name:\n  []`) and flow-mapping continuations (`name: legacy-tag}`) into invalid YAML. It now locates the genuine top-level key via the libyaml composer (no per-key ruamel parses), replaces full value spans convergently, and no-ops on unverifiable shapes. Both shapes are covered in the safe-idempotency fixture.
- `write_text_preserving()` forced the whole file to CRLF if any single CRLF was present; it now uses the dominant line ending (lone-CR and tie cases covered).

**Rule accuracy**
- A non-string plugin `name` in marketplace.json crashed `plugin-naming` with a TypeError; `marketplace-json-valid` now reports it as an ERROR and `get_plugin_name()` falls back to the directory name.
- `agentskill-unreferenced-files` reachability now follows slash-less directory mentions (`./fonts`, `assets/fonts`), Python import chains in `.py` helpers *and* fenced code blocks (ast with regex fallback), and matches mentions case-insensitively — all while keeping the C-speed substring prefilter and per-blob lowering. On `anthropics/skills` this drops out-of-the-box warnings from **243 to 80**, with the remainder spot-checked as genuinely dead files.

**Performance / project rules**
- `rename_refs.py` regained the prefilter dropped in the #325 rewrite (`patterns_matching_anywhere` before the per-line loop), results-identical.
- Reuse pre-resolved paths in the unreferenced-files traversal instead of re-resolving per candidate.

**Docs**
- Plugin dependency floor corrected from `skillsaw>=0.14` to `>=0.15` in the plugin guide, the create-plugin skill, and the example plugin — plugin loading only ships in 0.15, so a `>=0.14` install silently never loads.
- `agentskill-name` description and how-to-fix docs now mention numbers and leading digits (per the #337 spec change).

## Test plan

- 57 tests added (plugin fault isolation, absolute-glob rejection, both YAML corruption shapes, mixed line endings, BOM'd command files, non-string marketplace names, and 16 for the new reachability semantics), each verified to fail without its fix
- `make test`: 2421 passed; `make lint` clean; `make update` leaves the tree clean
- `openshift-eng/ai-helpers`: exit 0, grade A (default and `--no-plugins`)
- Self-lint: grade A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linting stability when plugin metadata is malformed or plugin rules fail to load.
  * Added safer handling for absolute content-path patterns and invalid glob inputs.
  * Fixed frontmatter updates to better preserve file encoding and line endings.

* **Documentation**
  * Clarified rule guidance for skill names, directory references, and file reference detection.
  * Updated plugin setup examples and minimum supported version notes.

* **Tests**
  * Expanded coverage for reference detection, plugin error handling, and text/frontmatter preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->