### PR TITLE
Add `skillsaw mcp`: agents lint their own context over MCP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install package and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          # The mcp extra is marker-gated to Python >= 3.10; on 3.9 it's a
+          # no-op and the MCP server tests skip.
+          pip install -e '.[mcp]'
           pip install pytest pytest-cov
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -196,6 +196,21 @@ repos:
 
 See the [Pre-commit guide](https://skillsaw.org/pre-commit/) for details.
 
+## MCP Server
+
+Agents can lint the context they're authoring over the
+[Model Context Protocol](https://modelcontextprotocol.io):
+
+```bash
+pip install 'skillsaw[mcp]'
+claude mcp add skillsaw -- skillsaw mcp
+```
+
+`skillsaw mcp` serves `lint`, `grade`, `fix`, `explain_rule`, and
+`list_rules` tools over stdio to any MCP client (Claude Code, Cursor, Codex
+CLI, Gemini CLI). See the [MCP Server guide](https://skillsaw.org/mcp-server/)
+for other clients and tool details.
+
 ## Quality Grade & Badge
 
 Every lint run computes a letter grade (A+ through F) summarizing

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,6 +100,10 @@ Grade the repository and write a shields.io badge JSON file
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
 | `-o`, `--output` | Badge JSON output path (default: .skillsaw-badge.json in the repository root) |  |
 
+## `skillsaw mcp`
+
+Run an MCP server exposing lint, grade, fix, and rule docs over stdio
+
 ## `skillsaw add`
 
 Scaffold marketplaces, plugins, skills, commands, agents, and hooks

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,86 @@
+# MCP Server
+
+`skillsaw mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io)
+server over stdio, so coding agents (Claude Code, Cursor, Codex CLI, Gemini
+CLI, ...) can lint, grade, and fix the skills, plugins, and instruction files
+they are authoring — without shelling out to the CLI.
+
+## Installation
+
+The MCP SDK is an optional extra (it requires Python 3.10+):
+
+```bash
+pip install 'skillsaw[mcp]'
+```
+
+Without the extra installed, `skillsaw mcp` prints an install hint and exits
+non-zero.
+
+## Connecting a client
+
+### Claude Code
+
+```bash
+claude mcp add skillsaw -- skillsaw mcp
+```
+
+Or without installing anything, via uvx:
+
+```bash
+claude mcp add skillsaw -- uvx --from 'skillsaw[mcp]' skillsaw mcp
+```
+
+### Cursor / Codex CLI / Gemini CLI
+
+Any MCP client that supports stdio servers works. The generic configuration
+is:
+
+```json
+{
+  "mcpServers": {
+    "skillsaw": {
+      "command": "skillsaw",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Tools
+
+All tools are deterministic and offline. Everything is read-only except
+`fix` with `dry_run=false`.
+
+| Tool | Arguments | Returns |
+|------|-----------|---------|
+| `lint` | `path`, optional `rules` (rule-id filter), optional `strict` | Violations (rule id, severity, message, file, line, docs URL), summary counts, letter grade, and a `passed` verdict. Respects `.skillsaw.yaml` and the baseline file, exactly like `skillsaw lint`. |
+| `grade` | `path` | Letter grade (A+ through F), weighted violation density, and estimated content token count — the same scale as the [badge](https://skillsaw.org/cli/#skillsaw-badge). Ignores any baseline. |
+| `explain_rule` | `rule_id` | The long-form markdown documentation `skillsaw explain` prints: what the rule checks, why, examples, and configuration options. Unknown ids error with close-match suggestions. |
+| `list_rules` | — | Every rule (builtin and installed plugins) with its one-line description, default severity, and autofix support. |
+| `fix` | `path`, `dry_run` (default `true`), `suggest` (default `false`) | Applies (or previews) skillsaw's deterministic autofixes and returns a per-file summary. `suggest=true` also applies suggest-confidence fixes, like `skillsaw fix --suggest`. |
+
+A typical agent loop: `lint` the directory being authored, `explain_rule`
+anything unclear, `fix` with the default dry run to preview, then `fix` with
+`dry_run=false` to apply, and `lint` again to confirm.
+
+## Security
+
+The server never executes content from the repository it lints:
+
+- Custom rules defined in the linted repository's `.skillsaw.yaml` are
+  **never loaded** (equivalent to `--no-custom-rules`).
+- No tool performs network access; results are computed locally from the
+  files on disk.
+- Only `fix` with `dry_run=false` writes to the repository, and it only
+  applies skillsaw's deterministic autofixes.
+
+Rule plugins installed as Python packages in skillsaw's own environment
+(`skillsaw.plugins` entry points) still load normally — they are part of
+your toolchain, not of the repository under lint.
+
+## Registry manifest
+
+The repository ships a [`server.json`](https://github.com/stbenjam/skillsaw/blob/main/server.json)
+manifest following the [MCP registry schema](https://github.com/modelcontextprotocol/registry),
+describing the server as the PyPI package `skillsaw` with the `mcp` extra,
+run via `uvx --from 'skillsaw[mcp]' skillsaw mcp`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
     - CI Integration: ci.md
     - Pre-commit: pre-commit.md
     - CLI Reference: cli.md
+    - MCP Server: mcp-server.md
     - Custom Rules: custom-rules.md
     - Rule Plugins: plugins.md
     - Scaffolding: scaffolding.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ docs = [
     "mkdocs-material>=9.0",
     "mkdocs-redirects>=1.2,<1.2.4",
 ]
+# The MCP SDK needs Python >= 3.10 (skillsaw's floor is 3.9); the marker
+# makes `pip install 'skillsaw[mcp]'` a no-op there and `skillsaw mcp`
+# prints an actionable error instead.
+mcp = [
+    "mcp>=1.10,<2; python_version >= '3.10'",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -45,6 +51,7 @@ dev = [
     "flake8>=6.0",
     "mypy>=1.0",
     "skillsaw-runbooks==0.1.0",
+    "mcp>=1.10,<2; python_version >= '3.10'",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,9 @@ black>=26,<27
 flake8>=6.0
 mypy>=1.0
 
+# MCP server (optional `skillsaw[mcp]` extra; tests exercise the real SDK)
+mcp>=1.10,<2; python_version >= "3.10"
+
 # Build
 build>=1.5.0
 twine>=6.2.0

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.stbenjam/skillsaw",
+  "description": "Lint, grade, and autofix agent skills, plugins, and AI coding assistant context files.",
+  "repository": {
+    "url": "https://github.com/stbenjam/skillsaw",
+    "source": "github"
+  },
+  "websiteUrl": "https://skillsaw.org",
+  "version": "0.16.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "skillsaw",
+      "version": "0.16.0",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "skillsaw[mcp]"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/src/skillsaw/cli/__init__.py
+++ b/src/skillsaw/cli/__init__.py
@@ -18,6 +18,7 @@ _SUBCOMMANDS = {
     "explain",
     "badge",
     "plugins",
+    "mcp",
 }
 
 
@@ -89,6 +90,10 @@ def main():
         from ._tree import _run_tree
 
         _run_tree(args)
+    elif args.command == "mcp":
+        from ._mcp import _run_mcp
+
+        _run_mcp(args)
 
 
 def claudelint_shim():

--- a/src/skillsaw/cli/_explain.py
+++ b/src/skillsaw/cli/_explain.py
@@ -11,8 +11,7 @@ from ._helpers import _ansi_colors
 
 
 def _run_explain(args):
-    from ..rules.builtin import BUILTIN_RULES
-    from ..rule_docs import load_rule_docs, rule_doc_url
+    from ..rule_docs import find_rule_class, load_rule_docs, rule_doc_url
 
     if not args.path.exists():
         print(f"Error: Path not found: {args.path}", file=sys.stderr)
@@ -21,32 +20,7 @@ def _run_explain(args):
         print(f"Error: Config file not found: {args.config}", file=sys.stderr)
         sys.exit(1)
 
-    rule_class = None
-    known_ids = []
-    for candidate in BUILTIN_RULES:
-        rule = candidate()
-        known_ids.append(rule.rule_id)
-        if rule.rule_id == args.rule_id:
-            rule_class = candidate
-            break
-
-    plugin_name = None
-    if rule_class is None:
-        from ..plugins import load_plugins
-
-        for plugin in load_plugins():
-            for candidate in plugin.rule_classes:
-                try:
-                    rule = candidate()
-                except Exception:
-                    continue
-                known_ids.append(rule.rule_id)
-                if rule.rule_id == args.rule_id:
-                    rule_class = candidate
-                    plugin_name = plugin.name
-                    break
-            if rule_class is not None:
-                break
+    rule_class, plugin_name, known_ids = find_rule_class(args.rule_id)
 
     if rule_class is None:
         print(f"Error: Unknown rule '{args.rule_id}'", file=sys.stderr)

--- a/src/skillsaw/cli/_mcp.py
+++ b/src/skillsaw/cli/_mcp.py
@@ -1,0 +1,30 @@
+"""Handler for the ``skillsaw mcp`` subcommand."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+
+def _run_mcp(args):
+    # The MCP SDK is an optional extra (and needs Python >= 3.10, above
+    # skillsaw's own floor) — fail with an actionable hint, not a traceback.
+    if importlib.util.find_spec("mcp") is None:
+        print(
+            "Error: `skillsaw mcp` requires the optional 'mcp' dependency,"
+            " which is not installed.",
+            file=sys.stderr,
+        )
+        if sys.version_info < (3, 10):
+            print(
+                "The MCP SDK requires Python 3.10 or newer (you are running"
+                f" {sys.version_info.major}.{sys.version_info.minor}).",
+                file=sys.stderr,
+            )
+        else:
+            print("Install it with: pip install 'skillsaw[mcp]'", file=sys.stderr)
+        sys.exit(1)
+
+    from ..mcp_server import create_server
+
+    create_server().run(transport="stdio")

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -378,6 +378,17 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Badge JSON output path (default: .skillsaw-badge.json in the repository root)",
     )
 
+    # --- mcp ---
+    subparsers.add_parser(
+        "mcp",
+        help="Run an MCP server exposing lint, grade, fix, and rule docs over stdio",
+        description="Serve skillsaw over the Model Context Protocol (stdio "
+        "transport) so coding agents can lint, grade, and fix the context "
+        "files they are authoring. Exposes lint, grade, fix, explain_rule, "
+        "and list_rules tools. Requires the optional 'mcp' dependency: "
+        "pip install 'skillsaw[mcp]'.",
+    )
+
     # --- add ---
     subparsers.add_parser(
         "add",

--- a/src/skillsaw/mcp_server.py
+++ b/src/skillsaw/mcp_server.py
@@ -1,0 +1,375 @@
+"""
+MCP server exposing skillsaw's core capabilities over the Model Context
+Protocol (stdio transport).
+
+Coding agents (Claude Code, Cursor, Codex CLI, Gemini CLI, ...) connect to
+``skillsaw mcp`` to lint, grade, and fix the skills and instruction files
+they are authoring without shelling out.
+
+Every tool is deterministic and offline. All tools are read-only except
+``fix`` with ``dry_run=false``, which writes skillsaw's deterministic
+autofixes. Custom rules defined in the linted repository's
+``.skillsaw.yaml`` are never executed (equivalent to ``--no-custom-rules``),
+so the server never runs code from the repository under lint.
+
+This module requires the optional ``mcp`` dependency
+(``pip install 'skillsaw[mcp]'``); ``skillsaw.cli._mcp`` guards the import
+and prints an install hint when it is missing.
+"""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from .config import LinterConfig, find_config
+from .context import RepositoryContext
+from .formatters import get_counts, relative_path
+from .grade import compute_grade
+from .linter import Linter
+from .rule import AutofixConfidence
+from .rule_docs import find_rule_class, load_rule_docs, rule_doc_url
+
+_INSTRUCTIONS = (
+    "Lint, grade, and autofix agent context files — Claude Code plugins and "
+    "marketplaces, SKILL.md skills, commands, agents, hooks, and instruction "
+    "files like CLAUDE.md / AGENTS.md — with skillsaw. Point the tools at the "
+    "repository or directory you are authoring. Start with `lint`; use "
+    "`explain_rule` to understand a violation, and `fix` (dry_run first) to "
+    "apply deterministic autofixes."
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared internals
+# ---------------------------------------------------------------------------
+
+
+def _resolve_root(path: str) -> Path:
+    """Normalize a tool's ``path`` argument to an existing directory."""
+    root = Path(path).expanduser()
+    if not root.exists():
+        raise ValueError(f"Path not found: {path}")
+    root = root.resolve()
+    if root.is_file():
+        root = root.parent
+    return root
+
+
+def _load_config(root: Path) -> LinterConfig:
+    """Auto-discover and load .skillsaw.yaml (builtin defaults otherwise)."""
+    config_path = find_config(root)
+    if config_path is None:
+        return LinterConfig.default()
+    # Invalid config raises ValueError, which surfaces as a tool error.
+    return LinterConfig.from_file(config_path)
+
+
+def _build_linter(root: Path, config: LinterConfig, rule_ids=None, baseline=None):
+    """RepositoryContext + Linter, mirroring the CLI's construction.
+
+    ``no_custom_rules=True`` always: custom rules are arbitrary Python
+    loaded from the linted repository, and the server must never execute
+    repository content.
+    """
+    context = RepositoryContext(
+        root,
+        exclude_patterns=config.exclude_patterns,
+        content_paths=config.content_paths,
+    )
+    linter = Linter(
+        context,
+        config,
+        rule_ids=set(rule_ids) if rule_ids else None,
+        baseline=baseline,
+        no_custom_rules=True,
+    )
+    return context, linter
+
+
+def _grade_for(context: RepositoryContext, violations) -> Any:
+    tokens = sum(b.estimate_tokens() for b in context.lint_tree.content_blocks())
+    return compute_grade(violations, tokens)
+
+
+def _violation_dict(violation, root: Path) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "rule_id": violation.rule_id,
+        "severity": violation.severity.value,
+        "message": violation.message,
+        "file": relative_path(violation.file_path, root),
+        "line": violation.file_line,
+        "source": violation.source,
+    }
+    if violation.source == "builtin":
+        result["docs"] = rule_doc_url(violation.rule_id)
+    return result
+
+
+def explain_rule_markdown(rule_id: str) -> str:
+    """Long-form markdown for one rule — same content ``skillsaw explain``
+    prints, without the terminal colors or per-repository effective config.
+
+    Raises ValueError (with close-match suggestions) for unknown rules.
+    """
+    rule_class, plugin_name, known_ids = find_rule_class(rule_id)
+    if rule_class is None:
+        close = difflib.get_close_matches(rule_id, known_ids, n=3)
+        hint = f" Did you mean: {', '.join(close)}?" if close else ""
+        raise ValueError(
+            f"Unknown rule '{rule_id}'.{hint} Use the list_rules tool to see all rules."
+        )
+
+    defaults = LinterConfig.default()
+    rule = rule_class(defaults.get_rule_config(rule_id))
+    default_enabled = defaults.get_rule_config(rule_id).get("enabled", True)
+    autofix_label = "auto" if rule.supports_autofix else "none"
+
+    meta = f"severity: {rule.severity.value}, autofix: {autofix_label}, since {rule.since}"
+    if plugin_name:
+        meta += f", plugin: {plugin_name}"
+
+    lines = [f"# {rule_id}", "", f"({meta})", "", rule.description]
+
+    long_docs = load_rule_docs(rule_id)
+    if long_docs:
+        lines += ["", long_docs]
+
+    if rule.repo_types:
+        # repo_types may mix RepositoryType members with plugin type names.
+        repo_types_str = ", ".join(sorted(getattr(t, "value", t) for t in rule.repo_types))
+        lines += ["", f"**Applies to repo types:** {repo_types_str}"]
+
+    lines += [
+        "",
+        "## Configuration (.skillsaw.yaml)",
+        "",
+        "```yaml",
+        "rules:",
+        f"  {rule_id}:",
+        f"    enabled: {LinterConfig._yaml_value(default_enabled)}  # true | false | auto",
+        f"    severity: {rule.severity.value}  # error | warning | info",
+    ]
+    for param_name, param_info in rule.config_schema.items():
+        default_val = LinterConfig._yaml_value(param_info.get("default"), indent=6)
+        desc = param_info.get("description", "")
+        if default_val.startswith("\n"):
+            lines.append(f"    {param_name}:  # {desc}{default_val}")
+        else:
+            lines.append(f"    {param_name}: {default_val}  # {desc}")
+    lines.append("```")
+
+    if plugin_name is None:
+        # Plugin rules have no page on the skillsaw documentation site.
+        lines += ["", f"Docs: {rule_doc_url(rule_id)}"]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+def create_server() -> FastMCP:
+    """Build the skillsaw MCP server with all tools registered."""
+    # FastMCP's default INFO logging echoes every rule decision to stderr;
+    # WARNING keeps the transport chatter out of agent logs.
+    server = FastMCP("skillsaw", instructions=_INSTRUCTIONS, log_level="WARNING")
+
+    _read_only = ToolAnnotations(readOnlyHint=True, idempotentHint=True)
+
+    @server.tool(annotations=_read_only)
+    def lint(
+        path: str,
+        rules: Optional[List[str]] = None,
+        strict: bool = False,
+    ) -> Dict[str, Any]:
+        """Lint a repository of agent context files (skills, plugins,
+        CLAUDE.md/AGENTS.md, commands, agents, hooks, marketplaces).
+
+        Args:
+            path: Repository or directory to lint (a file path lints its
+                containing directory).
+            rules: Optional rule ids to run exclusively (default: all
+                enabled rules).
+            strict: Treat warnings as failures, like ``skillsaw lint
+                --strict``.
+
+        Returns violations (rule_id, severity, message, file, line, docs
+        URL), summary counts, the repository's letter grade, and a
+        ``passed`` verdict. Respects the repository's ``.skillsaw.yaml``
+        and baseline file, exactly like ``skillsaw lint``.
+        """
+        root = _resolve_root(path)
+        config = _load_config(root)
+
+        baseline = None
+        from .baseline import find_baseline, load_baseline
+
+        baseline_path = find_baseline(config.config_dir or root)
+        if baseline_path:
+            try:
+                baseline = load_baseline(baseline_path)
+            except (ValueError, OSError):
+                baseline = None
+
+        context, linter = _build_linter(root, config, rule_ids=rules, baseline=baseline)
+        violations = linter.run()
+        grade = _grade_for(context, violations)
+
+        errors, warnings, info = get_counts(violations)
+        fail_level = "warning" if strict else config.effective_fail_level()
+        failed = (
+            errors > 0
+            or (fail_level in ("warning", "info") and warnings > 0)
+            or (fail_level == "info" and info > 0)
+        )
+
+        return {
+            "path": str(root),
+            "passed": not failed,
+            "violations": [_violation_dict(v, root) for v in violations],
+            "summary": {
+                "errors": errors,
+                "warnings": warnings,
+                "info": info,
+                "total": len(violations),
+                "baseline_suppressed": linter.baseline_suppressed_count,
+            },
+            "grade": grade.to_dict(),
+        }
+
+    @server.tool(annotations=_read_only)
+    def grade(path: str) -> Dict[str, Any]:
+        """Grade a repository's agent-context quality (A+ through F).
+
+        Same scale as the skillsaw badge: weighted violation density per
+        10,000 estimated content tokens sets the letter, and errors knock
+        off whole letters. Ignores any baseline so the grade reflects all
+        violations.
+        """
+        root = _resolve_root(path)
+        config = _load_config(root)
+        context, linter = _build_linter(root, config)
+        violations = linter.run()
+        result = _grade_for(context, violations)
+        return {
+            "path": str(root),
+            "letter": result.letter,
+            "density": round(result.density, 2),
+            "content_tokens": result.content_tokens,
+            "errors": result.errors,
+            "warnings": result.warnings,
+            "info": result.info,
+        }
+
+    @server.tool(annotations=_read_only)
+    def explain_rule(rule_id: str) -> str:
+        """Explain a lint rule: what it checks, why it exists, bad/good
+        examples, and its configuration options — the same long-form
+        documentation ``skillsaw explain`` prints. Errors for unknown rule
+        ids, with close-match suggestions.
+        """
+        return explain_rule_markdown(rule_id)
+
+    @server.tool(annotations=_read_only)
+    def list_rules() -> Dict[str, Any]:
+        """List every available lint rule (builtin and installed plugins)
+        with its one-line description, default severity, and whether it
+        supports autofix.
+        """
+        from .plugins import load_plugins
+        from .rules.builtin import BUILTIN_RULES
+
+        entries = []
+        for rule_class in BUILTIN_RULES:
+            rule = rule_class()
+            entries.append(
+                {
+                    "rule_id": rule.rule_id,
+                    "description": rule.description,
+                    "default_severity": rule.default_severity().value,
+                    "autofix": rule.supports_autofix,
+                    "docs": rule_doc_url(rule.rule_id),
+                }
+            )
+        for plugin in load_plugins():
+            if plugin.error:
+                continue
+            for rule_class in plugin.rule_classes:
+                try:
+                    rule = rule_class()
+                except Exception:
+                    continue
+                entries.append(
+                    {
+                        "rule_id": rule.rule_id,
+                        "description": rule.description,
+                        "default_severity": rule.default_severity().value,
+                        "autofix": rule.supports_autofix,
+                        "plugin": plugin.name,
+                    }
+                )
+        return {"rules": entries, "count": len(entries)}
+
+    @server.tool(
+        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True)
+    )
+    def fix(path: str, dry_run: bool = True, suggest: bool = False) -> Dict[str, Any]:
+        """Apply (or preview) skillsaw's deterministic autofixes.
+
+        Args:
+            path: Repository or directory to fix.
+            dry_run: Preview only — report what would change without
+                modifying any file (default: true).
+            suggest: Also apply suggest-confidence fixes, not just safe
+                ones (like ``skillsaw fix --suggest``).
+
+        Returns the fixes applied (or previewed), fixes that need
+        ``suggest=true``, and a per-file summary.
+        """
+        root = _resolve_root(path)
+        config = _load_config(root)
+        confidence = AutofixConfidence.SUGGEST if suggest else AutofixConfidence.SAFE
+
+        context, linter = _build_linter(root, config)
+        applied, suggested = linter.fix_and_apply(confidence, dry_run=dry_run)
+
+        # A skill-directory rename changes discovery, unlocking fixes a
+        # single pass can't see — same follow-up run `skillsaw fix` does.
+        if not dry_run and any(f.rule_id == "agentskill-name" for f in applied):
+            context, linter = _build_linter(root, config)
+            more_applied, more_suggested = linter.fix_and_apply(confidence)
+            applied.extend(more_applied)
+            suggested.extend(more_suggested)
+
+        def _fix_dict(fix_result):
+            return {
+                "file": relative_path(fix_result.file_path, root),
+                "rule_id": fix_result.rule_id,
+                "description": fix_result.description,
+            }
+
+        per_file: Dict[str, int] = {}
+        for fix_result in applied:
+            key = relative_path(fix_result.file_path, root)
+            per_file[key] = per_file.get(key, 0) + 1
+
+        return {
+            "path": str(root),
+            "dry_run": dry_run,
+            "fixes": [_fix_dict(f) for f in applied],
+            "suggested": [_fix_dict(f) for f in suggested],
+            "summary": {
+                "fixed": len(applied),
+                "suggested": len(suggested),
+                "files": per_file,
+            },
+        }
+
+    return server

--- a/src/skillsaw/mcp_server.py
+++ b/src/skillsaw/mcp_server.py
@@ -342,9 +342,10 @@ def create_server() -> FastMCP:
 
         # A skill-directory rename changes discovery, unlocking fixes a
         # single pass can't see — same follow-up run `skillsaw fix` does.
+        # This branch only runs for real fix runs, so apply for real too.
         if not dry_run and any(f.rule_id == "agentskill-name" for f in applied):
             context, linter = _build_linter(root, config)
-            more_applied, more_suggested = linter.fix_and_apply(confidence)
+            more_applied, more_suggested = linter.fix_and_apply(confidence, dry_run=False)
             applied.extend(more_applied)
             suggested.extend(more_suggested)
 

--- a/src/skillsaw/rule_docs.py
+++ b/src/skillsaw/rule_docs.py
@@ -10,7 +10,7 @@ package data under ``skillsaw/rules/docs/<rule-id>.md`` so that
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Tuple
 
 DOCS_BASE_URL = "https://skillsaw.org/rules/"
 
@@ -32,3 +32,37 @@ def load_rule_docs(rule_id: str) -> Optional[str]:
     if not doc_path.is_file():
         return None
     return doc_path.read_text(encoding="utf-8").strip()
+
+
+def find_rule_class(rule_id: str) -> Tuple[Optional[type], Optional[str], List[str]]:
+    """Locate a rule class by id across builtin rules and installed plugins.
+
+    Shared by ``skillsaw explain`` and the MCP server's ``explain_rule``
+    tool. Returns ``(rule_class, plugin_name, known_ids)``: *rule_class* is
+    ``None`` when the id is unknown, *plugin_name* is ``None`` for builtin
+    rules, and *known_ids* lists every rule id seen (for suggestions).
+    """
+    # Late imports: rules.builtin walks every rule module and plugins hit
+    # entry points — neither belongs at import time of this small helper.
+    from .rules.builtin import BUILTIN_RULES
+
+    known_ids: List[str] = []
+    for candidate in BUILTIN_RULES:
+        rule = candidate()
+        known_ids.append(rule.rule_id)
+        if rule.rule_id == rule_id:
+            return candidate, None, known_ids
+
+    from .plugins import load_plugins
+
+    for plugin in load_plugins():
+        for candidate in plugin.rule_classes:
+            try:
+                rule = candidate()
+            except Exception:
+                continue
+            known_ids.append(rule.rule_id)
+            if rule.rule_id == rule_id:
+                return candidate, plugin.name, known_ids
+
+    return None, None, known_ids

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,313 @@
+"""
+Tests for the ``skillsaw mcp`` MCP server.
+
+Tool tests use the mcp SDK's in-memory client/server session, so every
+tool is exercised end-to-end (schema generation, argument validation,
+JSON serialization) against static fixtures without spawning a
+subprocess. They skip cleanly when the optional ``mcp`` dependency is
+unavailable (it requires Python >= 3.10; skillsaw's floor is 3.9).
+
+The CLI gate tests (missing-dependency error path) run everywhere — they
+must not require the SDK.
+"""
+
+import asyncio
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+HAS_MCP = sys.version_info >= (3, 10) and importlib.util.find_spec("mcp") is not None
+
+needs_mcp = pytest.mark.skipif(
+    not HAS_MCP,
+    reason="mcp SDK not installed (requires Python >= 3.10 and `pip install 'skillsaw[mcp]'`)",
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def copy_fixture(name, tmp_path):
+    src = FIXTURES / name
+    dst = tmp_path / name.replace("/", "_")
+    shutil.copytree(src, dst)
+    return dst
+
+
+def call_tool(name, arguments):
+    """Call one tool against an in-memory server and return the raw result."""
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    from skillsaw.mcp_server import create_server
+
+    async def _run():
+        server = create_server()
+        async with create_connected_server_and_client_session(server._mcp_server) as session:
+            return await session.call_tool(name, arguments)
+
+    return asyncio.run(_run())
+
+
+def payload(result):
+    """Parse a successful tool result's JSON payload."""
+    assert not result.isError, f"tool errored: {result.content}"
+    return json.loads(result.content[0].text)
+
+
+def snapshot_files(root):
+    """Map of relative path -> bytes for every file under *root*."""
+    return {p.relative_to(root): p.read_bytes() for p in sorted(root.rglob("*")) if p.is_file()}
+
+
+# ── Server surface ───────────────────────────────────────────────
+
+
+@needs_mcp
+def test_all_tools_registered():
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    from skillsaw.mcp_server import create_server
+
+    async def _run():
+        server = create_server()
+        async with create_connected_server_and_client_session(server._mcp_server) as session:
+            return await session.list_tools()
+
+    listed = asyncio.run(_run())
+    names = {tool.name for tool in listed.tools}
+    assert names == {"lint", "grade", "explain_rule", "list_rules", "fix"}
+    for tool in listed.tools:
+        assert tool.description, f"tool {tool.name} has no description"
+
+
+# ── lint ─────────────────────────────────────────────────────────
+
+
+@needs_mcp
+class TestLintTool:
+    def test_reports_violations_for_bad_fixture(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        data = payload(call_tool("lint", {"path": str(repo)}))
+
+        assert data["violations"], "expected violations in the broken fixture"
+        for violation in data["violations"]:
+            assert violation["rule_id"]
+            assert violation["severity"] in ("error", "warning", "info")
+            assert violation["message"]
+        builtin = [v for v in data["violations"] if v["source"] == "builtin"]
+        assert builtin, "expected builtin violations"
+        for violation in builtin:
+            assert violation["docs"] == f"https://skillsaw.org/rules/{violation['rule_id']}/"
+
+        summary = data["summary"]
+        assert summary["total"] == len(data["violations"])
+        assert summary["errors"] == sum(1 for v in data["violations"] if v["severity"] == "error")
+        # The broken fixture has errors, so the lint fails.
+        assert summary["errors"] > 0
+        assert data["passed"] is False
+
+        from skillsaw.grade import LETTER_NOTCHES
+
+        assert data["grade"]["letter"] in LETTER_NOTCHES
+
+    def test_line_numbers_reported(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        data = payload(call_tool("lint", {"path": str(repo)}))
+        with_lines = [v for v in data["violations"] if v["line"] is not None]
+        assert with_lines, "expected line numbers on line-traceable violations"
+        assert all(v["line"] >= 1 for v in with_lines)
+
+    def test_rules_filter_limits_rules(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        data = payload(call_tool("lint", {"path": str(repo), "rules": ["content-weak-language"]}))
+        assert data["violations"], "filtered rule should still fire on the fixture"
+        assert {v["rule_id"] for v in data["violations"]} == {"content-weak-language"}
+
+    def test_strict_fails_on_warnings(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        args = {"path": str(repo), "rules": ["content-weak-language"]}
+
+        relaxed = payload(call_tool("lint", args))
+        assert relaxed["summary"]["errors"] == 0
+        assert relaxed["summary"]["warnings"] > 0
+        assert relaxed["passed"] is True
+
+        strict = payload(call_tool("lint", {**args, "strict": True}))
+        assert strict["passed"] is False
+
+    def test_unknown_rule_errors(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        result = call_tool("lint", {"path": str(repo), "rules": ["not-a-rule"]})
+        assert result.isError
+        assert "Unknown rule" in result.content[0].text
+
+    def test_missing_path_errors(self, tmp_path):
+        result = call_tool("lint", {"path": str(tmp_path / "does-not-exist")})
+        assert result.isError
+        assert "not found" in result.content[0].text.lower()
+
+
+# ── grade ────────────────────────────────────────────────────────
+
+
+@needs_mcp
+class TestGradeTool:
+    def test_returns_letter_density_and_tokens(self, tmp_path):
+        repo = copy_fixture("agentskills/broken", tmp_path)
+        data = payload(call_tool("grade", {"path": str(repo)}))
+
+        from skillsaw.grade import LETTER_NOTCHES
+
+        assert data["letter"] in LETTER_NOTCHES
+        assert data["density"] >= 0
+        assert data["content_tokens"] > 0
+        assert data["errors"] + data["warnings"] + data["info"] > 0
+
+    def test_clean_fixture_grades_better_than_broken(self, tmp_path):
+        from skillsaw.grade import LETTER_NOTCHES
+
+        broken = copy_fixture("agentskills/broken", tmp_path)
+        clean = copy_fixture("agentskills/clean", tmp_path)
+        broken_grade = payload(call_tool("grade", {"path": str(broken)}))
+        clean_grade = payload(call_tool("grade", {"path": str(clean)}))
+        assert LETTER_NOTCHES.index(clean_grade["letter"]) < LETTER_NOTCHES.index(
+            broken_grade["letter"]
+        )
+
+
+# ── explain_rule ─────────────────────────────────────────────────
+
+
+@needs_mcp
+class TestExplainRuleTool:
+    def test_known_rule_returns_long_form_markdown(self):
+        result = call_tool("explain_rule", {"rule_id": "content-weak-language"})
+        assert not result.isError
+        text = result.content[0].text
+
+        assert "content-weak-language" in text
+        assert "## Configuration (.skillsaw.yaml)" in text
+        assert "https://skillsaw.org/rules/content-weak-language/" in text
+
+        # The same long-form docs `skillsaw explain` prints.
+        from skillsaw.rule_docs import load_rule_docs
+
+        long_docs = load_rule_docs("content-weak-language")
+        assert long_docs, "fixture rule should have long-form docs"
+        assert long_docs.splitlines()[0] in text
+
+    def test_unknown_rule_errors_with_suggestion(self):
+        result = call_tool("explain_rule", {"rule_id": "content-weak-languge"})
+        assert result.isError
+        text = result.content[0].text
+        assert "Unknown rule 'content-weak-languge'" in text
+        assert "content-weak-language" in text  # close-match suggestion
+
+
+# ── list_rules ───────────────────────────────────────────────────
+
+
+@needs_mcp
+class TestListRulesTool:
+    def test_lists_builtin_rules_with_metadata(self):
+        data = payload(call_tool("list_rules", {}))
+        assert data["count"] == len(data["rules"])
+
+        by_id = {entry["rule_id"]: entry for entry in data["rules"]}
+        assert "agentskill-name" in by_id
+        assert "content-weak-language" in by_id
+        for entry in data["rules"]:
+            assert entry["description"]
+            assert entry["default_severity"] in ("error", "warning", "info")
+            assert isinstance(entry["autofix"], bool)
+
+        from skillsaw.rules.builtin import BUILTIN_RULES
+
+        assert data["count"] >= len(BUILTIN_RULES)
+
+
+# ── fix ──────────────────────────────────────────────────────────
+
+
+@needs_mcp
+class TestFixTool:
+    def test_dry_run_is_default_and_modifies_nothing(self, tmp_path):
+        repo = copy_fixture("autofix/safe-idempotency", tmp_path)
+        before = snapshot_files(repo)
+
+        data = payload(call_tool("fix", {"path": str(repo)}))
+
+        assert data["dry_run"] is True
+        assert data["fixes"], "fixture should have safe autofixable violations"
+        assert data["summary"]["fixed"] == len(data["fixes"])
+        assert data["summary"]["files"], "expected a per-file summary"
+        assert snapshot_files(repo) == before, "dry_run must not modify files"
+
+    def test_apply_writes_fixes_and_is_idempotent(self, tmp_path):
+        repo = copy_fixture("autofix/safe-idempotency", tmp_path)
+        before = snapshot_files(repo)
+
+        data = payload(call_tool("fix", {"path": str(repo), "dry_run": False}))
+        assert data["dry_run"] is False
+        assert data["fixes"]
+        after_first = snapshot_files(repo)
+        assert after_first != before
+
+        # Second run finds nothing left to fix and changes nothing.
+        again = payload(call_tool("fix", {"path": str(repo), "dry_run": False}))
+        assert again["fixes"] == []
+        assert snapshot_files(repo) == after_first
+
+
+# ── CLI gate (`skillsaw mcp` without the SDK) ────────────────────
+
+
+class TestCliGate:
+    def test_missing_mcp_dependency_exits_with_install_hint(self, monkeypatch, capsys):
+        import argparse
+        import importlib.util as importlib_util
+
+        from skillsaw.cli import _mcp
+
+        real_find_spec = importlib_util.find_spec
+        monkeypatch.setattr(
+            importlib_util,
+            "find_spec",
+            lambda name, *args, **kwargs: (
+                None if name == "mcp" else real_find_spec(name, *args, **kwargs)
+            ),
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            _mcp._run_mcp(argparse.Namespace(command="mcp"))
+
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "'mcp'" in err
+        if sys.version_info >= (3, 10):
+            assert "pip install 'skillsaw[mcp]'" in err
+        else:
+            assert "Python 3.10" in err
+
+
+# ── stdio integration ────────────────────────────────────────────
+
+
+@needs_mcp
+@pytest.mark.integration
+def test_stdio_server_starts_and_exits_cleanly_on_eof():
+    result = subprocess.run(
+        [sys.executable, "-m", "skillsaw", "mcp"],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -253,12 +253,18 @@ class TestFixTool:
     def test_apply_writes_fixes_and_is_idempotent(self, tmp_path):
         repo = copy_fixture("autofix/safe-idempotency", tmp_path)
         before = snapshot_files(repo)
+        lint_before = payload(call_tool("lint", {"path": str(repo)}))
 
         data = payload(call_tool("fix", {"path": str(repo), "dry_run": False}))
         assert data["dry_run"] is False
         assert data["fixes"]
         after_first = snapshot_files(repo)
         assert after_first != before
+
+        # Independent re-lint confirms the fixes resolved violations (some
+        # rules keep unfixable instances, so the count drops, not zeroes).
+        lint_after = payload(call_tool("lint", {"path": str(repo)}))
+        assert lint_after["summary"]["total"] < lint_before["summary"]["total"]
 
         # Second run finds nothing left to fix and changes nothing.
         again = payload(call_tool("fix", {"path": str(repo), "dry_run": False}))


### PR DESCRIPTION
## What

A new `skillsaw mcp` subcommand that serves skillsaw's core capabilities over the [Model Context Protocol](https://modelcontextprotocol.io) (stdio transport) using the official `mcp` Python SDK, so coding agents — Claude Code, Cursor, Codex CLI, Gemini CLI — can lint, grade, and fix the skills and instruction files they are authoring **without shelling out**:

```bash
pip install 'skillsaw[mcp]'
claude mcp add skillsaw -- skillsaw mcp
```

Five tools, all deterministic and offline:

| Tool | Returns |
|------|---------|
| `lint` (`path`, optional `rules` filter, optional `strict`) | violations (rule_id, severity, message, file, line, per-rule docs URL), summary counts, letter grade, `passed` verdict — respects `.skillsaw.yaml` and the baseline, exactly like `skillsaw lint` |
| `grade` (`path`) | letter grade + weighted density + content token count (reuses `skillsaw.grade`, badge semantics: ignores baseline) |
| `explain_rule` (`rule_id`) | the same long-form markdown `skillsaw explain` prints; unknown ids error with close-match suggestions |
| `list_rules` | every builtin + plugin rule with one-line description, default severity, autofix support |
| `fix` (`path`, `dry_run` default **true**, `suggest`) | applies/previews deterministic autofixes via the existing `Linter.fix_and_apply` machinery, returns per-file summary |

Also ships a `server.json` MCP registry manifest at the repo root (validates against the 2025-12-11 registry schema; `uvx --from 'skillsaw[mcp]' skillsaw mcp`).

## Why

Agents already author most of the content skillsaw lints. Today they must shell out and parse CLI text/JSON; an MCP server gives them typed tools with structured results, tool descriptions that teach the workflow (`lint` → `explain_rule` → `fix` dry-run → `fix`), and one-line registration in every major agent harness. It's the shortest path to "the agent lints its own context before committing it."

## How it works

- **Thin CLI, reusable core**: `cli/_mcp.py` only guards the optional import and calls `mcp_server.create_server().run(transport="stdio")`. `src/skillsaw/mcp_server.py` builds a `FastMCP` server whose tools reuse the CLI's internals — `RepositoryContext` + `Linter` construction mirrors `_lint.py`/`_fix.py` (config auto-discovery, baseline handling, `compute_grade` over content-block tokens).
- **Optional dependency, marker-gated**: `pip install 'skillsaw[mcp]'`. The `mcp` SDK requires Python ≥ 3.10 while skillsaw's floor stays 3.9, so the extra carries a `python_version >= '3.10'` environment marker. `skillsaw mcp` without the SDK prints an install hint (or the Python-version explanation on 3.9) and exits 1 — never a traceback.
- **Never executes repo content**: every linter the server builds passes `no_custom_rules=True`, so custom rules from the *linted* repository's `.skillsaw.yaml` are never loaded; no tool performs network access; only `fix` with `dry_run=false` writes.
- **Minimal shared-helper refactor**: the rule-lookup loop duplicated between `skillsaw explain` and the new `explain_rule` tool moved to `rule_docs.find_rule_class()`; `_explain.py` now uses it (behavior unchanged).
- **Read-only tool annotations** (`readOnlyHint`/`idempotentHint`) on everything except `fix`, and FastMCP logging pinned to WARNING so agent logs aren't flooded with per-rule chatter.
- CI's test job installs `-e '.[mcp]'` (a no-op on 3.9, where the MCP tests skip) so the matrix exercises the real SDK on 3.10–3.14; `mcp` is also in `requirements-dev.txt` and the `dev` extra so `make test` covers it locally.

## Tests

`tests/test_mcp_server.py` — 16 tests using the mcp SDK's **in-memory client/server session** (no subprocess for tool calls) against existing static fixtures:

- `lint` returns violations/summary/grade/docs-URLs for `agentskills/broken`; line numbers ≥ 1; `rules` filter narrows to one rule; unknown rule ids and missing paths error; `strict` flips `passed` on a warnings-only run
- `grade` returns a valid letter + density + tokens; clean fixture outgrades broken
- `explain_rule` returns the long-form markdown (asserted against `load_rule_docs`) and errors with a close-match suggestion for a typo'd id
- `list_rules` covers builtin rules with description/severity/autofix
- `fix` with `dry_run=true` (the default) modifies **nothing** (full byte-level file snapshot compare on `autofix/safe-idempotency`); `dry_run=false` applies and is idempotent on a second run
- the no-mcp-installed error path: monkeypatched `find_spec` import failure → exit 1 + `pip install 'skillsaw[mcp]'` hint (this test runs even where the SDK is absent)
- stdio integration: `python -m skillsaw mcp` with closed stdin exits 0

## Validation

- `make test`: 2482 passed
- `make lint`: clean
- `make update`: regenerated `docs/cli.md` (new subcommand picked up from the parser), self-lint exit 0, grade A
- `server.json` validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema`
- `openshift-eng/ai-helpers`: `skillsaw lint` exit 0; MCP `grade` tool on the same clone returns `{"letter": "A", "density": 1.02, "content_tokens": 441326}` and `lint` returns `passed: true` with 452 info violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `skillsaw mcp` command that runs an MCP server over stdio.
  * Exposed tools for linting, grading, fixing, explaining rules, and listing rules.

* **Documentation**
  * Added setup and usage docs for the MCP server in the README and developer docs.
  * Updated site navigation to include the new MCP Server guide.

* **Tests**
  * Added end-to-end coverage for MCP tool behavior, CLI startup, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->