### PR TITLE
Add fail-on severity threshold for exit codes

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -360,3 +360,6 @@ content-paths: []
 
 # Treat warnings as errors
 strict: false
+
+# Fail on violations at this severity or above: error, warning, info
+fail-on: error

--- a/README.md
+++ b/README.md
@@ -1110,7 +1110,9 @@ By default only errors fail the run. `strict: true` (or `--strict`) also
 fails on warnings, and `fail-on: <error|warning|info>` (or `--fail-on`)
 sets the threshold directly — `fail-on: info` fails on any violation, so a
 clean repo stays clean as new rules land. `strict: true` is equivalent to
-`fail-on: warning`; when both are set the strictest wins.
+`fail-on: warning`; when both config keys are set the strictest wins. The
+CLI flags override the config file's settings; passing both flags with
+contradictory values is an error.
 
 ## Example Output
 

--- a/README.md
+++ b/README.md
@@ -1097,8 +1097,14 @@ skill summaries, and configuration details extracted from your repository.
 
 ## Exit Codes
 
-- `0` - Success (no errors, or warnings only in non-strict mode)
-- `1` - Failure (errors found, or warnings in strict mode)
+- `0` - Success (no violations at or above the failure threshold)
+- `1` - Failure (errors found; warnings in strict mode; any violation with `fail-on: info`)
+
+By default only errors fail the run. `strict: true` (or `--strict`) also
+fails on warnings, and `fail-on: <error|warning|info>` (or `--fail-on`)
+sets the threshold directly — `fail-on: info` fails on any violation, so a
+clean repo stays clean as new rules land. `strict: true` is equivalent to
+`fail-on: warning`; when both are set the strictest wins.
 
 ## Example Output
 

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Treat warnings as errors'
     required: false
     default: 'false'
+  fail-on:
+    description: 'Fail on violations at this severity or above: error, warning, info (strict is equivalent to fail-on: warning; the strictest setting wins)'
+    required: false
+    default: ''
   plugins:
     description: 'Newline-separated list of plugin packages to install (e.g. skillsaw-runbooks==0.1.0)'
     required: false
@@ -32,7 +36,7 @@ inputs:
 
 outputs:
   exit-code:
-    description: 'skillsaw exit code (0=pass, 1=errors or strict warnings)'
+    description: 'skillsaw exit code (0=pass, 1=violations at or above the fail-on threshold)'
     value: ${{ steps.lint.outputs.exit-code }}
   errors:
     description: 'Number of errors found'
@@ -77,6 +81,7 @@ runs:
       env:
         SKILLSAW_PATH: ${{ inputs.path }}
         SKILLSAW_STRICT: ${{ inputs.strict }}
+        SKILLSAW_FAIL_ON: ${{ inputs.fail-on }}
         SKILLSAW_VERBOSE: ${{ inputs.verbose }}
         SKILLSAW_NO_CUSTOM_RULES: ${{ inputs.no-custom-rules }}
       run: |
@@ -84,6 +89,9 @@ runs:
         ARGS=""
         if [ "$SKILLSAW_STRICT" = "true" ]; then
           ARGS="$ARGS --strict"
+        fi
+        if [ -n "$SKILLSAW_FAIL_ON" ]; then
+          ARGS="$ARGS --fail-on $SKILLSAW_FAIL_ON"
         fi
         if [ "$SKILLSAW_VERBOSE" = "true" ]; then
           ARGS="$ARGS -v"

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: 'false'
   fail-on:
-    description: 'Fail on violations at this severity or above: error, warning, info (strict is equivalent to fail-on: warning; the strictest setting wins)'
+    description: 'Fail on violations at this severity or above: error, warning, info (strict: true is equivalent to fail-on: warning; combining strict with a contradictory fail-on fails the run)'
     required: false
     default: ''
   plugins:

--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,10 @@ runs:
           ARGS="$ARGS --strict"
         fi
         if [ -n "$SKILLSAW_FAIL_ON" ]; then
-          ARGS="$ARGS --fail-on $SKILLSAW_FAIL_ON"
+          case "$SKILLSAW_FAIL_ON" in
+            error|warning|info) ARGS="$ARGS --fail-on $SKILLSAW_FAIL_ON" ;;
+            *) echo "Invalid fail-on value: $SKILLSAW_FAIL_ON (expected error, warning, or info)" >&2; exit 1 ;;
+          esac
         fi
         if [ "$SKILLSAW_VERBOSE" = "true" ]; then
           ARGS="$ARGS -v"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -96,7 +96,7 @@ jobs:
 | `path` | Path to lint | `.` |
 | `version` | Specific skillsaw version to install | latest |
 | `strict` | Treat warnings as errors | `false` |
-| `fail-on` | Fail on violations at this severity or above (`error`, `warning`, `info`); `strict` is equivalent to `fail-on: warning`, strictest wins | `''` |
+| `fail-on` | Fail on violations at this severity or above (`error`, `warning`, `info`); `strict: true` is equivalent to `fail-on: warning`, and combining `strict` with a contradictory `fail-on` fails the run | `''` |
 | `verbose` | Include info-level violations | `false` |
 | `no-custom-rules` | Skip custom rules defined in `.skillsaw.yaml` | `true` |
 | `plugins` | Newline-separated list of plugin packages to install | `''` |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -96,6 +96,7 @@ jobs:
 | `path` | Path to lint | `.` |
 | `version` | Specific skillsaw version to install | latest |
 | `strict` | Treat warnings as errors | `false` |
+| `fail-on` | Fail on violations at this severity or above (`error`, `warning`, `info`); `strict` is equivalent to `fail-on: warning`, strictest wins | `''` |
 | `verbose` | Include info-level violations | `false` |
 | `no-custom-rules` | Skip custom rules defined in `.skillsaw.yaml` | `true` |
 | `plugins` | Newline-separated list of plugin packages to install | `''` |
