### PR TITLE
Add github + markdown output formats and zero-config PR annotations in the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ ratchet behavior, and refresh workflow.
 ## CI Integration
 
 ```yaml
-# GitHub Actions
+# GitHub Actions — annotations + job-summary report card, zero config
 - uses: stbenjam/skillsaw@v0
   with:
     strict: true
@@ -175,7 +175,8 @@ skillsaw:
 ```
 
 Output formats for `--format` / `--output`: `text`, `json`, `sarif`, `html`,
-`code-climate`, and `gitlab`.
+`code-climate`, `gitlab`, `github` (GitHub Actions annotations), and
+`markdown` (report card for `$GITHUB_STEP_SUMMARY`).
 
 For PR review comments, the secure two-workflow pattern, plugins, custom
 rules, and full configuration options, see the

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs)'
     required: false
     default: 'true'
+  annotations:
+    description: 'Emit GitHub annotations (inline PR/file annotations, no extra permissions needed). GitHub caps them at 10 errors + 10 warnings per step; the full report always goes to the log and job summary.'
+    required: false
+    default: 'true'
 
 outputs:
   exit-code:
@@ -84,6 +88,7 @@ runs:
         SKILLSAW_FAIL_ON: ${{ inputs.fail-on }}
         SKILLSAW_VERBOSE: ${{ inputs.verbose }}
         SKILLSAW_NO_CUSTOM_RULES: ${{ inputs.no-custom-rules }}
+        SKILLSAW_ANNOTATIONS: ${{ inputs.annotations }}
       run: |
         set +e
         ARGS=""
@@ -104,8 +109,33 @@ runs:
         fi
 
         REPORT_FILE=$(mktemp --suffix=.json)
-        skillsaw $ARGS --format text --output "$REPORT_FILE" "$SKILLSAW_PATH"
+        ANNOTATIONS_FILE=$(mktemp)
+        SUMMARY_FILE=$(mktemp --suffix=.md)
+
+        # Older skillsaw releases don't have the github/markdown formats;
+        # only request them when the installed version supports them.
+        EXTRA_OUTPUTS=""
+        if skillsaw lint --help 2>/dev/null | grep -q "markdown"; then
+          EXTRA_OUTPUTS="--output markdown:$SUMMARY_FILE"
+          if [ "$SKILLSAW_ANNOTATIONS" = "true" ]; then
+            EXTRA_OUTPUTS="$EXTRA_OUTPUTS --output github:$ANNOTATIONS_FILE"
+          fi
+        fi
+
+        skillsaw $ARGS --format text --output "$REPORT_FILE" $EXTRA_OUTPUTS "$SKILLSAW_PATH"
         EXIT_CODE=$?
+
+        # Annotations: workflow commands become inline PR/file annotations
+        # when printed to the step's stdout.
+        if [ -s "$ANNOTATIONS_FILE" ]; then
+          cat "$ANNOTATIONS_FILE"
+        fi
+
+        # Job summary: markdown report card on the workflow run page.
+        if [ -n "$GITHUB_STEP_SUMMARY" ] && [ -s "$SUMMARY_FILE" ]; then
+          cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+        fi
 
         echo "exit-code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
         echo "report-file=${REPORT_FILE}" >> "$GITHUB_OUTPUT"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,9 +2,11 @@
 
 ## GitHub Action
 
-The GitHub Action installs skillsaw, runs it, and prints violations in the CI
-log. A separate review action posts violations as inline PR comments with
-automatic deduplication and thread resolution.
+The GitHub Action installs skillsaw, runs it, prints violations in the CI
+log, posts them as GitHub annotations, and appends a markdown report card to
+the job summary — all with read-only permissions and zero configuration. For
+richer PR feedback, a separate review action posts violations as inline PR
+comments with automatic deduplication and thread resolution.
 
 ### Basic usage (lint only)
 
