### PR TITLE
content-inconsistent-terminology: configure individual term groups

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -146,6 +146,7 @@ rules:
   content-inconsistent-terminology:
     enabled: auto
     severity: info
+    # groups: {}
 
   # Check if instruction count in a file exceeds LLM instruction budget (~150)
   content-instruction-budget:

--- a/README.md
+++ b/README.md
@@ -824,6 +824,12 @@ Rules that go beyond structural validation to analyze the *quality* of instructi
 | `skip-builtins` | Disable built-in deprecated model/API checks | `false` |
 | `regex-timeout` | Per-pattern wall-clock budget (seconds) for custom banned patterns; guards against catastrophic-backtracking regexes (clamped to 10s max) | `2.0` |
 
+**`content-inconsistent-terminology` parameters:**
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `groups` | Per-group overrides keyed by group name (e.g. 'function/method'): 'off' or false disables the group; a severity ('error', 'warning', 'info') overrides the rule severity for that group | `{}` |
+
 **`content-unlinked-internal-reference` parameters:**
 
 | Parameter | Description | Default |

--- a/docs/rules/content-inconsistent-terminology.md
+++ b/docs/rules/content-inconsistent-terminology.md
@@ -46,6 +46,24 @@ everywhere. Prefer technical terms over informal ones (e.g., "directory"
 over "folder", "repository" over "codebase"). A coding agent can
 standardize terminology automatically.
 
+If a group doesn't apply to your repository — for example, a polyglot
+repo that legitimately documents both Go *functions* and Java *methods* —
+disable just that group (or override its severity) while keeping the
+rest enforced:
+
+```yaml
+rules:
+  content-inconsistent-terminology:
+    severity: error
+    groups:
+      function/method: off      # disable this group only
+      PR/pull request/merge request: warning  # downgrade this group
+```
+
+Valid group names: `directory/folder`, `repo/repository/codebase`,
+`PR/pull request/merge request`, `function/method`. Valid values: `off`
+(or `false`) to disable, or a severity (`error`, `warning`, `info`).
+
 ## Configuration
 
 ```yaml
@@ -54,6 +72,10 @@ rules:
     enabled: auto  # true | false | auto
     severity: info
 ```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `groups` | Per-group overrides keyed by group name (e.g. 'function/method'): 'off' or false disables the group; a severity ('error', 'warning', 'info') overrides the rule severity for that group | `{}` |
 
 ## Research Basis
 

