### PR TITLE
[Auto] Bump version to 0.16.0

### DIFF
--- a/.agents/skills/skillsaw-release/SKILL.md
+++ b/.agents/skills/skillsaw-release/SKILL.md
@@ -16,11 +16,14 @@ You are releasing a new version of the **skillsaw** linter.
 
 Before releasing, verify:
 
-1. You are on the `main` branch and it is clean (`git status`)
+1. You are on the `main` branch, it is clean (`git status`), and up to
+   date with `origin/main` (`git pull origin main`)
 2. All tests pass: `make test`
 3. Formatting is clean: `make lint`
-4. Determine what version to release — if no version was specified, the
-   bump script will auto-increment the patch version
+4. Determine what version to release — if no version was specified,
+   choose based on the commits since the last tag: new features or rules
+   → bump minor; fixes only → bump patch (the bump script defaults to
+   patch when given no argument)
 
 The Makefile automatically creates the `.venv` and installs dependencies.
 
@@ -33,20 +36,44 @@ Run the bump script:
 bash scripts/bump-version.sh [version]
 ```
 
-This updates both `pyproject.toml` and `src/skillsaw/__init__.py`. If no
-version argument is given, it increments the patch version automatically.
+This updates `pyproject.toml`, `src/skillsaw/__init__.py`, and
+`action.yml` (the action's default skillsaw version). If no version
+argument is given, it increments the patch version automatically.
 
-Verify the bump by checking the output and confirming both files were updated.
-
-## Step 3: Commit and push the version bump
-
-First verify remotes with `git remote -v` to confirm `origin` points to
-the user's fork (stbenjam/skillsaw). Then:
+Then regenerate generated files and catch the pinned version references
+the script does NOT update:
 
 ```bash
-git add pyproject.toml src/skillsaw/__init__.py
+make update
+grep -rn "{old_version}" README.md docs/
+```
+
+Update every stale pin by hand — currently `pip install skillsaw==X.Y.Z`
+in `README.md` and `docs/ci.md`, and pre-commit `rev: vX.Y.Z` in
+`README.md` and `docs/pre-commit.md`. Do NOT touch historical
+"Since vX.Y.Z" lines in `docs/rules/`.
+
+## Step 3: Open a version-bump PR
+
+`main` is branch-protected — a direct push is rejected, so the bump goes
+through a PR. First verify remotes with `git remote -v` (`origin` should
+be stbenjam/skillsaw). Then:
+
+```bash
+git checkout -b release/{version}-bump
+git add -A
 git commit -m "[Auto] Bump version to {version}"
-git push origin main
+git push -u origin release/{version}-bump
+gh pr create --title "[Auto] Bump version to {version}" --body "Version bump for the {version} release."
+```
+
+Wait for all required checks to pass, merge the PR, then update local
+main:
+
+```bash
+gh pr checks {pr} --watch
+gh pr merge {pr} --squash
+git checkout main && git pull origin main
 ```
 
 ## Step 4: Generate release notes
@@ -69,8 +96,11 @@ commits, CI-only changes).
 
 ## Step 5: Create the GitHub release
 
+Only after the bump PR has merged, so the tag includes the bumped
+version files:
+
 ```bash
-gh release create v{version} --title "v{version}" --notes "{release_notes}"
+gh release create v{version} --title "v{version}" --notes "{release_notes}" --target main
 ```
 
 This triggers the `release.yml` workflow which builds and publishes to PyPI

--- a/.apm/skills/skillsaw-release/SKILL.md
+++ b/.apm/skills/skillsaw-release/SKILL.md
@@ -16,11 +16,14 @@ You are releasing a new version of the **skillsaw** linter.
 
 Before releasing, verify:
 
-1. You are on the `main` branch and it is clean (`git status`)
+1. You are on the `main` branch, it is clean (`git status`), and up to
+   date with `origin/main` (`git pull origin main`)
 2. All tests pass: `make test`
 3. Formatting is clean: `make lint`
-4. Determine what version to release — if no version was specified, the
-   bump script will auto-increment the patch version
+4. Determine what version to release — if no version was specified,
+   choose based on the commits since the last tag: new features or rules
+   → bump minor; fixes only → bump patch (the bump script defaults to
+   patch when given no argument)
 
 The Makefile automatically creates the `.venv` and installs dependencies.
 
@@ -33,20 +36,44 @@ Run the bump script:
 bash scripts/bump-version.sh [version]
 ```
 