@@ -28,7 +30,31 @@ jobs:
           strict: true
 ```
 
+That single step already gives you, without any write permissions:
+
+- **Annotations** — each violation becomes a GitHub annotation
+  (`::error` / `::warning` workflow commands). On pull requests these render
+  inline in the diff, but only for lines the PR actually changed; every
+  annotation also appears on the run's summary page. GitHub caps annotations
+  at 10 errors and 10 warnings per step — when the cap is hit, a notice
+  reports how many more violations were found. Set `annotations: 'false'`
+  to turn them off.
+- **Job summary** — a markdown report card (violation counts, grade, and a
+  violations table) appended to the workflow run's summary page.
+- **Log output** — the full human-readable report, always.
+
+When the `path` input points at a subdirectory, annotation paths are still
+emitted relative to `$GITHUB_WORKSPACE` (as GitHub requires), so annotations
+attach to the right files.
+
+If you need feedback on *every* violation as resolvable inline PR comments —
+including on lines the PR didn't touch — use the review action below.
+
 ### With PR review comments
+
+The review action goes beyond annotations: comments are deduplicated across
+re-runs, threads resolve automatically when violations are fixed, and
+comments attach to any line, not just those in the PR diff.
 
 To post inline comments on PRs (including fork PRs), use the two-workflow
 pattern. The lint workflow runs with read-only permissions and uploads the
@@ -99,6 +125,7 @@ jobs:
 | `fail-on` | Fail on violations at this severity or above (`error`, `warning`, `info`); `strict: true` is equivalent to `fail-on: warning`, and combining `strict` with a contradictory `fail-on` fails the run | `''` |
 | `verbose` | Include info-level violations | `false` |
 | `no-custom-rules` | Skip custom rules defined in `.skillsaw.yaml` | `true` |
+| `annotations` | Emit GitHub annotations (capped by GitHub at 10 errors + 10 warnings per step) | `true` |
 | `plugins` | Newline-separated list of plugin packages to install | `''` |
 
 ### Outputs
@@ -139,9 +166,26 @@ git ls-remote --tags https://github.com/stbenjam/skillsaw.git v0
 
 skillsaw supports several machine-readable output formats — `--format`
 (stdout) and `--output` (file) accept `text`, `json`, `sarif`, `html`,
-`code-climate`, and `gitlab` — including [SARIF
+`code-climate`, `gitlab`, `github`, and `markdown` — including [SARIF
 2.1.0](https://sarifweb.azurewebsites.net/) for tools that ingest it.
 See the [CLI reference](cli.md) for details.
+
+If you run skillsaw in GitHub Actions without the action (e.g. inside an
+existing job), the `github` and `markdown` formats give you the same
+zero-config feedback:
+
+```yaml
+- run: |
+    pip install skillsaw==0.16.0
+    skillsaw lint --format github --output markdown:skillsaw-report.md .
+    cat skillsaw-report.md >> "$GITHUB_STEP_SUMMARY"
+```
+
+The `github` format prints [workflow
+commands](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions)
+(`::error file=...,line=...,title=rule-id::message`) that GitHub turns into
+annotations; the `markdown` format is a compact report card for
+`$GITHUB_STEP_SUMMARY` (or anywhere else markdown renders).
 
 ## GitLab CI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,8 +17,8 @@ Lint agent skills, plugins, and AI coding assistant context
 | `-v`, `--verbose` | Show info-level messages |  |
 | `--strict` | Treat warnings as errors (equivalent to --fail-on warning; overrides the config file's strict/fail-on settings) |  |
 | `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Overrides the config file's strict/fail-on settings. (choices: error, warning, info) |  |
