### PR TITLE
Enable subprocess coverage: CLI layer was reporting 0% despite 209 integration tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,6 +22,16 @@ make test         # full suite with coverage
 
 Tests run against Python 3.9–3.14 in CI. Locally, your active Python version is used.
 
+Most of `tests/test_integration.py` drives the CLI out-of-process via
+`subprocess.run([sys.executable, "-m", "skillsaw", ...])`. pytest-cov 7
+dropped automatic subprocess instrumentation, so without help
+`src/skillsaw/cli/` would report ~0% coverage despite being thoroughly
+exercised. `pyproject.toml` sets `[tool.coverage.run] patch =
+["subprocess"]` (requires coverage>=7.10) to have coverage.py patch the
+`subprocess` module so child interpreters get instrumented automatically —
+no `COVERAGE_PROCESS_START`/`sitecustomize.py` setup needed. This adds
+roughly 25 seconds to `make test`.
+
 ## Formatting and linting
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint: $(VENV)/bin/activate
 	$(VENV)/bin/black --check src/ tests/
 
 test: $(VENV)/bin/activate
-	$(VENV)/bin/pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
+	$(VENV)/bin/pytest tests/ -v --cov=src/skillsaw --cov-report=xml --cov-report=term
 
 # Generate example config in a temp dir to avoid clobbering .skillsaw.yaml
 generate-example: $(VENV)/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ docs = [
 ]
 dev = [
     "pytest>=7.0",
-    "pytest-cov>=4.0",
-    "coverage>=7.10",  # needed for [tool.coverage.run] patch = ["subprocess"]
+    "pytest-cov>=7.0",
+    "coverage[toml]>=7.10",  # needed for [tool.coverage.run] patch = ["subprocess"]
     "black>=26,<27",
     "flake8>=6.0",
     "mypy>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ docs = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "coverage>=7.10",  # needed for [tool.coverage.run] patch = ["subprocess"]
     "black>=26,<27",
     "flake8>=6.0",
     "mypy>=1.0",
@@ -77,6 +78,16 @@ addopts = "-v"
 markers = [
     "integration: end-to-end CLI integration tests",
 ]
+
+[tool.coverage.run]
+# tests/test_integration.py drives the CLI via subprocess.run([sys.executable,
+# "-m", "skillsaw", ...]). pytest-cov 7 dropped automatic subprocess
+# instrumentation, so without this the entire src/skillsaw/cli/ package
+# reports ~0% despite being exercised by 200+ integration tests. `patch =
+# ["subprocess"]` (coverage.py >=7.10) makes coverage inject itself into
+# subprocesses started via the subprocess module, no COVERAGE_PROCESS_START
+# env var or sitecustomize.py needed.
+patch = ["subprocess"]
 
 [tool.black]
 line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@
 
 # Testing
 pytest>=7.0
-pytest-cov>=4.0
-coverage>=7.10  # needed for [tool.coverage.run] patch = ["subprocess"] in pyproject.toml
+pytest-cov>=7.0
+coverage[toml]>=7.10  # needed for [tool.coverage.run] patch = ["subprocess"] in pyproject.toml
 
 # Code quality
 black>=26,<27

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest>=7.0
 pytest-cov>=4.0
+coverage>=7.10  # needed for [tool.coverage.run] patch = ["subprocess"] in pyproject.toml
 
 # Code quality
 black>=26,<27


### PR DESCRIPTION
## What

`tests/test_integration.py` drives the CLI exclusively via
`subprocess.run([sys.executable, "-m", "skillsaw", ...])`. pytest-cov 7
dropped automatic subprocess instrumentation, so `src/skillsaw/cli/`
reported ~0-11% coverage despite being thoroughly exercised by 209
integration tests (`cli/_lint.py`: 0%, 133/133 lines missed).

This PR enables coverage.py's built-in subprocess patching so the CLI
package's real coverage shows up in local runs and Codecov, with no
change to test behavior or CLI code:

1. `pyproject.toml`: add `[tool.coverage.run]` with `patch =
   ["subprocess"]`.
2. Pin `coverage>=7.10` (the `patch` option requires it; older versions
   warn on an unknown option and silently no-op) in both the `dev` extra
   in `pyproject.toml` — which is what `make venv` and CI's
   `verify-update` job actually resolve via `pip install -e '.[dev]'` —
   and in `requirements-dev.txt` for consistency.
3. `Makefile`: reconcile the `test` target's `--cov=src` with
   `--cov=src/skillsaw`, already used in `.github/workflows/test.yml`, so
   local and CI coverage numbers match.
4. `DEVELOPMENT.md`: document why subprocess coverage is patched in, and
   its cost.

## Why

Without subprocess patching, the CLI layer — the code path actually
invoked by every real `skillsaw` user — looks completely untested in
coverage reports, even though 209 integration tests exercise it
end-to-end via the `python -m skillsaw` entrypoint. This makes coverage
reports misleading and could hide real regressions in `cli/_lint.py`,
`cli/_fix.py`, etc. Enabling `patch = ["subprocess"]` fixes the
attribution without changing what's tested or how.

No CLI code is touched by this PR — this is test-infrastructure only.
Any "dead" CLI code the new coverage reveals is an explicitly separate
follow-up.

## Numbers

Measured locally with `make test` before and after:

| Metric | Before | After |
|---|---|---|
| TOTAL coverage | 85% | 93% |
| `cli/_lint.py` | 0% | 91% |
| `cli/_parser.py` | 12% (0.125) | 100% |
| `cli/` package (aggregate) | ~0-11% per module | 88% |
| Tests passing | 2466 | 2466 |
| Runtime | ~42s | ~61s (+~19s) |

## Testing

- `make test` — all 2466 tests pass; coverage table confirms the numbers
  above.
- `make lint` — passes, no formatting changes needed (no Python source
  touched).
- `make update` — no-op; confirmed no unexpected regenerated file diffs.
- `skillsaw lint` against a local checkout of `openshift-eng/ai-helpers`
  — exit 0, Grade A, 0 errors/warnings.
- Self-lint (`skillsaw lint .` via `make update`) — exit 0, Grade A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)