### PR TITLE
benchmarks: fail fast when --compare baseline is missing

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -236,6 +236,14 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.repeats < 1:
         parser.error("--repeats must be at least 1")
 
+    # Validate the baseline before the (slow) benchmark run so a missing file
+    # fails fast with guidance instead of crashing after all the work.
+    if args.compare and not args.compare.exists():
+        parser.error(
+            f"baseline not found: {args.compare}\n"
+            "save one first on a clean tree: make benchmark-save"
+        )
+
     with tempfile.TemporaryDirectory(prefix="skillsaw-bench-") as tmp:
         if args.repo:
             repo_path = args.repo.resolve()

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -238,9 +238,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     # Validate the baseline before the (slow) benchmark run so a missing file
     # fails fast with guidance instead of crashing after all the work.
-    if args.compare and not args.compare.exists():
+    if args.compare and not args.compare.is_file():
         parser.error(
-            f"baseline not found: {args.compare}\n"
+            f"baseline file not found: {args.compare}\n"
             "save one first on a clean tree: make benchmark-save"
         )
 


### PR DESCRIPTION
## Problem

`make benchmark-compare` is broken when no local baseline exists (the common first-run case — `.benchmarks/baseline.json` is gitignored/local). `bench.py` reads the baseline with an unguarded `read_text()`, so it:

1. Runs the **entire** benchmark (generate repo + lint, ~a minute), then
2. Crashes with a raw traceback:

```
FileNotFoundError: [Errno 2] No such file or directory: '.benchmarks/baseline.json'
make: *** [benchmark-compare] Error 1
```

## Fix

Validate `--compare` right after arg parsing, **before** the slow run, and exit with guidance:

```
bench.py: error: baseline not found: .benchmarks/baseline.json
save one first on a clean tree: make benchmark-save
```

## Verification

- Missing baseline → fails **fast** (no benchmark run) with the message above.
- `benchmark-save` then `benchmark-compare` → works end-to-end ("No regressions detected"), confirming the compare logic itself was fine.

Note: `benchmarks/` isn't in the `make lint` target and the file predates black formatting; this change only adds a black-clean guard and leaves the pre-existing formatting untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The benchmark command now checks comparison files up front and stops immediately with a clear message if the baseline file is missing, avoiding wasted time on a run that would fail later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->