--- a/src/skillsaw/rules/builtin/content/inconsistent_terminology.py
+++ b/src/skillsaw/rules/builtin/content/inconsistent_terminology.py
@@ -76,7 +76,9 @@ class ContentInconsistentTerminologyRule(Rule):
         ``None`` means the group is disabled. Groups absent from the map keep
         the rule-level severity.
         """
-        raw = self.config.get("groups") or {}
+        raw = self.config.get("groups")
+        if raw is None:
+            raw = {}
         if not isinstance(raw, dict):
             raise ValueError(
                 f"'groups' for rule '{self.rule_id}' must be a mapping of "
@@ -91,12 +93,12 @@ class ContentInconsistentTerminologyRule(Rule):
                     f"'{self.rule_id}'. Valid groups: {', '.join(valid_names)}"
                 )
             # YAML may parse a bare ``off`` as boolean False depending on the
-            # loader, so accept both spellings.
-            if value is False or (isinstance(value, str) and value.lower() == "off"):
+            # loader, so accept the boolean and both string spellings.
+            if value is False or (isinstance(value, str) and value.lower() in ("off", "false")):
                 overrides[name] = None
                 continue
             try:
-                overrides[name] = Severity(value)
+                overrides[name] = Severity(value.lower() if isinstance(value, str) else value)
             except (ValueError, KeyError, TypeError) as err:
                 valid = ", ".join(s.value for s in Severity)
                 raise ValueError(

--- a/src/skillsaw/rules/builtin/content/inconsistent_terminology.py
+++ b/src/skillsaw/rules/builtin/content/inconsistent_terminology.py
@@ -3,7 +3,7 @@
 import re
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
@@ -54,6 +54,57 @@ class ContentInconsistentTerminologyRule(Rule):
 
     MIN_FILES = 2
 
+    config_schema = {
+        "groups": {
+            "type": "dict",
+            "default": {},
+            "description": (
+                "Per-group overrides keyed by group name (e.g. 'function/method'): "
+                "'off' or false disables the group; a severity ('error', 'warning', "
+                "'info') overrides the rule severity for that group"
+            ),
+        },
+    }
+
+    def __init__(self, config: Dict[str, Any] = None):
+        super().__init__(config)
+        self._group_overrides: Dict[str, Optional[Severity]] = self._parse_group_overrides()
+
+    def _parse_group_overrides(self) -> Dict[str, Optional[Severity]]:
+        """Parse the ``groups`` config into {group name: severity or None}.
+
+        ``None`` means the group is disabled. Groups absent from the map keep
+        the rule-level severity.
+        """
+        raw = self.config.get("groups") or {}
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"'groups' for rule '{self.rule_id}' must be a mapping of "
+                f"group name to 'off' or a severity, got {type(raw).__name__}"
+            )
+        valid_names = [name for name, _ in self._TERM_GROUPS]
+        overrides: Dict[str, Optional[Severity]] = {}
+        for name, value in raw.items():
+            if name not in valid_names:
+                raise ValueError(
+                    f"Unknown terminology group '{name}' for rule "
+                    f"'{self.rule_id}'. Valid groups: {', '.join(valid_names)}"
+                )
+            # YAML may parse a bare ``off`` as boolean False depending on the
+            # loader, so accept both spellings.
+            if value is False or (isinstance(value, str) and value.lower() == "off"):
+                overrides[name] = None
+                continue
+            try:
+                overrides[name] = Severity(value)
+            except (ValueError, KeyError, TypeError) as err:
+                valid = ", ".join(s.value for s in Severity)
+                raise ValueError(
+                    f"Invalid setting '{value}' for terminology group '{name}' "
+                    f"in rule '{self.rule_id}'. Valid values: off, {valid}"
+                ) from err
+        return overrides
+
     @property
     def rule_id(self) -> str:
         return "content-inconsistent-terminology"
@@ -72,6 +123,9 @@ class ContentInconsistentTerminologyRule(Rule):
 
         violations = []
         for group_name, patterns in self._TERM_GROUPS:
+            group_severity = self._group_overrides.get(group_name, self.severity)
+            if group_severity is None:
+                continue
             term_usage: Dict[str, int] = defaultdict(int)
             files_by_term: Dict[str, List[Path]] = defaultdict(list)
             for cf in content_files:
@@ -96,6 +150,6 @@ class ContentInconsistentTerminologyRule(Rule):
                         minority_files.update(fpaths)
                 msg = f"Inconsistent terminology: {group_name} — multiple variants used across files. Pick one and use it consistently."
                 for fpath in sorted(minority_files):
-                    violations.append(self.violation(msg, file_path=fpath))
+                    violations.append(self.violation(msg, file_path=fpath, severity=group_severity))
 
         return violations

--- a/src/skillsaw/rules/docs/content-inconsistent-terminology.md
+++ b/src/skillsaw/rules/docs/content-inconsistent-terminology.md
@@ -31,3 +31,21 @@ Pick the most common term across your instruction files and use it
 everywhere. Prefer technical terms over informal ones (e.g., "directory"
 over "folder", "repository" over "codebase"). A coding agent can
 standardize terminology automatically.
+
+If a group doesn't apply to your repository — for example, a polyglot
+repo that legitimately documents both Go *functions* and Java *methods* —
+disable just that group (or override its severity) while keeping the
+rest enforced:
+
+```yaml
+rules:
+  content-inconsistent-terminology:
+    severity: error
+    groups:
+      function/method: off      # disable this group only
+      PR/pull request/merge request: warning  # downgrade this group
+```
+
+Valid group names: `directory/folder`, `repo/repository/codebase`,
+`PR/pull request/merge request`, `function/method`. Valid values: `off`
+(or `false`) to disable, or a severity (`error`, `warning`, `info`).

--- a/tests/fixtures/config/terminology-groups/.skillsaw.yaml
+++ b/tests/fixtures/config/terminology-groups/.skillsaw.yaml
@@ -1,0 +1,7 @@
+version: "99.0.0"
+rules:
+  content-inconsistent-terminology:
+    enabled: true
+    severity: error
+    groups:
+      function/method: off

--- a/tests/fixtures/config/terminology-groups/AGENTS.md
+++ b/tests/fixtures/config/terminology-groups/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Guidelines
+
+## Java plugins
+
+- Java plugins implement the `execute` method on the `Plugin` interface.
+- Place generated sources in the `build/` folder before packaging.

--- a/tests/fixtures/config/terminology-groups/CLAUDE.md
+++ b/tests/fixtures/config/terminology-groups/CLAUDE.md
@@ -1,0 +1,9 @@
+# Project Standards
+
+This marketplace documents plugins written in Go, Java, and Python.
+
+## Layout
+
+- Put each plugin in its own directory under `plugins/`.
+- Go plugins export a `Run` function as the entry point.
+- Keep shared helpers in the `internal/` directory.

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -1017,13 +1017,19 @@ class TestContentInconsistentTerminologyRule:
         assert all("function/method" not in v.message for v in violations)
         assert any("directory/folder" in v.message for v in violations)
 
-    def test_disabled_group_accepts_yaml_false(self, temp_dir):
-        """YAML 1.1 loaders parse a bare ``off`` as boolean False."""
+    @pytest.mark.parametrize("setting", [False, "false", "OFF"])
+    def test_disabled_group_accepts_off_spellings(self, temp_dir, setting):
+        """YAML 1.1 loaders parse a bare ``off`` as boolean False; quoted
+        strings and casing variants must behave the same."""
         (temp_dir / "CLAUDE.md").write_text("Write a helper function.\n")
         (temp_dir / "AGENTS.md").write_text("Write a helper method.\n")
         context = RepositoryContext(temp_dir)
-        rule = ContentInconsistentTerminologyRule({"groups": {"function/method": False}})
+        rule = ContentInconsistentTerminologyRule({"groups": {"function/method": setting}})
         assert rule.check(context) == []
+
+    def test_group_severity_is_case_insensitive(self):
+        rule = ContentInconsistentTerminologyRule({"groups": {"function/method": "Warning"}})
+        assert rule._group_overrides["function/method"] == Severity.WARNING
 
     def test_group_severity_override(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text("Write a helper function in a directory.\n")
@@ -1048,9 +1054,19 @@ class TestContentInconsistentTerminologyRule:
         with pytest.raises(ValueError, match="Invalid setting 'loud'"):
             ContentInconsistentTerminologyRule({"groups": {"function/method": "loud"}})
 
-    def test_groups_must_be_mapping(self):
+    @pytest.mark.parametrize("bad", [["function/method"], [], "", 0, False])
+    def test_groups_must_be_mapping(self, bad):
         with pytest.raises(ValueError, match="must be a mapping"):
-            ContentInconsistentTerminologyRule({"groups": ["function/method"]})
+            ContentInconsistentTerminologyRule({"groups": bad})
+
+    def test_groups_null_treated_as_absent(self, temp_dir):
+        """``groups:`` with no value parses as None and must not raise."""
+        (temp_dir / "CLAUDE.md").write_text("Write a helper function.\n")
+        (temp_dir / "AGENTS.md").write_text("Write a helper method.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentInconsistentTerminologyRule({"groups": None})
+        assert rule._group_overrides == {}
+        assert rule.check(context)
 
 
 class TestContentBrokenInternalReferenceRule:

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -609,7 +609,7 @@ class TestContentEmbeddedSecretsRule:
 
     def test_detects_github_token(self, temp_dir):
         (temp_dir / "CLAUDE.md").write_text(
-            "Use token ghp_abcdefghijklmnopqrstuvwxyz123456789012\n"
+            "Use token ghp_abcdefghijklmnopqrstuvwxyz123456789012\n"  # notsecret
         )
         context = RepositoryContext(temp_dir)
         violations = ContentEmbeddedSecretsRule().check(context)
@@ -630,7 +630,7 @@ class TestContentEmbeddedSecretsRule:
         assert len(violations) == 0
 
     def test_reports_line_number(self, temp_dir):
-        content = "Line 1\nLine 2\nPassword: password='xK9$mQ2vLp8#nR4zW7@j'\nLine 4\n"
+        content = "Line 1\nLine 2\nPassword: password='xK9$mQ2vLp8#nR4zW7@j'\nLine 4\n"  # notsecret
         (temp_dir / "CLAUDE.md").write_text(content)
         context = RepositoryContext(temp_dir)
         violations = ContentEmbeddedSecretsRule().check(context)
@@ -641,19 +641,19 @@ class TestContentEmbeddedSecretsRule:
         "secret,expected_desc",
         [
             ("sk-ant-api03-abcdefghijklmnopqrst", "Anthropic API key"),
-            ("ghr_abcdefghijklmnopqrstuvwxyz123456789012", "GitHub refresh token"),
+            ("ghr_abcdefghijklmnopqrstuvwxyz123456789012", "GitHub refresh token"),  # notsecret
             ("ASIAIOSFODNN7EXAMPLE", "AWS temporary access key"),
             ("xoxa-123456789012-abcdefghij", "Slack app token"),
             ("xoxr-123456789012-abcdefghij", "Slack refresh token"),
             (_STRIPE_SK, "Stripe secret key"),
             (_STRIPE_RK, "Stripe restricted key"),
-            ("AIzaSyATESTFAKEKEYDONOTUSE0000000000000", "Google API key"),
-            ("SK00000000000000000000000000000000", "Twilio API key"),
+            ("AIzaSyATESTFAKEKEYDONOTUSE0000000000000", "Google API key"),  # notsecret
+            ("SK00000000000000000000000000000000", "Twilio API key"),  # notsecret
             (
-                "SG.abcdefghijklmnopqrstuv.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijk",
+                "SG.abcdefghijklmnopqrstuv.abcdefghijklmnopqrstuvwxyz0123456789abcdefghijk",  # notsecret
                 "SendGrid API key",
             ),
-            ("npm_abcdefghijklmnopqrstuvwxyz1234567890", "npm access token"),
+            ("npm_abcdefghijklmnopqrstuvwxyz1234567890", "npm access token"),  # notsecret
             ("pypi-abcdefghijklmnopqrstuvwxyz", "PyPI API token"),
             (
                 "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456",
@@ -714,7 +714,7 @@ class TestContentEmbeddedSecretsRule:
             'password="hunter2placeholder"',
             "password = 'your-password-here'",
             'password: "aaaaaaaaaaaaaaaa"',
-            'password = "dummy-value-123"',
+            'password = "dummy-value-123"',  # notsecret
             'api_key = "<your-api-key-goes-here>"',
             'api_key = "${MY_API_KEY_FROM_ENV}"',
             'api_key = "EXAMPLE_KEY_1234567890"',
@@ -757,9 +757,9 @@ class TestContentEmbeddedSecretsRule:
     @pytest.mark.parametrize(
         "line,expected_desc",
         [
-            ('password = "xK9$mQ2vLp8#nR4z"', "Hardcoded password"),
+            ('password = "xK9$mQ2vLp8#nR4z"', "Hardcoded password"),  # notsecret
             ('api_key = "9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c"', "Hardcoded API key"),
-            ('secret_key = "kJ8vQz3mN9pL2wXyRb5cDf7g"', "Hardcoded secret key"),
+            ('secret_key = "kJ8vQz3mN9pL2wXyRb5cDf7g"', "Hardcoded secret key"),  # notsecret
         ],
         ids=["random-password", "hex-api-key", "mixed-secret-key"],
     )
@@ -781,10 +781,10 @@ class TestContentEmbeddedSecretsRule:
             'password = "Tr0ub4dor&3"',
             # $ followed by uppercase inside a random value is not an
             # env-var reference and must not suppress the finding.
-            'password = "xK9$MQ2vLp8#nR4z"',
+            'password = "xK9$MQ2vLp8#nR4z"',  # notsecret
             # Incidental <..> punctuation inside a random value is not an
             # angle-bracket placeholder.
-            'password = "k<9x>Km2#pQzW4vT"',
+            'password = "k<9x>Km2#pQzW4vT"',  # notsecret
         ],
         ids=[
             "short-random-8",
@@ -810,7 +810,7 @@ class TestContentEmbeddedSecretsRule:
             # stoplists and plausibly occur inside real credential values —
             # they must not act as placeholder markers.
             ('api_key = "app-secret-x8K2mQ9zL4vN"', "Hardcoded API key"),
-            ('password = "xK2passwd9QmZ4vN"', "Hardcoded password"),
+            ('password = "xK2passwd9QmZ4vN"', "Hardcoded password"),  # notsecret
         ],
         ids=["secret-substring", "passwd-substring"],
     )
@@ -1003,6 +1003,54 @@ class TestContentInconsistentTerminologyRule:
         context = RepositoryContext(temp_dir)
         violations = ContentInconsistentTerminologyRule().check(context)
         assert len(violations) == 0
+
+    def test_disabled_group_is_skipped(self, temp_dir):
+        """Issue #366: a group set to 'off' stops firing while others keep working."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "The first function parameter is the context directory.\n"
+        )
+        (temp_dir / "AGENTS.md").write_text("Call the service method in this folder.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentInconsistentTerminologyRule({"groups": {"function/method": "off"}})
+        violations = rule.check(context)
+        assert violations, "directory/folder group should still fire"
+        assert all("function/method" not in v.message for v in violations)
+        assert any("directory/folder" in v.message for v in violations)
+
+    def test_disabled_group_accepts_yaml_false(self, temp_dir):
+        """YAML 1.1 loaders parse a bare ``off`` as boolean False."""
+        (temp_dir / "CLAUDE.md").write_text("Write a helper function.\n")
+        (temp_dir / "AGENTS.md").write_text("Write a helper method.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentInconsistentTerminologyRule({"groups": {"function/method": False}})
+        assert rule.check(context) == []
+
+    def test_group_severity_override(self, temp_dir):
+        (temp_dir / "CLAUDE.md").write_text("Write a helper function in a directory.\n")
+        (temp_dir / "AGENTS.md").write_text("Write a helper method in a folder.\n")
+        context = RepositoryContext(temp_dir)
+        rule = ContentInconsistentTerminologyRule(
+            {"severity": "error", "groups": {"function/method": "info"}}
+        )
+        violations = rule.check(context)
+        by_group = {}
+        for v in violations:
+            group = v.message.split("Inconsistent terminology: ")[1].split(" —")[0]
+            by_group[group] = v.severity
+        assert by_group["function/method"] == Severity.INFO
+        assert by_group["directory/folder"] == Severity.ERROR
+
+    def test_unknown_group_name_rejected(self):
+        with pytest.raises(ValueError, match="Unknown terminology group 'bogus'"):
+            ContentInconsistentTerminologyRule({"groups": {"bogus": "off"}})
+
+    def test_invalid_group_setting_rejected(self):
+        with pytest.raises(ValueError, match="Invalid setting 'loud'"):
+            ContentInconsistentTerminologyRule({"groups": {"function/method": "loud"}})
+
+    def test_groups_must_be_mapping(self):
+        with pytest.raises(ValueError, match="must be a mapping"):
+            ContentInconsistentTerminologyRule({"groups": ["function/method"]})
 
 
 class TestContentBrokenInternalReferenceRule:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1567,6 +1567,45 @@ class TestRequiredFieldsConfig:
 
 
 @pytest.mark.integration
+class TestTerminologyGroupsConfig:
+    """End-to-end tests for per-group content-inconsistent-terminology config
+    (issue #366).
+
+    The fixture mixes function/method (disabled via ``groups``) and
+    directory/folder (kept at the rule-level error severity) across
+    CLAUDE.md and AGENTS.md.
+    """
+
+    FIXTURE = "config/terminology-groups"
+
+    def _rule_violations(self, r):
+        return [v for v in violations(r) if v["rule_id"] == "content-inconsistent-terminology"]
+
+    def test_disabled_group_silenced_others_kept(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
+        vs = self._rule_violations(r)
+        assert vs, "directory/folder group should still fire"
+        assert all("function/method" not in v["message"] for v in vs)
+        assert all(v["severity"] == "error" for v in vs)
+
+    def test_without_groups_config_all_groups_fire(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        (repo / ".skillsaw.yaml").write_text(
+            'version: "99.0.0"\n'
+            "rules:\n"
+            "  content-inconsistent-terminology:\n"
+            "    enabled: true\n"
+        )
+        r = run_lint(repo, config=repo / ".skillsaw.yaml")
+        assert r["out"] is not None, f"Expected JSON output, got rc={r['rc']} stderr={r['stderr']}"
+        messages = [v["message"] for v in self._rule_violations(r)]
+        assert any("function/method" in m for m in messages)
+        assert any("directory/folder" in m for m in messages)
+
+
+@pytest.mark.integration
 class TestDescriptionMaxLengthConfig:
     """End-to-end tests for the configurable agentskill-description max_length.
 


### PR DESCRIPTION
Fixes #366

## What

Adds a `groups` config option to `content-inconsistent-terminology` so individual term groups can be configured independently of the rule:

```yaml
rules:
  content-inconsistent-terminology:
    severity: error
    groups:
      function/method: off      # disable just this group
      PR/pull request/merge request: warning  # or override its severity
```

- `off` (or `false`) disables a group while the rest keep firing at the rule-level severity.
- A severity value (`error` / `warning` / `info`) overrides the severity for just that group.
- Unknown group names and invalid values are rejected at config load with the valid options listed, matching the existing invalid-severity behavior — a typo'd group name fails loudly instead of silently disabling nothing.
- No config → behavior is unchanged.

This addresses the polyglot-repo case from the issue: a marketplace documenting Go (*functions*) and Java/C# (*methods*) can silence `function/method` while keeping `directory/folder` and `repo/repository/codebase` enforced as errors.

## Changes

- `groups` declared in `config_schema`, so `skillsaw explain`, the generated docs, README parameter table, and `.skillsaw.yaml.example` all pick it up (regenerated via `make update`).
- Rule doc source updated with a worked example and the list of valid group names/values.
- Unit tests: disable a group (string `off` and YAML-boolean `False`), per-group severity override, unknown group / invalid value / non-mapping rejection.
- Integration test with a new `tests/fixtures/config/terminology-groups` fixture: disabled group is silenced end-to-end while `directory/folder` still fires at `error`; without the `groups` config both groups fire.
- Pre-existing fake-secret fixtures in `tests/test_content_rules.py` annotated with `# notsecret` so secret-scanning pre-commit hooks don't block commits touching this file.

## Testing

- `make test` — 2433 passed
- `make lint` — clean
- `make update` — regenerated files committed
- Linted `openshift-eng/ai-helpers` with this branch — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-group configuration for terminology checks, letting specific terms be disabled or lowered in severity while other checks still run.
  * Expanded documentation with clearer “How to fix” examples and supported configuration options.

* **Bug Fixes**
  * Improved handling of group-specific settings so invalid or unknown values are reported clearly.
  * Added test coverage for disabled groups, severity overrides, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->