-| `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
-| `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
+| `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab, github, markdown) | `text` |
+| `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .md, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo. |  |
 | `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |
 | `--skip-rule` | Skip these rules (repeatable). Cannot be combined with --rule. |  |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,10 +166,13 @@ skillsaw list-rules
 # Generate plugin/skill documentation
 skillsaw docs
 
-# Output in different formats (text, json, sarif, html, code-climate, gitlab)
+# Output in different formats (text, json, sarif, html, code-climate,
+# gitlab, github, markdown)
 skillsaw --format json
 skillsaw --format code-climate   # Code Climate / GitLab Code Quality format
 skillsaw --format gitlab          # Alias for code-climate
+skillsaw --format github          # GitHub Actions annotations (workflow commands)
+skillsaw --format markdown        # Markdown report card (e.g. $GITHUB_STEP_SUMMARY)
 
 # Write formatted output to a file (format inferred from extension)
 skillsaw --output report.sarif

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -1,7 +1,8 @@
 """
 Output formatters for skillsaw lint results.
 
-Supported formats: text, json, sarif, html, code-climate (alias: gitlab).
+Supported formats: text, json, sarif, html, code-climate (alias: gitlab),
+github, markdown.
 """
 
 from pathlib import Path
@@ -9,7 +10,7 @@ from typing import List, Optional
 
 from ..rule import Rule, RuleViolation
 
-FORMATS = ("text", "json", "sarif", "html", "code-climate", "gitlab")
+FORMATS = ("text", "json", "sarif", "html", "code-climate", "gitlab", "github", "markdown")
 
 
 def relative_path(file_path: Optional[Path], root: Path) -> Optional[str]:
@@ -28,6 +29,7 @@ EXTENSION_MAP = {
     ".html": "html",
     ".htm": "html",
     ".txt": "text",
+    ".md": "markdown",
 }
 
 _FORMAT_SET = set(FORMATS)
@@ -107,7 +109,8 @@ def format_report(
     Format lint results in the specified format.
 
     Args:
-        fmt: One of "text", "json", "sarif", "html", "code-climate", "gitlab"
+        fmt: One of "text", "json", "sarif", "html", "code-climate", "gitlab",
+            "github", "markdown"
         violations: Violations from linter.run()
         context: RepositoryContext
         rules: List of Rule instances that were run
@@ -116,7 +119,7 @@ def format_report(
         baseline_suppressed: Number of violations suppressed by baseline
         duration: Wall-clock lint time in seconds (text and json formats only;
             sarif/code-climate schemas have no place for it)
-        grade: Optional Grade for the run (text and json formats only)
+        grade: Optional Grade for the run (text, json, and markdown formats only)
         fail_level: Effective severity threshold that fails the run — with
             ``fail-on: info`` every format must include the info violations
             that caused the failure even without -v
@@ -161,5 +164,22 @@ def format_report(
         from .code_climate import format_code_climate
 
         return format_code_climate(violations, context, rules, version, verbose, fail_level)
+    elif fmt == "github":
+        from .github import format_github
+
+        return format_github(violations, context, rules, version, verbose, fail_level)
+    elif fmt == "markdown":
+        from .markdown import format_markdown
+
+        return format_markdown(
+            violations,
+            context,
+            rules,
+            version,
+            verbose,
+            baseline_suppressed,
+            grade,
+            fail_level,
+        )
     else:
         raise ValueError(f"Unknown format: {fmt}. Supported: {', '.join(FORMATS)}")

--- a/src/skillsaw/formatters/github.py
+++ b/src/skillsaw/formatters/github.py
@@ -1,0 +1,125 @@
+"""GitHub Actions workflow-command output formatter.
+
+Emits ``::error`` / ``::warning`` / ``::notice`` workflow commands that GitHub
+Actions turns into PR annotations when printed to a step's stdout. See
+https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+
+GitHub renders at most 10 error and 10 warning annotations per step (and 10
+notices), so output is capped per severity and truncation is reported with a
+single trailing ``::notice`` — never silently.
+"""
+
+import os
+from pathlib import Path, PurePath
+from typing import List, Optional
+
+from ..rule import Rule, RuleViolation, Severity
+from . import relative_path, should_show_info
+
+# GitHub Actions shows at most this many annotations per step for each of
+# the error, warning, and notice levels; anything beyond is dropped.
+ANNOTATION_LIMIT = 10
+
+_SEVERITY_COMMAND = {
+    "error": "error",
+    "warning": "warning",
+    "info": "notice",
+}
+
+
+def _escape_data(value: str) -> str:
+    """Escape a workflow-command message (the part after ``::``).
+
+    ``%`` must be escaped first so already-escaped sequences aren't
+    double-escaped.
+    """
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_property(value: str) -> str:
+    """Escape a workflow-command property value (``file=``, ``title=``, ...).
+
+    Properties additionally need ``,`` and ``:`` escaped — they delimit
+    properties and the command itself.
+    """
+    return _escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
+def _annotation_path(file_path: Optional[Path], root: Path) -> Optional[str]:
+    """Path for the ``file=`` property, as GitHub expects it.
+
+    Annotations only attach to files when ``file=`` is relative to
+    ``GITHUB_WORKSPACE`` — not to the lint root, which may be a
+    subdirectory of the checkout. When ``GITHUB_WORKSPACE`` is set and the
+    file lives under it, relativize against the workspace; otherwise fall
+    back to the lint root (identical when the action lints the whole
+    checkout, and the best available answer outside CI).
+    """
+    if file_path is None:
+        return None
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        absolute = file_path if file_path.is_absolute() else root / file_path
+        try:
+            return absolute.resolve().relative_to(Path(workspace).resolve()).as_posix()
+        except (ValueError, OSError):
+            pass
+    rel = relative_path(file_path, root)
+    return PurePath(rel).as_posix() if rel else None
+
+
+def _format_command(v: RuleViolation, root: Path) -> str:
+    command = _SEVERITY_COMMAND[v.severity.value]
+    properties = []
+    rel = _annotation_path(v.file_path, root)
+    if rel:
+        properties.append(f"file={_escape_property(rel)}")
+        line = v.file_line
+        if line is not None and line >= 1:
+            properties.append(f"line={line}")
+    properties.append(f"title={_escape_property(v.rule_id)}")
+    return f"::{command} {','.join(properties)}::{_escape_data(v.message)}"
+
+
+def format_github(
+    violations: List[RuleViolation],
+    context,
+    rules: List[Rule],
+    version: str,
+    verbose: bool = False,
+    fail_level: str = "error",
+) -> str:
+    show_info = should_show_info(verbose, fail_level)
+
+    errors = [v for v in violations if v.severity == Severity.ERROR]
+    warnings = [v for v in violations if v.severity == Severity.WARNING]
+    info = [v for v in violations if v.severity == Severity.INFO] if show_info else []
+
+    hidden = max(0, len(errors) - ANNOTATION_LIMIT) + max(0, len(warnings) - ANNOTATION_LIMIT)
+    # The truncation notice shares the notice budget with info annotations:
+    # when one is needed, keep a slot free so it isn't dropped too.
+    info_limit = ANNOTATION_LIMIT
+    if hidden or len(info) > ANNOTATION_LIMIT:
+        info_limit = ANNOTATION_LIMIT - 1
+    hidden += max(0, len(info) - info_limit)
+
+    lines = []
+    for group, limit in (
+        (errors, ANNOTATION_LIMIT),
+        (warnings, ANNOTATION_LIMIT),
+        (info, info_limit),
+    ):
+        for v in group[:limit]:
+            lines.append(_format_command(v, context.root_path))
+
+    if hidden:
+        plural = "" if hidden == 1 else "s"
+        lines.append(
+            "::notice title=skillsaw::"
+            + _escape_data(
+                f"...and {hidden} more violation{plural} not annotated "
+                "(GitHub caps annotations per step); see the log or report for the full list."
+            )
+        )
+
+    return "\n".join(lines)

--- a/src/skillsaw/formatters/github.py
+++ b/src/skillsaw/formatters/github.py
@@ -62,7 +62,10 @@ def _annotation_path(file_path: Optional[Path], root: Path) -> Optional[str]:
         absolute = file_path if file_path.is_absolute() else root / file_path
         try:
             return absolute.resolve().relative_to(Path(workspace).resolve()).as_posix()
-        except (ValueError, OSError):
+        except (ValueError, OSError, RuntimeError):
+            # ValueError: not under the workspace. OSError / RuntimeError:
+            # unresolvable paths — e.g. symlink loops, which raise
+            # RuntimeError from Path.resolve() before Python 3.13.
             pass
     rel = relative_path(file_path, root)
     return PurePath(rel).as_posix() if rel else None

--- a/src/skillsaw/formatters/markdown.py
+++ b/src/skillsaw/formatters/markdown.py
@@ -1,0 +1,104 @@
+"""GitHub-flavored-markdown report formatter.
+
+A compact report card suitable for ``$GITHUB_STEP_SUMMARY``, PR comments, or
+any other markdown sink: summary counts, the quality grade when available,
+and a violations table — truncated politely for huge repos.
+"""
+
+from typing import List, Optional
+
+from ..rule import Rule, RuleViolation, Severity
+from . import get_counts, relative_path, should_show_info
+
+# Keep step summaries readable (and under GitHub's 1 MiB summary cap) on
+# huge repos: show at most this many table rows, then a truncation note.
+MAX_TABLE_ROWS = 100
+
+_SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
+_SEVERITY_ICON = {"error": "✗", "warning": "⚠", "info": "ℹ"}
+
+
+def _escape_cell(value: str) -> str:
+    """Escape text for a GFM table cell: HTML, pipes, and newlines."""
+    value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    value = value.replace("|", "\\|")
+    return value.replace("\r\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
+
+
+def format_markdown(
+    violations: List[RuleViolation],
+    context,
+    rules: List[Rule],
+    version: str,
+    verbose: bool = False,
+    baseline_suppressed: int = 0,
+    grade=None,
+    fail_level: str = "error",
+) -> str:
+    show_info = should_show_info(verbose, fail_level)
+    errors, warnings, info = get_counts(violations)
+
+    output = ["## skillsaw report", ""]
+
+    counts = [
+        f"**{errors}** error{'' if errors == 1 else 's'}",
+        f"**{warnings}** warning{'' if warnings == 1 else 's'}",
+    ]
+    if show_info:
+        counts.append(f"**{info}** info")
+    output.append(" · ".join(counts))
+    output.append("")
+
+    if grade is not None:
+        output.append(
+            f"**Grade: {grade.letter}** "
+            f"({grade.density:.2f} weighted violations per 10k tokens)"
+        )
+        output.append("")
+
+    shown = [v for v in violations if show_info or v.severity != Severity.INFO]
+    shown.sort(
+        key=lambda v: (
+            _SEVERITY_ORDER[v.severity.value],
+            str(v.file_path or ""),
+            v.file_line or 0,
+            v.rule_id,
+        )
+    )
+
+    if shown:
+        output.append("| Severity | Rule | Location | Message |")
+        output.append("| --- | --- | --- | --- |")
+        for v in shown[:MAX_TABLE_ROWS]:
+            icon = _SEVERITY_ICON[v.severity.value]
+            rel = relative_path(v.file_path, context.root_path)
+            location = ""
+            if rel:
+                location = f"`{_escape_cell(rel)}`"
+                line = v.file_line
+                if line is not None and line >= 1:
+                    location = f"`{_escape_cell(rel)}:{line}`"
+            output.append(
+                f"| {icon} {v.severity.value} "
+                f"| `{_escape_cell(v.rule_id)}` "
+                f"| {location} "
+                f"| {_escape_cell(v.message)} |"
+            )
+        output.append("")
+        if len(shown) > MAX_TABLE_ROWS:
+            remaining = len(shown) - MAX_TABLE_ROWS
+            output.append(
+                f"_...and {remaining} more violation{'' if remaining == 1 else 's'} "
+                "not shown — run `skillsaw lint` locally for the full report._"
+            )
+            output.append("")
+    else:
+        output.append("**✓ All checks passed!**")
+        output.append("")
+
+    footnotes = [f"skillsaw {version}", f"{len(rules)} rules"]
+    if baseline_suppressed:
+        footnotes.append(f"{baseline_suppressed} baseline-suppressed")
+    output.append(f"_{' · '.join(footnotes)}_")
+
+    return "\n".join(output)

--- a/tests/fixtures/github-annotations/.claude-plugin/plugin.json
+++ b/tests/fixtures/github-annotations/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "release-tools",
+  "description": "Commands for cutting and validating releases",
+  "version": "1.2.0",
+  "author": {
+    "name": "Release Team"
+  }
+}

--- a/tests/fixtures/github-annotations/README.md
+++ b/tests/fixtures/github-annotations/README.md
@@ -1,0 +1,12 @@
+# release-tools
+
+Commands for cutting and validating releases.
+
+## Installation
+
+Install this plugin from the marketplace, then run `/release-tools:deploy-prod`
+to start a production deployment.
+
+## Commands
+
+- `Deploy_Prod.md` — deploy the current release to production

--- a/tests/fixtures/github-annotations/commands/Deploy_Prod.md
+++ b/tests/fixtures/github-annotations/commands/Deploy_Prod.md
@@ -1,0 +1,21 @@
+---
+description: Deploy the current release to production
+---
+
+## Name
+release-tools:deploy-prod
+
+## Synopsis
+```
+/release-tools:deploy-prod [version]
+```
+
+## Description
+Deploys the specified version (default: latest tagged release) to the
+production environment after running the smoke-test suite.
+
+## Implementation
+1. Verify the working tree is clean and the tag exists.
+2. Run the smoke tests with `make smoke`.
+3. Trigger the deployment pipeline for the requested version.
+4. Report the pipeline URL.

--- a/tests/fixtures/github-annotations/evals/smoke.yaml
+++ b/tests/fixtures/github-annotations/evals/smoke.yaml
@@ -1,0 +1,6 @@
+description: "Smoke-test the deploy command prompt"
+providers:
+  - id: anthropic:messages:claude-3-5-sonnet-latest
+prompts:
+  - "Deploy version {{version}} to production"
+tests: 42

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1095,6 +1095,32 @@ def test_github_paths_relative_to_workspace(valid_plugin, monkeypatch):
     assert f"file={valid_plugin.name}/commands/test-command.md," in output
 
 
+def test_github_unresolvable_path_falls_back_to_root(valid_plugin, monkeypatch):
+    """Path.resolve() raises RuntimeError on symlink loops before Python
+    3.13 — annotation paths must fall back to root-relative, not crash."""
+    import pathlib
+
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(valid_plugin.parent))
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="symlink loop on the way to the workspace",
+            file_path=Path("commands/test-command.md"),
+            line=1,
+        ),
+    ]
+
+    def raise_loop(self, strict=False):
+        raise RuntimeError(f"Symlink loop from {self!r}")
+
+    monkeypatch.setattr(pathlib.Path, "resolve", raise_loop)
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert "file=commands/test-command.md," in output
+
+
 def test_github_path_outside_workspace_falls_back_to_root(valid_plugin, monkeypatch, tmp_path):
     monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path / "elsewhere"))
     context = RepositoryContext(valid_plugin)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,6 +11,8 @@ from skillsaw.formatters.json_fmt import format_json
 from skillsaw.formatters.sarif import format_sarif
 from skillsaw.formatters.html import format_html
 from skillsaw.formatters.code_climate import format_code_climate
+from skillsaw.formatters.github import ANNOTATION_LIMIT, format_github
+from skillsaw.formatters.markdown import MAX_TABLE_ROWS, format_markdown
 from skillsaw.rule import RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.config import LinterConfig
@@ -141,7 +143,12 @@ def test_format_report_dispatches_all_formats(valid_plugin):
 
     for fmt in FORMATS:
         output = format_report(fmt, violations, context, linter.rules, "0.0.0")
-        assert len(output) > 0
+        if fmt == "github":
+            # A clean run emits no workflow commands — annotations would be
+            # pure noise. Every other format always renders a report.
+            assert output == ""
+        else:
+            assert len(output) > 0
 
 
 def test_format_report_unknown_format(valid_plugin):
@@ -921,3 +928,363 @@ def test_json_includes_duration(valid_plugin):
 
     report = json.loads(format_json(violations, context, linter.rules, "0.0.0"))
     assert "duration_seconds" not in report["stats"]
+
+
+# --- GitHub Actions annotations formatter ---
+
+
+def _bulk_violations(count, severity, rule_id="bulk-rule"):
+    return [
+        RuleViolation(
+            rule_id=rule_id,
+            severity=severity,
+            message=f"violation number {i}",
+            file_path=Path(f"docs/file-{i}.md"),
+            line=i + 1,
+        )
+        for i in range(count)
+    ]
+
+
+def test_github_basic_commands(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_github(violations, context, [], "1.0.0", verbose=True)
+    lines = output.split("\n")
+
+    assert lines[0] == (
+        "::error file=plugins/foo/.claude-plugin,title=plugin-json-required::Missing plugin.json"
+    )
+    assert lines[1] == (
+        "::warning file=plugins/foo/commands/Bad_Name.md,line=3,"
+        "title=command-naming::Command file should use kebab-case"
+    )
+    assert lines[2] == (
+        "::notice file=plugins/foo/.claude-plugin/plugin.json,line=1,"
+        "title=plugin-json-valid::Recommended field 'author' missing"
+    )
+
+
+def test_github_hides_info_without_verbose(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_github(violations, context, [], "1.0.0", verbose=False)
+    assert "::notice" not in output
+    assert "::error" in output
+    assert "::warning" in output
+
+
+def test_github_shows_info_when_fail_on_info(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_github(violations, context, [], "1.0.0", verbose=False, fail_level="info")
+    assert "::notice" in output
+
+
+def test_github_escapes_message(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="50% failed\nsecond line\rthird line",
+            file_path=Path("docs/a.md"),
+            line=1,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert output == (
+        "::error file=docs/a.md,line=1,title=test-rule::" "50%25 failed%0Asecond line%0Dthird line"
+    )
+
+
+def test_github_escapes_percent_first(valid_plugin, monkeypatch):
+    """A literal '%0A' in the message must not survive as a newline escape."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="literal %0A sequence",
+            file_path=Path("docs/a.md"),
+            line=1,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert "::literal %250A sequence" in output
+
+
+def test_github_escapes_properties(valid_plugin, monkeypatch):
+    """Commas and colons in property values must be escaped — they delimit
+    properties and the command itself."""
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.WARNING,
+            message="odd path",
+            file_path=Path("docs/a,b/c:d.md"),
+            line=2,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert output == "::warning file=docs/a%2Cb/c%3Ad.md,line=2,title=test-rule::odd path"
+
+
+def test_github_no_file_omits_file_property(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="repo-rule",
+            severity=Severity.ERROR,
+            message="repo-level problem",
+            file_path=None,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert output == "::error title=repo-rule::repo-level problem"
+
+
+def test_github_paths_relative_to_root(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="absolute path input",
+            file_path=valid_plugin / "commands" / "test-command.md",
+            line=1,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert "file=commands/test-command.md," in output
+
+
+def test_github_paths_relative_to_workspace(valid_plugin, monkeypatch):
+    """When the lint root is a subdirectory of GITHUB_WORKSPACE, annotations
+    still need paths relative to the workspace, not the lint root."""
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(valid_plugin.parent))
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="workspace-relative path",
+            file_path=Path("commands/test-command.md"),
+            line=1,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert f"file={valid_plugin.name}/commands/test-command.md," in output
+
+
+def test_github_path_outside_workspace_falls_back_to_root(valid_plugin, monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path / "elsewhere"))
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="outside the workspace",
+            file_path=Path("commands/test-command.md"),
+            line=1,
+        ),
+    ]
+
+    output = format_github(violations, context, [], "1.0.0")
+    assert "file=commands/test-command.md," in output
+
+
+def test_github_caps_errors_with_truncation_notice(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _bulk_violations(25, Severity.ERROR)
+
+    output = format_github(violations, context, [], "1.0.0")
+    lines = output.split("\n")
+
+    error_lines = [ln for ln in lines if ln.startswith("::error ")]
+    notice_lines = [ln for ln in lines if ln.startswith("::notice ")]
+    assert len(error_lines) == ANNOTATION_LIMIT
+    assert len(notice_lines) == 1
+    assert lines[-1].startswith("::notice title=skillsaw::")
+    assert "15 more violations" in lines[-1]
+
+
+def test_github_caps_each_severity_independently(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = (
+        _bulk_violations(12, Severity.ERROR, "error-rule")
+        + _bulk_violations(11, Severity.WARNING, "warning-rule")
+        + _bulk_violations(12, Severity.INFO, "info-rule")
+    )
+
+    output = format_github(violations, context, [], "1.0.0", verbose=True)
+    lines = output.split("\n")
+
+    assert len([ln for ln in lines if ln.startswith("::error ")]) == ANNOTATION_LIMIT
+    assert len([ln for ln in lines if ln.startswith("::warning ")]) == ANNOTATION_LIMIT
+    # Info notices leave one notice slot free for the truncation notice, so
+    # GitHub's 10-notice cap never drops it.
+    notice_lines = [ln for ln in lines if ln.startswith("::notice ")]
+    assert len(notice_lines) == ANNOTATION_LIMIT
+    assert "6 more violations" in notice_lines[-1]
+
+
+def test_github_at_cap_has_no_truncation_notice(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _bulk_violations(ANNOTATION_LIMIT, Severity.ERROR)
+
+    output = format_github(violations, context, [], "1.0.0")
+    lines = output.split("\n")
+
+    assert len(lines) == ANNOTATION_LIMIT
+    assert "::notice" not in output
+
+
+def test_github_clean_run_emits_nothing(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+
+    assert format_github([], context, [], "1.0.0") == ""
+
+
+def test_github_dispatched_via_format_report(valid_plugin, monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_report("github", violations, context, [], "1.0.0")
+    assert "::error " in output
+
+
+# --- Markdown formatter ---
+
+
+def test_markdown_structure(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_markdown(violations, context, [], "1.0.0", verbose=True)
+    assert output.startswith("## skillsaw report")
+    assert "**1** error · **1** warning · **1** info" in output
+    assert "| Severity | Rule | Location | Message |" in output
+    assert "| --- | --- | --- | --- |" in output
+    assert "`plugin-json-required`" in output
+    assert "`plugins/foo/commands/Bad_Name.md:3`" in output
+    assert "Missing plugin.json" in output
+
+
+def test_markdown_sorted_by_severity(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = list(reversed(_make_violations()))
+
+    output = format_markdown(violations, context, [], "1.0.0", verbose=True)
+    error_pos = output.index("plugin-json-required")
+    warning_pos = output.index("command-naming")
+    info_pos = output.index("plugin-json-valid")
+    assert error_pos < warning_pos < info_pos
+
+
+def test_markdown_hides_info_without_verbose(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_markdown(violations, context, [], "1.0.0", verbose=False)
+    assert "plugin-json-valid" not in output
+    assert "info" not in output.split("\n")[2]
+
+
+def test_markdown_escapes_table_cells(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="test-rule",
+            severity=Severity.ERROR,
+            message="pipe | and <b>html</b> & ampersand\nsecond line",
+            file_path=Path("docs/a.md"),
+            line=1,
+        ),
+    ]
+
+    output = format_markdown(violations, context, [], "1.0.0")
+    assert "pipe \\| and &lt;b&gt;html&lt;/b&gt; &amp; ampersand<br>second line" in output
+
+
+def test_markdown_includes_grade(valid_plugin):
+    from skillsaw.grade import Grade
+
+    context = RepositoryContext(valid_plugin)
+    grade = Grade(letter="B", density=1.23, errors=0, warnings=2, info=0, content_tokens=10000)
+
+    output = format_markdown([], context, [], "1.0.0", grade=grade)
+    assert "**Grade: B** (1.23 weighted violations per 10k tokens)" in output
+
+
+def test_markdown_omits_grade_when_absent(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+
+    output = format_markdown([], context, [], "1.0.0")
+    assert "Grade" not in output
+
+
+def test_markdown_clean_run(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+
+    output = format_markdown([], context, [], "1.0.0")
+    assert "All checks passed" in output
+    assert "| Severity |" not in output
+
+
+def test_markdown_truncates_huge_reports(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _bulk_violations(MAX_TABLE_ROWS + 7, Severity.WARNING)
+
+    output = format_markdown(violations, context, [], "1.0.0")
+    rows = [ln for ln in output.split("\n") if ln.startswith("| ⚠")]
+    assert len(rows) == MAX_TABLE_ROWS
+    assert "...and 7 more violations not shown" in output
+
+
+def test_markdown_reports_baseline_suppressed(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+
+    output = format_markdown([], context, [], "1.0.0", baseline_suppressed=4)
+    assert "4 baseline-suppressed" in output
+
+
+def test_markdown_dispatched_via_format_report(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = _make_violations()
+
+    output = format_report("markdown", violations, context, [], "1.0.0")
+    assert output.startswith("## skillsaw report")
+
+
+def test_markdown_extension_inferred():
+    assert infer_format("report.md") == "markdown"
+    assert parse_output_spec("summary.md") == ("markdown", "summary.md")
+
+
+def test_github_output_spec_prefix():
+    assert parse_output_spec("github:annotations.txt") == ("github", "annotations.txt")
+    assert parse_output_spec("markdown:report.md") == ("markdown", "report.md")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3113,3 +3113,96 @@ class TestNameAutofixMultilineScalar:
         assert any("folded-name" in f for f in remaining)
         assert any("next-line" in f for f in remaining)
         assert any("dup-keys" in f for f in remaining)
+
+
+# ── github / markdown output formats ─────────────────────────────
+
+
+@pytest.mark.integration
+class TestGithubAndMarkdownFormats:
+    """End-to-end coverage for the CI-facing output formats: ``--format
+    github`` (GitHub Actions workflow commands, machine-parsed) and
+    ``--output markdown:FILE`` (job-summary report card).
+
+    The fixture is pinned to two stable rules with ``--rule`` so the
+    expected output stays exact as unrelated rules evolve."""
+
+    FIXTURE = "github-annotations"
+    RULE_ARGS = ("--rule", "command-naming", "--rule", "promptfoo-valid")
+
+    def _run(self, repo, *args, env_overrides=None):
+        env = os.environ.copy()
+        # GITHUB_WORKSPACE leaks in when the suite itself runs in Actions
+        env.pop("GITHUB_WORKSPACE", None)
+        if env_overrides:
+            env.update(env_overrides)
+        cmd = [sys.executable, "-m", "skillsaw", "lint", *args, str(repo)]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=env)
+
+    def test_github_format_emits_workflow_commands(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run(repo, "--format", "github", *self.RULE_ARGS)
+
+        assert result.returncode == 1
+        lines = [ln for ln in result.stdout.splitlines() if ln]
+        assert lines == [
+            "::error file=evals/smoke.yaml,line=6,title=promptfoo-valid::"
+            "'tests' must be an array or a string file reference",
+            "::warning file=commands/Deploy_Prod.md,title=command-naming::"
+            "Command name 'Deploy_Prod' should use kebab-case",
+        ]
+
+    def test_github_format_paths_relative_to_workspace(self, tmp_path):
+        """When GITHUB_WORKSPACE is set and the lint root is a subdirectory
+        (the action's ``path`` input), ``file=`` must still be
+        workspace-relative or annotations attach to the wrong files."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run(
+            repo,
+            "--format",
+            "github",
+            *self.RULE_ARGS,
+            env_overrides={"GITHUB_WORKSPACE": str(tmp_path)},
+        )
+
+        assert result.returncode == 1
+        assert f"file={repo.name}/evals/smoke.yaml,line=6,title=promptfoo-valid" in result.stdout
+        assert f"file={repo.name}/commands/Deploy_Prod.md,title=command-naming" in result.stdout
+
+    def test_markdown_output_file(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        report = tmp_path / "report.md"
+        result = self._run(repo, "--output", f"markdown:{report}", *self.RULE_ARGS)
+
+        assert result.returncode == 1
+        # stdout keeps the human-readable text report
+        assert "Summary:" in result.stdout
+
+        content = report.read_text()
+        assert content.startswith("## skillsaw report")
+        assert "**1** error · **1** warning" in content
+        assert "| Severity | Rule | Location | Message |" in content
+        assert (
+            "| ✗ error | `promptfoo-valid` | `evals/smoke.yaml:6` "
+            "| 'tests' must be an array or a string file reference |"
+        ) in content
+        assert (
+            "| ⚠ warning | `command-naming` | `commands/Deploy_Prod.md` "
+            "| Command name 'Deploy_Prod' should use kebab-case |"
+        ) in content
+        assert "**Grade:" in content
+
+    def test_md_extension_infers_markdown(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        report = tmp_path / "summary.md"
+        result = self._run(repo, "--output", str(report), *self.RULE_ARGS)
+
+        assert result.returncode == 1
+        assert report.read_text().startswith("## skillsaw report")
+
+    def test_github_format_clean_repo_emits_nothing(self, tmp_path):
+        repo = copy_fixture("single-plugin/clean", tmp_path)
+        result = self._run(repo, "--format", "github")
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""


### PR DESCRIPTION
## What

Two new output formats and a zero-config CI feedback tier for the GitHub Action:

- **`--format github`** — emits GitHub Actions workflow commands that render as annotations:

  ```
  ::error file=evals/smoke.yaml,line=6,title=promptfoo-valid::'tests' must be an array or a string file reference
  ::warning file=commands/Deploy_Prod.md,title=command-naming::Command name 'Deploy_Prod' should use kebab-case
  ::notice title=skillsaw::...and 443 more violations not annotated (GitHub caps annotations per step); see the log or report for the full list.
  ```

- **`--format markdown`** — a compact GFM report card (counts, grade, sorted violations table, truncated at 100 rows) for `$GITHUB_STEP_SUMMARY`. `.md` now infers `markdown` in `--output`.

- **action.yml** — new `annotations` input (default `true`) prints the workflow commands after the existing text report, and the markdown report card is always appended to the job summary. On the run page the summary shows the `## skillsaw report` heading, an error/warning count line, the letter grade with weighted-violation density, and a severity-sorted table of rule / location / message rows.