@@ -104,7 +105,7 @@ jobs:
 
 | Output | Description |
 |--------|-------------|
-| `exit-code` | skillsaw exit code (0=pass, 1=errors or strict warnings) |
+| `exit-code` | skillsaw exit code (0=pass, 1=violations at or above the fail-on threshold) |
 | `errors` | Number of errors found |
 | `warnings` | Number of warnings found |
 | `report-file` | Path to JSON report file |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover from the first path) |  |
 | `-v`, `--verbose` | Show info-level messages |  |
 | `--strict` | Treat warnings as errors (exit with error code if warnings exist) |  |
+| `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Like --strict, this can only tighten the config file's setting, never loosen it. (choices: error, warning, info) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo. |  |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,8 +15,8 @@ Lint agent skills, plugins, and AI coding assistant context
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover from the first path) |  |
 | `-v`, `--verbose` | Show info-level messages |  |
-| `--strict` | Treat warnings as errors (exit with error code if warnings exist) |  |
-| `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Like --strict, this can only tighten the config file's setting, never loosen it. (choices: error, warning, info) |  |
+| `--strict` | Treat warnings as errors (equivalent to --fail-on warning; overrides the config file's strict/fail-on settings) |  |
+| `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Overrides the config file's strict/fail-on settings. (choices: error, warning, info) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo. |  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,7 @@ content-paths:
   - "docs/runbooks/*.md"
 
 strict: false
+fail-on: error
 ```
 
 ## Version Pinning
@@ -89,8 +90,11 @@ Most rules default to `auto`, so they activate only where they make sense.
 repository and why.
 
 Each rule also has a `severity`, one of `error`, `warning`, or `info`.
-Errors fail the lint; warnings fail it only in [strict mode](#strict-mode);
-info-level violations are shown with `--verbose` and never fail the lint.
+By default only errors fail the lint; warnings fail it in
+[strict mode](#strict-mode), and the [`fail-on`](#failure-threshold)
+threshold can make any severity — including info — fail the run.
+Info-level violations are shown with `--verbose` (and always when
+`fail-on: info` makes them fatal).
 
 ```yaml
 rules:
@@ -111,6 +115,36 @@ The `--strict` CLI flag does the same for a single run. Note that the CLI
 flag can only *upgrade* to strict — there is no `--no-strict` flag, so a
 `strict: true` in the config file cannot be overridden from the command
 line.
+
+## Failure Threshold
+
+`fail-on` generalizes strict mode: violations at the given severity or
+above make the run exit non-zero.
+
+```yaml
+fail-on: info   # any violation at info or above fails the run
+```
+
+| `fail-on` | Fails the run |
+|-----------|---------------|
+| `error` (default) | errors only |
+| `warning` | errors and warnings (same as `strict: true`) |
+| `info` | any violation |
+
+`strict: true` is shorthand for `fail-on: warning`. When both are set, the
+strictest one wins — neither option can loosen the other, so adding
+`fail-on: info` to a config that already has `strict: true` just tightens
+the threshold.
+
+The `--fail-on` CLI flag does the same for a single run and, like
+`--strict`, can only tighten the config file's setting.
+
+`fail-on: info` is useful for ratcheting: once a repo is at zero
+violations, it stays that way — new info-level findings (including from
+rules added in newer skillsaw versions) fail CI instead of accumulating
+silently. When info violations are what failed the run, the text output
+shows them even without `--verbose`. Pair it with a
+[baseline](baseline.md) to adopt the threshold before reaching zero.
 
 ## Custom Rules
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,10 +111,8 @@ With `strict: true`, warnings fail the lint just like errors:
 strict: true
 ```
 
-The `--strict` CLI flag does the same for a single run. Note that the CLI
-flag can only *upgrade* to strict — there is no `--no-strict` flag, so a
-`strict: true` in the config file cannot be overridden from the command
-line.
+The `--strict` CLI flag does the same for a single run, overriding the
+config file's `strict` and `fail-on` settings (see below).
 
 ## Failure Threshold
 
@@ -131,13 +129,15 @@ fail-on: info   # any violation at info or above fails the run
 | `warning` | errors and warnings (same as `strict: true`) |
 | `info` | any violation |
 
-`strict: true` is shorthand for `fail-on: warning`. When both are set, the
-strictest one wins — neither option can loosen the other, so adding
-`fail-on: info` to a config that already has `strict: true` just tightens
-the threshold.
+`strict: true` is shorthand for `fail-on: warning`. When both config keys
+are set, the strictest one wins — adding `fail-on: info` to a config that
+already has `strict: true` just tightens the threshold.
 
-The `--fail-on` CLI flag does the same for a single run and, like
-`--strict`, can only tighten the config file's setting.
+The `--fail-on` and `--strict` CLI flags override the config file's
+settings for a single run — `--fail-on error` runs with the default
+threshold even when the config says `strict: true`. Passing both flags
+with contradictory values (`--strict --fail-on info`) is an error;
+`--strict --fail-on warning` is accepted since they agree.
 
 `fail-on: info` is useful for ratcheting: once a repo is at zero
 violations, it stays that way — new info-level findings (including from

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,8 +138,8 @@ Summary:
 
 | Code | Meaning |
 |------|---------|
-| `0` | Success (no errors, or warnings only in non-strict mode) |
-| `1` | Failure (errors found, or warnings in strict mode) |
+| `0` | Success (no violations at or above the failure threshold) |
+| `1` | Failure (errors found; warnings in strict mode; any violation with `fail-on: info`) |
 
 ## More Commands
 
@@ -156,6 +156,9 @@ skillsaw -v
 
 # Strict mode (warnings become errors)
 skillsaw --strict
+
+# Fail on any violation, even info-level (see Configuration → Failure Threshold)
+skillsaw --fail-on info
 
 # List all rules with fix support info
 skillsaw list-rules

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -35,6 +35,14 @@ def _run_lint(args):
 
     cli_version = _get_version()
 
+    if args.strict and args.fail_on and args.fail_on != "warning":
+        print(
+            f"Error: --strict and --fail-on {args.fail_on} contradict each other "
+            "(--strict means --fail-on warning)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     output_formats = {}
     for spec in args.outputs:
         try:
@@ -91,14 +99,6 @@ def _run_lint(args):
 
     if config_path and args.verbose and args.fmt == "text":
         print(f"Using config: {config_path}\n")
-
-    if args.strict and args.fail_on and args.fail_on != "warning":
-        print(
-            f"Error: --strict and --fail-on {args.fail_on} contradict each other "
-            "(--strict means --fail-on warning)",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     # CLI flags override the config file's strict/fail-on settings; the config
     # values only apply when neither flag is given.

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -7,7 +7,6 @@ import sys
 import time
 from pathlib import Path
 
-from ..config import _FAIL_ON_LEVELS
 from ..context import RepositoryContext, RepositoryType
 from ..formatters import format_report, get_counts, parse_output_spec
 from ..linter import Linter
@@ -93,12 +92,22 @@ def _run_lint(args):
     if config_path and args.verbose and args.fmt == "text":
         print(f"Using config: {config_path}\n")
 
-    if args.strict:
-        config.strict = True
+    if args.strict and args.fail_on and args.fail_on != "warning":
+        print(
+            f"Error: --strict and --fail-on {args.fail_on} contradict each other "
+            "(--strict means --fail-on warning)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-    if args.fail_on and _FAIL_ON_LEVELS[args.fail_on] > _FAIL_ON_LEVELS[config.fail_on]:
-        # CLI can only tighten the threshold, mirroring --strict semantics.
-        config.fail_on = args.fail_on
+    # CLI flags override the config file's strict/fail-on settings; the config
+    # values only apply when neither flag is given.
+    if args.fail_on:
+        fail_level = args.fail_on
+    elif args.strict:
+        fail_level = "warning"
+    else:
+        fail_level = config.effective_fail_level()
 
     baseline = None
     if not args.no_baseline:
@@ -198,8 +207,6 @@ def _run_lint(args):
         block.estimate_tokens() for ctx in contexts for block in ctx.lint_tree.content_blocks()
     )
     grade = compute_grade(all_violations, content_tokens)
-
-    fail_level = config.effective_fail_level()
 
     stdout_output = format_report(
         args.fmt,

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -7,6 +7,7 @@ import sys
 import time
 from pathlib import Path
 
+from ..config import _FAIL_ON_LEVELS
 from ..context import RepositoryContext, RepositoryType
 from ..formatters import format_report, get_counts, parse_output_spec
 from ..linter import Linter
@@ -94,6 +95,10 @@ def _run_lint(args):
 
     if args.strict:
         config.strict = True
+
+    if args.fail_on and _FAIL_ON_LEVELS[args.fail_on] > _FAIL_ON_LEVELS[config.fail_on]:
+        # CLI can only tighten the threshold, mirroring --strict semantics.
+        config.fail_on = args.fail_on
 
     baseline = None
     if not args.no_baseline:
@@ -194,6 +199,8 @@ def _run_lint(args):
     )
     grade = compute_grade(all_violations, content_tokens)
 
+    fail_level = config.effective_fail_level()
+
     stdout_output = format_report(
         args.fmt,
         all_violations,
@@ -204,6 +211,7 @@ def _run_lint(args):
         baseline_suppressed=baseline_suppressed,
         duration=lint_duration,
         grade=grade,
+        fail_level=fail_level,
     )
     print(stdout_output)
 
@@ -220,6 +228,7 @@ def _run_lint(args):
                 baseline_suppressed=baseline_suppressed,
                 duration=lint_duration,
                 grade=grade,
+                fail_level=fail_level,
             )
         out_path = Path(output_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -229,7 +238,9 @@ def _run_lint(args):
 
     if missing_count > 0 or errors > 0:
         sys.exit(1)
-    elif config.strict and warnings_count > 0:
+    elif fail_level in ("warning", "info") and warnings_count > 0:
+        sys.exit(1)
+    elif fail_level == "info" and info > 0:
         sys.exit(1)
     else:
         sys.exit(0)

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from ..config import _FAIL_ON_LEVELS
 from ..context import RepositoryType
 from ..formatters import EXTENSION_MAP, FORMATS
 from ._config import _get_version
@@ -67,7 +68,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     lint_parser.add_argument(
         "--fail-on",
         dest="fail_on",
-        choices=["error", "warning", "info"],
+        choices=list(_FAIL_ON_LEVELS),
         default=None,
         help="Fail on violations at this severity or above (default: error; "
         "--strict is equivalent to --fail-on warning). Overrides the config "

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -64,6 +64,15 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Treat warnings as errors (exit with error code if warnings exist)",
     )
     lint_parser.add_argument(
+        "--fail-on",
+        dest="fail_on",
+        choices=["error", "warning", "info"],
+        default=None,
+        help="Fail on violations at this severity or above (default: error; "
+        "--strict is equivalent to --fail-on warning). Like --strict, this "
+        "can only tighten the config file's setting, never loosen it.",
+    )
+    lint_parser.add_argument(
         "--format",
         dest="fmt",
         default="text",

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -61,7 +61,8 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     lint_parser.add_argument(
         "--strict",
         action="store_true",
-        help="Treat warnings as errors (exit with error code if warnings exist)",
+        help="Treat warnings as errors (equivalent to --fail-on warning; "
+        "overrides the config file's strict/fail-on settings)",
     )
     lint_parser.add_argument(
         "--fail-on",
@@ -69,8 +70,8 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         choices=["error", "warning", "info"],
         default=None,
         help="Fail on violations at this severity or above (default: error; "
-        "--strict is equivalent to --fail-on warning). Like --strict, this "
-        "can only tighten the config file's setting, never loosen it.",
+        "--strict is equivalent to --fail-on warning). Overrides the config "
+        "file's strict/fail-on settings.",
     )
     lint_parser.add_argument(
         "--format",

--- a/src/skillsaw/config.py
+++ b/src/skillsaw/config.py
@@ -23,6 +23,11 @@ _DEFAULT_EXCLUDE_PATTERNS = [
     "**/_template/**",
 ]
 
+# Severity threshold ordering for ``fail-on``: a run fails when violations
+# exist at the configured level or above (error < warning < info in terms of
+# how much fails the run).
+_FAIL_ON_LEVELS = {"error": 0, "warning": 1, "info": 2}
+
 
 def _parse_version(v: str) -> Tuple[int, ...]:
     """Parse a version string leniently into a comparable numeric tuple.
@@ -56,6 +61,10 @@ class LinterConfig:
     exclude_patterns: List[str] = field(default_factory=list)
     content_paths: List[str] = field(default_factory=list)
     strict: bool = False
+    # Severity threshold that fails the run: violations at this level or above
+    # exit non-zero. ``strict: true`` is sugar for ``fail-on: warning``; the
+    # strictest of the two wins (see ``effective_fail_level``).
+    fail_on: str = "error"
     # Rule plugins (pip-installed packages exposing skillsaw.plugins entry
     # points). ``plugins_enabled: False`` skips all of them; ``disabled_plugins``
     # skips specific plugins by entry point name.
@@ -76,6 +85,7 @@ class LinterConfig:
             "exclude",
             "content-paths",
             "strict",
+            "fail-on",
             "plugins",
         }
     )
@@ -205,6 +215,21 @@ class LinterConfig:
         else:
             raise ValueError(f"'strict' must be a boolean, got {type(raw_strict).__name__}")
 
+        raw_fail_on = data.get("fail-on")
+        if raw_fail_on is None:
+            fail_on = "error"
+        elif isinstance(raw_fail_on, str) and raw_fail_on in _FAIL_ON_LEVELS:
+            fail_on = raw_fail_on
+            if fail_on == "error" and strict:
+                load_warnings.append(
+                    "'fail-on: error' has no effect while 'strict: true' — "
+                    "the strictest setting wins; remove 'strict' to lower the threshold"
+                )
+        else:
+            raise ValueError(
+                f"'fail-on' must be one of {', '.join(_FAIL_ON_LEVELS)}, got {raw_fail_on!r}"
+            )
+
         raw_plugins = data.get("plugins")
         plugins_enabled = True
         disabled_plugins: List[str] = []
@@ -248,6 +273,7 @@ class LinterConfig:
             exclude_patterns=exclude_patterns,
             content_paths=content_paths,
             strict=strict,
+            fail_on=fail_on,
             plugins_enabled=plugins_enabled,
             disabled_plugins=disabled_plugins,
             config_dir=config_path.resolve().parent,
@@ -287,6 +313,17 @@ class LinterConfig:
         config = cls.default()
         config.version = __version__
         return config
+
+    def effective_fail_level(self) -> str:
+        """Resolve ``strict`` and ``fail-on`` into a single severity threshold.
+
+        ``strict: true`` counts as ``fail-on: warning``; the strictest setting
+        wins, so neither option can loosen the other.
+        """
+        candidates = [self.fail_on if self.fail_on in _FAIL_ON_LEVELS else "error"]
+        if self.strict:
+            candidates.append("warning")
+        return max(candidates, key=_FAIL_ON_LEVELS.__getitem__)
 
     def get_rule_config(self, rule_id: str) -> Dict[str, Any]:
         """
@@ -432,6 +469,7 @@ class LinterConfig:
         d["custom-rules"] = self.custom_rules
         d["exclude"] = self.exclude_patterns
         d["strict"] = self.strict
+        d["fail-on"] = self.fail_on
         if self.content_paths:
             d["content-paths"] = self.content_paths
         if not self.plugins_enabled or self.disabled_plugins:
@@ -519,6 +557,8 @@ class LinterConfig:
             self._write_field(f, "content-paths", self.content_paths)
             f.write("\n# Treat warnings as errors\n")
             f.write(f"strict: {self._yaml_value(self.strict)}\n")
+            f.write("\n# Fail on violations at this severity or above: error, warning, info\n")
+            f.write(f"fail-on: {self._yaml_value(self.fail_on)}\n")
 
     def _write_field(self, f, key: str, value: Any):
         """Helper to write a YAML field to the file."""

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -108,9 +108,9 @@ def format_report(
         duration: Wall-clock lint time in seconds (text and json formats only;
             sarif/code-climate schemas have no place for it)
         grade: Optional Grade for the run (text and json formats only)
-        fail_level: Effective severity threshold that fails the run (text
-            format only) — with ``fail-on: info`` the text output must show
-            the info violations that caused the failure even without -v
+        fail_level: Effective severity threshold that fails the run — with
+            ``fail-on: info`` every format must include the info violations
+            that caused the failure even without -v
     """
     if fmt == "text":
         from .text import format_text
@@ -130,19 +130,27 @@ def format_report(
         from .json_fmt import format_json
 
         return format_json(
-            violations, context, rules, version, verbose, baseline_suppressed, duration, grade
+            violations,
+            context,
+            rules,
+            version,
+            verbose,
+            baseline_suppressed,
+            duration,
+            grade,
+            fail_level,
         )
     elif fmt == "sarif":
         from .sarif import format_sarif
 
-        return format_sarif(violations, context, rules, version, verbose)
+        return format_sarif(violations, context, rules, version, verbose, fail_level)
     elif fmt == "html":
         from .html import format_html
 
-        return format_html(violations, context, rules, version, verbose)
+        return format_html(violations, context, rules, version, verbose, fail_level)
     elif fmt in ("code-climate", "gitlab"):
         from .code_climate import format_code_climate
 
-        return format_code_climate(violations, context, rules, version, verbose)
+        return format_code_climate(violations, context, rules, version, verbose, fail_level)
     else:
         raise ValueError(f"Unknown format: {fmt}. Supported: {', '.join(FORMATS)}")

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -92,6 +92,7 @@ def format_report(
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
     grade=None,
+    fail_level: str = "error",
 ) -> str:
     """
     Format lint results in the specified format.
@@ -107,12 +108,23 @@ def format_report(
         duration: Wall-clock lint time in seconds (text and json formats only;
             sarif/code-climate schemas have no place for it)
         grade: Optional Grade for the run (text and json formats only)
+        fail_level: Effective severity threshold that fails the run (text
+            format only) — with ``fail-on: info`` the text output must show
+            the info violations that caused the failure even without -v
     """
     if fmt == "text":
         from .text import format_text
 
         return format_text(
-            violations, context, rules, version, verbose, baseline_suppressed, duration, grade
+            violations,
+            context,
+            rules,
+            version,
+            verbose,
+            baseline_suppressed,
+            duration,
+            grade,
+            fail_level,
         )
     elif fmt == "json":
         from .json_fmt import format_json

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -72,6 +72,15 @@ def parse_output_spec(spec: str) -> tuple:
     return infer_format(spec), spec
 
 
+def should_show_info(verbose: bool, fail_level: str) -> bool:
+    """Whether info-level violations should be surfaced in a report.
+
+    Info violations are always shown with -v, and also when ``fail-on: info``
+    makes them decide the exit code — a failing CI run must show its cause.
+    """
+    return verbose or fail_level == "info"
+
+
 def get_counts(violations: List[RuleViolation]):
     """Count violations by severity."""
     from ..rule import Severity

--- a/src/skillsaw/formatters/code_climate.py
+++ b/src/skillsaw/formatters/code_climate.py
@@ -20,8 +20,10 @@ def format_code_climate(
     rules,
     version: str,
     verbose: bool = False,
+    fail_level: str = "error",
 ) -> str:
-    filtered = violations if verbose else [v for v in violations if v.severity != Severity.INFO]
+    show_info = verbose or fail_level == "info"
+    filtered = violations if show_info else [v for v in violations if v.severity != Severity.INFO]
 
     items = []
     for v in filtered:

--- a/src/skillsaw/formatters/code_climate.py
+++ b/src/skillsaw/formatters/code_climate.py
@@ -5,7 +5,7 @@ import json
 from typing import List
 
 from ..rule import RuleViolation, Severity
-from . import relative_path
+from . import relative_path, should_show_info
 
 _SEVERITY_MAP = {
     "error": "critical",
@@ -22,7 +22,7 @@ def format_code_climate(
     verbose: bool = False,
     fail_level: str = "error",
 ) -> str:
-    show_info = verbose or fail_level == "info"
+    show_info = should_show_info(verbose, fail_level)
     filtered = violations if show_info else [v for v in violations if v.severity != Severity.INFO]
 
     items = []

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -80,7 +80,7 @@ def format_html(
     </section>"""
 
     info_count_row = ""
-    if verbose:
+    if show_info:
         info_count_row = f'<span class="count-item count-info">Info: {info}</span>'
 
     return f"""\

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -13,10 +13,12 @@ def format_html(
     rules: List[Rule],
     version: str,
     verbose: bool = False,
+    fail_level: str = "error",
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
-    visible = [v for v in violations if verbose or v.severity != Severity.INFO]
+    show_info = verbose or fail_level == "info"
+    visible = [v for v in violations if show_info or v.severity != Severity.INFO]
 
     def severity_badge(sev: Severity) -> str:
         colors = {

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -4,7 +4,7 @@ import html
 from typing import List
 
 from ..rule import Rule, RuleViolation, Severity
-from . import get_counts, relative_path
+from . import get_counts, relative_path, should_show_info
 
 
 def format_html(
@@ -17,7 +17,7 @@ def format_html(
 ) -> str:
     errors, warnings, info = get_counts(violations)
 
-    show_info = verbose or fail_level == "info"
+    show_info = should_show_info(verbose, fail_level)
     visible = [v for v in violations if show_info or v.severity != Severity.INFO]
 
     def severity_badge(sev: Severity) -> str:

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -16,7 +16,11 @@ def format_json(
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
     grade=None,
+    fail_level: str = "error",
 ) -> str:
+    # With fail-on: info the info violations decide the exit code, so a CI
+    # report that omitted them would fail with no visible cause.
+    show_info = verbose or fail_level == "info"
     errors, warnings, info = get_counts(violations)
 
     repo_types_list = context.repo_type_names()
@@ -54,7 +58,7 @@ def format_json(
                 "source": v.source,
             }
             for v in violations
-            if verbose or v.severity != Severity.INFO
+            if show_info or v.severity != Severity.INFO
         ],
         "summary": {
             "errors": errors,

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -4,7 +4,7 @@ import json
 from typing import List, Optional
 
 from ..rule import Rule, RuleViolation, Severity
-from . import get_counts, relative_path
+from . import get_counts, relative_path, should_show_info
 
 
 def format_json(
@@ -18,9 +18,7 @@ def format_json(
     grade=None,
     fail_level: str = "error",
 ) -> str:
-    # With fail-on: info the info violations decide the exit code, so a CI
-    # report that omitted them would fail with no visible cause.
-    show_info = verbose or fail_level == "info"
+    show_info = should_show_info(verbose, fail_level)
     errors, warnings, info = get_counts(violations)
 
     repo_types_list = context.repo_type_names()

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -26,6 +26,7 @@ def format_sarif(
     rules: List[Rule],
     version: str,
     verbose: bool = False,
+    fail_level: str = "error",
 ) -> str:
     seen = {}
     for r in rules:
@@ -53,7 +54,8 @@ def format_sarif(
             }
 
     results = []
-    filtered = violations if verbose else [v for v in violations if v.severity != Severity.INFO]
+    show_info = verbose or fail_level == "info"
+    filtered = violations if show_info else [v for v in violations if v.severity != Severity.INFO]
     for v in filtered:
         result = {
             "ruleId": v.rule_id,

--- a/src/skillsaw/formatters/sarif.py
+++ b/src/skillsaw/formatters/sarif.py
@@ -6,6 +6,7 @@ from typing import List
 
 from ..rule import Rule, RuleViolation, Severity
 from ..rule_docs import rule_doc_url
+from . import should_show_info
 
 _SEVERITY_MAP = {
     "error": "error",
@@ -54,7 +55,7 @@ def format_sarif(
             }
 
     results = []
-    show_info = verbose or fail_level == "info"
+    show_info = should_show_info(verbose, fail_level)
     filtered = violations if show_info else [v for v in violations if v.severity != Severity.INFO]
     for v in filtered:
         result = {

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from ..rule import Rule, RuleViolation, Severity
 from ..rule_docs import rule_doc_url
-from . import get_counts, relative_path
+from . import get_counts, relative_path, should_show_info
 
 
 def format_duration(seconds: float) -> str:
@@ -31,9 +31,7 @@ def format_text(
     grade=None,
     fail_level: str = "error",
 ) -> str:
-    # With fail-on: info the info violations decide the exit code, so hiding
-    # them behind -v would fail CI without showing what failed.
-    show_info = verbose or fail_level == "info"
+    show_info = should_show_info(verbose, fail_level)
     no_color = "NO_COLOR" in os.environ
     red = "" if no_color else "\033[91m"
     yellow = "" if no_color else "\033[93m"

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -29,7 +29,11 @@ def format_text(
     baseline_suppressed: int = 0,
     duration: Optional[float] = None,
     grade=None,
+    fail_level: str = "error",
 ) -> str:
+    # With fail-on: info the info violations decide the exit code, so hiding
+    # them behind -v would fail CI without showing what failed.
+    show_info = verbose or fail_level == "info"
     no_color = "NO_COLOR" in os.environ
     red = "" if no_color else "\033[91m"
     yellow = "" if no_color else "\033[93m"
@@ -64,12 +68,12 @@ def format_text(
         for v in warnings_list:
             output.append(f"  {fmt_violation(v)}")
 
-    if verbose and info_list:
+    if show_info and info_list:
         output.append(f"\n{blue}{bold}Info:{reset}")
         for v in info_list:
             output.append(f"  {fmt_violation(v)}")
 
-    shown = errors_list + warnings_list + (info_list if verbose else [])
+    shown = errors_list + warnings_list + (info_list if show_info else [])
     # Synthetic rule IDs (e.g. invalid-config) have no documentation page —
     # only link rules that actually ran as builtins.
     builtin_ids = {r.rule_id for r in rules if getattr(r, "_source", "builtin") == "builtin"}
@@ -91,7 +95,7 @@ def format_text(
     output.append(f"\n{bold}Summary:{reset}")
     output.append(f"  {red}Errors:   {errors}{reset}")
     output.append(f"  {yellow}Warnings: {warnings}{reset}")
-    if verbose:
+    if show_info:
         output.append(f"  {blue}Info:     {info}{reset}")
     if baseline_suppressed:
         dim = "" if no_color else "\033[2m"
@@ -102,14 +106,14 @@ def format_text(
             f"  Grade:    {grade_color}{bold}{grade.letter}{reset} "
             f"({grade.density:.2f} weighted violations per 10k tokens)"
         )
-        if grade.info and not verbose:
+        if grade.info and not show_info:
             dim = "" if no_color else "\033[2m"
             output.append(
                 f"  {dim}{grade.info} info-level violation(s) count toward"
                 f" the grade — run with -v to see them{reset}"
             )
 
-    if errors == 0 and warnings == 0:
+    if errors == 0 and warnings == 0 and (fail_level != "info" or info == 0):
         output.append(f"\n{green}{bold}✓ All checks passed!{reset}")
 
     return "\n".join(output)

--- a/tests/fixtures/config/fail-on-info/.claude-plugin/plugin.json
+++ b/tests/fixtures/config/fail-on-info/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "fail-on-info-test",
+  "description": "Test fail-on info exit codes",
+  "version": "1.0.0",
+  "author": {"name": "Test"}
+}

--- a/tests/fixtures/config/fail-on-info/.skillsaw.yaml
+++ b/tests/fixtures/config/fail-on-info/.skillsaw.yaml
@@ -1,0 +1,6 @@
+version: "99.0.0"
+fail-on: info
+
+rules:
+  plugin-readme:
+    severity: info

--- a/tests/fixtures/config/fail-on-info/commands/test.md
+++ b/tests/fixtures/config/fail-on-info/commands/test.md
@@ -1,0 +1,18 @@
+---
+description: A valid command
+---
+
+## Name
+fail-on-info-test:test
+
+## Synopsis
+```text
+/fail-on-info-test:test
+```
+
+## Description
+A well-formatted command.
+
+## Implementation
+1. Do the thing
+2. Return the result

--- a/tests/fixtures/config/info-only/.claude-plugin/plugin.json
+++ b/tests/fixtures/config/info-only/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "info-only-test",
+  "description": "Test that info violations do not fail by default",
+  "version": "1.0.0",
+  "author": {"name": "Test"}
+}

--- a/tests/fixtures/config/info-only/.skillsaw.yaml
+++ b/tests/fixtures/config/info-only/.skillsaw.yaml
@@ -1,0 +1,5 @@
+version: "99.0.0"
+
+rules:
+  plugin-readme:
+    severity: info

--- a/tests/fixtures/config/info-only/commands/test.md
+++ b/tests/fixtures/config/info-only/commands/test.md
@@ -1,0 +1,18 @@
+---
+description: A valid command
+---
+
+## Name
+info-only-test:test
+
+## Synopsis
+```text
+/info-only-test:test
+```
+
+## Description
+A well-formatted command.
+
+## Implementation
+1. Do the thing
+2. Return the result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1212,3 +1212,70 @@ def test_find_config_at_filesystem_walk_includes_start_dir(tmp_path):
     # The walk must include the start directory itself.
     (tmp_path / ".skillsaw.yaml").write_text("rules: {}\n", encoding="utf-8")
     assert find_config(tmp_path) == tmp_path / ".skillsaw.yaml"
+
+
+# ── fail-on ──────────────────────────────────────────────────────
+
+
+def test_fail_on_defaults_to_error(tmp_path):
+    config = LinterConfig.from_file(_write(tmp_path, 'version: "0.15.0"\nrules: {}\n'))
+    assert config.fail_on == "error"
+    assert config.effective_fail_level() == "error"
+
+
+def test_fail_on_parses_valid_levels(tmp_path):
+    for level in ("error", "warning", "info"):
+        config = LinterConfig.from_file(_write(tmp_path, f'version: "0.15.0"\nfail-on: {level}\n'))
+        assert config.fail_on == level
+        assert config.effective_fail_level() == level
+
+
+def test_fail_on_invalid_value_raises(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'fail-on' must be one of"):
+        LinterConfig.from_file(_write(tmp_path, 'version: "0.15.0"\nfail-on: fatal\n'))
+
+
+def test_fail_on_non_string_raises(tmp_path):
+    import pytest
+
+    with pytest.raises(ValueError, match="'fail-on' must be one of"):
+        LinterConfig.from_file(_write(tmp_path, 'version: "0.15.0"\nfail-on: true\n'))
+
+
+def test_null_fail_on_does_not_crash(tmp_path):
+    """fail-on: null should not crash, should behave like the default"""
+    config = LinterConfig.from_file(_write(tmp_path, 'version: "0.15.0"\nfail-on:\n'))
+    assert config.fail_on == "error"
+
+
+def test_strict_implies_fail_on_warning(tmp_path):
+    config = LinterConfig.from_file(_write(tmp_path, 'version: "0.15.0"\nstrict: true\n'))
+    assert config.effective_fail_level() == "warning"
+
+
+def test_fail_on_info_tightens_past_strict(tmp_path):
+    config = LinterConfig.from_file(
+        _write(tmp_path, 'version: "0.15.0"\nstrict: true\nfail-on: info\n')
+    )
+    assert config.effective_fail_level() == "info"
+
+
+def test_fail_on_error_cannot_loosen_strict(tmp_path):
+    """strict: true wins over fail-on: error — the strictest setting applies,
+    and the ineffective fail-on produces a load warning."""
+    config = LinterConfig.from_file(
+        _write(tmp_path, 'version: "0.15.0"\nstrict: true\nfail-on: error\n')
+    )
+    assert config.effective_fail_level() == "warning"
+    assert any("fail-on: error" in w for w in config.warnings)
+
+
+def test_fail_on_roundtrips_through_save(tmp_path):
+    config = LinterConfig.default()
+    config.fail_on = "info"
+    config_path = tmp_path / ".skillsaw.yaml"
+    config.save(config_path)
+    reloaded = LinterConfig.from_file(config_path)
+    assert reloaded.fail_on == "info"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1363,6 +1363,16 @@ class TestExitCodes:
         assert all(v["severity"] != "info" for v in violations(r))
         assert summary(r)["info"] >= 1
 
+    def test_fail_on_info_includes_info_in_html_output(self, tmp_path):
+        """HTML report must show fatal info violations and count them in the footer."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        out_file = tmp_path / "report.html"
+        r = run_lint(repo, "--output", str(out_file), verbose=False, fmt="text")
+        assert r["rc"] == 1
+        html = out_file.read_text()
+        assert "plugin-readme" in html
+        assert "count-info" in html
+
     def test_fail_on_info_includes_info_in_sarif_output(self, tmp_path):
         """SARIF output must also include the info violations that failed the run."""
         repo = copy_fixture("config/fail-on-info", tmp_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1304,11 +1304,32 @@ class TestExitCodes:
         r = run_lint(repo, "--strict")
         assert r["rc"] == 0
 
-    def test_fail_on_flag_cannot_loosen_config_strict(self, tmp_path):
-        """--fail-on error must not override strict: true in the config."""
+    def test_fail_on_flag_overrides_config_strict(self, tmp_path):
+        """--fail-on error overrides strict: true in the config — warnings pass."""
         repo = copy_fixture("config/strict-mode", tmp_path)
         r = run_lint(repo, "--fail-on", "error")
+        assert r["rc"] == 0
+        assert summary(r)["warnings"] >= 1
+
+    def test_strict_flag_overrides_config_fail_on(self, tmp_path):
+        """--strict overrides fail-on: info in the config — info-only passes."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        r = run_lint(repo, "--strict")
+        assert r["rc"] == 0
+        assert summary(r)["info"] >= 1
+
+    def test_contradictory_strict_and_fail_on_flags_error(self, tmp_path):
+        """--strict with a disagreeing --fail-on is rejected."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, "--strict", "--fail-on", "info")
         assert r["rc"] == 1
+        assert "contradict" in r["stderr"]
+
+    def test_agreeing_strict_and_fail_on_flags_accepted(self, tmp_path):
+        """--strict --fail-on warning agree and lint normally."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, "--strict", "--fail-on", "warning")
+        assert r["rc"] == 0
 
     def test_fail_on_info_shows_info_in_text_output(self, tmp_path):
         """When info violations fail the run, text output must show them without -v."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1276,6 +1276,56 @@ class TestExitCodes:
         r = run_lint(repo, "--strict")
         assert r["rc"] == 1
 
+    def test_exit_1_on_info_with_fail_on_config(self, tmp_path):
+        """fail-on: info in config makes info-only violations exit 1."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        r = run_lint(repo)
+        assert r["rc"] == 1
+        assert summary(r)["errors"] == 0
+        assert summary(r)["warnings"] == 0
+        assert summary(r)["info"] >= 1
+
+    def test_exit_0_on_info_without_fail_on(self, tmp_path):
+        """Info-only violations exit 0 by default."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo)
+        assert r["rc"] == 0
+        assert summary(r)["info"] >= 1
+
+    def test_exit_1_on_info_with_fail_on_flag(self, tmp_path):
+        """--fail-on info tightens a config without fail-on."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, "--fail-on", "info")
+        assert r["rc"] == 1
+
+    def test_strict_alone_does_not_fail_on_info(self, tmp_path):
+        """--strict only promotes warnings — info-only violations still pass."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, "--strict")
+        assert r["rc"] == 0
+
+    def test_fail_on_flag_cannot_loosen_config_strict(self, tmp_path):
+        """--fail-on error must not override strict: true in the config."""
+        repo = copy_fixture("config/strict-mode", tmp_path)
+        r = run_lint(repo, "--fail-on", "error")
+        assert r["rc"] == 1
+
+    def test_fail_on_info_shows_info_in_text_output(self, tmp_path):
+        """When info violations fail the run, text output must show them without -v."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        r = run_lint(repo, fmt="text", verbose=False)
+        assert r["rc"] == 1
+        assert "Info:" in r["stdout"]
+        assert "All checks passed" not in r["stdout"]
+
+    def test_info_stays_hidden_in_text_output_without_fail_on(self, tmp_path):
+        """Without fail-on: info, non-verbose text output keeps info hidden."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, fmt="text", verbose=False)
+        assert r["rc"] == 0
+        assert "Info:" not in r["stdout"]
+        assert "All checks passed" in r["stdout"]
+
 
 # ── Output Formats ───────────────────────────────────────────────
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1347,6 +1347,32 @@ class TestExitCodes:
         assert "Info:" not in r["stdout"]
         assert "All checks passed" in r["stdout"]
 
+    def test_fail_on_info_includes_info_in_json_output(self, tmp_path):
+        """When info violations fail the run, non-verbose JSON must include them."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        r = run_lint(repo, verbose=False)
+        assert r["rc"] == 1
+        info_violations = [v for v in violations(r) if v["severity"] == "info"]
+        assert len(info_violations) >= 1
+
+    def test_info_stays_hidden_in_json_output_without_fail_on(self, tmp_path):
+        """Without fail-on: info, non-verbose JSON output keeps info hidden."""
+        repo = copy_fixture("config/info-only", tmp_path)
+        r = run_lint(repo, verbose=False)
+        assert r["rc"] == 0
+        assert all(v["severity"] != "info" for v in violations(r))
+        assert summary(r)["info"] >= 1
+
+    def test_fail_on_info_includes_info_in_sarif_output(self, tmp_path):
+        """SARIF output must also include the info violations that failed the run."""
+        repo = copy_fixture("config/fail-on-info", tmp_path)
+        out_file = tmp_path / "report.sarif"
+        r = run_lint(repo, "--output", str(out_file), verbose=False, fmt="text")
+        assert r["rc"] == 1
+        sarif = json.loads(out_file.read_text())
+        results = sarif["runs"][0]["results"]
+        assert any(res["level"] == "note" for res in results)
+
 
 # ── Output Formats ───────────────────────────────────────────────
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1371,7 +1371,7 @@ class TestExitCodes:
         assert r["rc"] == 1
         html = out_file.read_text()
         assert "plugin-readme" in html
-        assert "count-info" in html
+        assert '<span class="count-item count-info">Info:' in html
 
     def test_fail_on_info_includes_info_in_sarif_output(self, tmp_path):
         """SARIF output must also include the info violations that failed the run."""


### PR DESCRIPTION
Closes #365

## What

Adds a global severity threshold for failing the run, so info-level violations can fail CI without per-rule `severity:` bookkeeping:

- **`fail-on: error | warning | info`** config key (default `error`, current behavior)
- **`--fail-on`** CLI flag with the same values
- **`fail-on`** input on the GitHub Action, threaded through to the flag

## Semantics

`strict: true` is now sugar for `fail-on: warning`. When both are set, the **strictest wins** — neither option can loosen the other, mirroring the existing rule that `--strict` can only upgrade. `strict: true` + `fail-on: error` resolves to `warning` and emits a config load warning explaining that `fail-on: error` has no effect. The `--fail-on` flag, like `--strict`, can only tighten the config file's setting.

| `strict` | `fail-on` | effective threshold |
|---|---|---|
| unset | unset | `error` (unchanged default) |
| `true` | unset | `warning` (unchanged strict behavior) |
| unset | `info` | `info` |
| `true` | `info` | `info` |
| `true` | `error` | `warning` + load warning |

## UX

With `fail-on: info`, the text formatter shows the Info section (and info summary count) even without `-v` — otherwise CI would exit 1 while hiding the violations that caused it. "All checks passed" is suppressed when info violations are fatal. Default and `--strict` output is unchanged.

Baseline-suppressed violations already never reach the counts, so `fail-on: info` composes with a baseline for repos that aren't yet at zero.

## Testing

- 9 new config tests (parsing, validation errors, `fail-on: null`, strict/fail-on resolution matrix, save round-trip)
- 7 new integration tests on two new fixtures (`config/fail-on-info`, `config/info-only`): exit codes for config key, CLI flag, `--strict` on info-only repos, flag-cannot-loosen-strict, and text-output visibility
- Full suite passes (2441 tests); verified against openshift-eng/ai-helpers (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `fail-on` setting and CLI/action option to control which violation severity causes a run to fail.
  * Documentation and examples now show how `strict` and `fail-on` work together, including info-level failures.

* **Bug Fixes**
  * Updated exit-code behavior so reports and CI results match the selected failure threshold.
  * Improved output formats to include info-level violations when they affect pass/fail status, even without verbose mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->