-This updates both `pyproject.toml` and `src/skillsaw/__init__.py`. If no
-version argument is given, it increments the patch version automatically.
+This updates `pyproject.toml`, `src/skillsaw/__init__.py`, and
+`action.yml` (the action's default skillsaw version). If no version
+argument is given, it increments the patch version automatically.
 
-Verify the bump by checking the output and confirming both files were updated.
-
-## Step 3: Commit and push the version bump
-
-First verify remotes with `git remote -v` to confirm `origin` points to
-the user's fork (stbenjam/skillsaw). Then:
+Then regenerate generated files and catch the pinned version references
+the script does NOT update:
 
 ```bash
-git add pyproject.toml src/skillsaw/__init__.py
+make update
+grep -rn "{old_version}" README.md docs/
+```
+
+Update every stale pin by hand — currently `pip install skillsaw==X.Y.Z`
+in `README.md` and `docs/ci.md`, and pre-commit `rev: vX.Y.Z` in
+`README.md` and `docs/pre-commit.md`. Do NOT touch historical
+"Since vX.Y.Z" lines in `docs/rules/`.
+
+## Step 3: Open a version-bump PR
+
+`main` is branch-protected — a direct push is rejected, so the bump goes
+through a PR. First verify remotes with `git remote -v` (`origin` should
+be stbenjam/skillsaw). Then:
+
+```bash
+git checkout -b release/{version}-bump
+git add -A
 git commit -m "[Auto] Bump version to {version}"
-git push origin main
+git push -u origin release/{version}-bump
+gh pr create --title "[Auto] Bump version to {version}" --body "Version bump for the {version} release."
+```
+
+Wait for all required checks to pass, merge the PR, then update local
+main:
+
+```bash
+gh pr checks {pr} --watch
+gh pr merge {pr} --squash
+git checkout main && git pull origin main
 ```
 
 ## Step 4: Generate release notes
@@ -69,8 +96,11 @@ commits, CI-only changes).
 
 ## Step 5: Create the GitHub release
 
+Only after the bump PR has merged, so the tag includes the bumped
+version files:
+
 ```bash
-gh release create v{version} --title "v{version}" --notes "{release_notes}"
+gh release create v{version} --title "v{version}" --notes "{release_notes}" --target main
 ```
 
 This triggers the `release.yml` workflow which builds and publishes to PyPI

--- a/.claude/skills/skillsaw-release/SKILL.md
+++ b/.claude/skills/skillsaw-release/SKILL.md
@@ -16,11 +16,14 @@ You are releasing a new version of the **skillsaw** linter.
 
 Before releasing, verify:
 
-1. You are on the `main` branch and it is clean (`git status`)
+1. You are on the `main` branch, it is clean (`git status`), and up to
+   date with `origin/main` (`git pull origin main`)
 2. All tests pass: `make test`
 3. Formatting is clean: `make lint`
-4. Determine what version to release — if no version was specified, the
-   bump script will auto-increment the patch version
+4. Determine what version to release — if no version was specified,
+   choose based on the commits since the last tag: new features or rules
+   → bump minor; fixes only → bump patch (the bump script defaults to
+   patch when given no argument)
 
 The Makefile automatically creates the `.venv` and installs dependencies.
 