## Why

Today violations only reach the PR if users wire up the two-workflow review pattern. Annotations and the job summary need **no write permissions and no second workflow** — a single read-only lint step now gives inline-diff feedback and a report card for free. The review action remains the richer tier: it dedups across re-runs, resolves threads when violations are fixed, and comments on lines outside the PR diff (annotations only render inline on diff lines). Docs position the two tiers side by side.

## How

- `src/skillsaw/formatters/github.py`:
  - Workflow-command escaping per the GitHub spec: `%` → `%25`, `\r` → `%0D`, `\n` → `%0A` in messages; additionally `:` → `%3A`, `,` → `%2C` in properties (`%` escaped first so literal `%0A` in a message can't smuggle a newline).
  - `file=` is made relative to `$GITHUB_WORKSPACE` when set and the file is under it (the action's `path` input may be a subdirectory of the checkout), else relative to the lint root.
  - Caps at GitHub's 10-errors + 10-warnings per-step limit, then one `::notice` reporting how many more were found — truncation is never silent. The truncation notice reserves a slot inside the 10-notice cap so it can't itself be dropped.
  - Clean runs emit nothing (no annotation noise).
- `src/skillsaw/formatters/markdown.py`: table cells escape `& < > |` and newlines; info shown under the same `-v` / `fail-on: info` rules as other formats; baseline-suppressed count in the footer.
- `action.yml`: both extra outputs come from the same single lint run (extra `--output` sinks); the text log output is byte-identical to before. A `skillsaw lint --help | grep markdown` guard skips the new flags gracefully if an older skillsaw version is installed, so existing pins keep working.
- Registered in `FORMATS`/`format_report` so `--format`, `--output FORMAT:FILE`, and extension inference all pick them up; `docs/cli.md` regenerated via `make update`.

## Testing

- 30 new unit tests in `tests/test_formatters.py`: message/property escaping, `%`-first ordering, per-severity caps and truncation-notice budgeting, workspace/root path relativity (incl. outside-workspace fallback), info gating, markdown structure/sorting/escaping/truncation/grade/baseline.
- 5 new integration tests in `tests/test_integration.py` against a new realistic fixture (`tests/fixtures/github-annotations/`), pinned to two stable rules with `--rule` for exact output assertions: exact workflow-command lines, `GITHUB_WORKSPACE`-relative paths, `--output markdown:FILE` content, `.md` inference, clean-repo empty output.
- `make test`: 2500 passed. `make lint`: clean. `make update`: regenerated docs committed.
- Verified against openshift-eng/ai-helpers: exit 0 on default, `--format github`, and `--format markdown`; verbose run confirmed real-world `%` escaping and the truncation notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)