### PR TITLE
Fix skillsaw-pr-review cache restore key never matching

### DIFF
--- a/.github/workflows/skillsaw-pr-review.yml
+++ b/.github/workflows/skillsaw-pr-review.yml
@@ -24,7 +24,10 @@ jobs:
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: .last-pr-review-run
-          key: pr-review-last-run
+          # The save step below writes a per-run key, so an exact match never
+          # hits; restore the most recent entry via the shared prefix instead.
+          key: pr-review-last-run-${{ github.run_id }}
+          restore-keys: pr-review-last-run-
 
       - name: Get reviewable PRs and new activity
         id: activity


### PR DESCRIPTION
Addresses the CodeRabbit finding on #396.

## Problem

In `skillsaw-pr-review.yml` the cache save/restore keys were out of sync:

- **Save**: `key: pr-review-last-run-${{ github.run_id }}` (unique per run)
- **Restore**: `key: pr-review-last-run` (fixed)

`actions/cache/restore` does an exact match on `key` first, then falls back
to `restore-keys` prefixes. Since the exact key `pr-review-last-run` is never
written, the restore **always missed**. Result: `.last-pr-review-run` was
never present, so the job's `SINCE` logic fell back to the 7-day window on
every run — re-scanning a week of collaborator comments each 15-minute tick
instead of only new activity since the last run.

## Fix

Restore the most recent entry via the shared prefix, mirroring the
rolling-cache pattern gh-aw generates in `issue-triage.lock.yml`:

```yaml
key: pr-review-last-run-${{ github.run_id }}
restore-keys: pr-review-last-run-
```

The save step is unchanged. One-line-of-config fix; no behavior change beyond
the cache now actually being read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->