@@ -33,20 +36,44 @@ Run the bump script:
 bash scripts/bump-version.sh [version]
 ```
 
-This updates both `pyproject.toml` and `src/skillsaw/__init__.py`. If no
-version argument is given, it increments the patch version automatically.
+This updates `pyproject.toml`, `src/skillsaw/__init__.py`, and
+`action.yml` (the action's default skillsaw version). If no version
+argument is given, it increments the patch version automatically.
 
-Verify the bump by checking the output and confirming both files were updated.
-
-## Step 3: Commit and push the version bump
-
-First verify remotes with `git remote -v` to confirm `origin` points to
-the user's fork (stbenjam/skillsaw). Then:
+Then regenerate generated files and catch the pinned version references
+the script does NOT update:
 
 ```bash
-git add pyproject.toml src/skillsaw/__init__.py
+make update
+grep -rn "{old_version}" README.md docs/
+```
+
+Update every stale pin by hand — currently `pip install skillsaw==X.Y.Z`
+in `README.md` and `docs/ci.md`, and pre-commit `rev: vX.Y.Z` in
+`README.md` and `docs/pre-commit.md`. Do NOT touch historical
+"Since vX.Y.Z" lines in `docs/rules/`.
+
+## Step 3: Open a version-bump PR
+
+`main` is branch-protected — a direct push is rejected, so the bump goes
+through a PR. First verify remotes with `git remote -v` (`origin` should
+be stbenjam/skillsaw). Then:
+
+```bash
+git checkout -b release/{version}-bump
+git add -A
 git commit -m "[Auto] Bump version to {version}"
-git push origin main
+git push -u origin release/{version}-bump
+gh pr create --title "[Auto] Bump version to {version}" --body "Version bump for the {version} release."
+```
+
+Wait for all required checks to pass, merge the PR, then update local
+main:
+
+```bash
+gh pr checks {pr} --watch
+gh pr merge {pr} --squash
+git checkout main && git pull origin main
 ```
 
 ## Step 4: Generate release notes
@@ -69,8 +96,11 @@ commits, CI-only changes).
 
 ## Step 5: Create the GitHub release
 
+Only after the bump PR has merged, so the tag includes the bumped
+version files:
+
 ```bash
-gh release create v{version} --title "v{version}" --notes "{release_notes}"
+gh release create v{version} --title "v{version}" --notes "{release_notes}" --target main
 ```
 
 This triggers the `release.yml` workflow which builds and publishes to PyPI

--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.15.0"
+version: "0.16.0"
 
 rules:
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker run -v $(pwd):/workspace ghcr.io/stbenjam/skillsaw
 # GitLab CI — outputs Code Quality JSON for MR widgets
 skillsaw:
   script:
-    - pip install skillsaw==0.15.0
+    - pip install skillsaw==0.16.0
     - skillsaw lint --output gitlab:gl-code-quality-report.json .
   artifacts:
     reports:
@@ -194,7 +194,7 @@ repository's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/stbenjam/skillsaw
-    rev: v0.15.0  # or pin a full commit SHA
+    rev: v0.16.0  # or pin a full commit SHA
     hooks:
       - id: skillsaw
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.12.1"). Defaults to the version this action was released with.'
     required: false
-    default: '0.15.0'
+    default: '0.16.0'
   strict:
     description: 'Treat warnings as errors'
     required: false

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -151,7 +151,7 @@ Quality report, available since skillsaw 0.11.3):
 ```yaml
 skillsaw:
   script:
-    - pip install skillsaw==0.15.0
+    - pip install skillsaw==0.16.0
     - skillsaw lint --output gitlab:gl-code-quality-report.json .
   artifacts:
     reports:

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -11,7 +11,7 @@ Add skillsaw to your repository's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/stbenjam/skillsaw
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: skillsaw
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.15.0"
+version = "0.16.0"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext


### PR DESCRIPTION
Version bump for the 0.16.0 release.

Changes since v0.15.0:
- `fail-on` severity threshold for exit codes (#368, closes #365)
- `content-inconsistent-terminology`: configurable individual term groups (#367)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->