### PR TITLE
Close the lint-to-fix loop: fixable markers and fix hints in lint output

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,17 +300,22 @@ generation options.
 Linting: /path/to/skills-repo
 
 Errors:
-  ✗ ERROR [skills/my-skill/SKILL.md]: Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
-  ✗ ERROR [plugins/git/.claude-plugin/plugin.json]: Missing plugin.json
+  ✗ ERROR (agentskill-name) [*] [skills/my-skill/SKILL.md:2]: Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
+  ✗ ERROR (plugin-json-required) [plugins/git/.claude-plugin/plugin.json]: Missing plugin.json
 
 Warnings:
-  ⚠ WARNING [skills/helper/SKILL.md]: Description exceeds 1024 characters (1087)
-  ⚠ WARNING [plugins/utils]: Missing README.md (recommended)
+  ⚠ WARNING (agentskill-description) [skills/helper/SKILL.md:3]: Description exceeds 1024 characters (1087)
+  ⚠ WARNING (plugin-readme) [plugins/utils]: Missing README.md (recommended)
 
 Summary:
   Errors:   2
   Warnings: 2
+  [*] 1 violation(s) fixable with `skillsaw fix`
 ```
+
+Violations that `skillsaw fix` can resolve automatically are marked with
+`[*]` (safe fixes) or `[?]` (suggested fixes, applied with
+`skillsaw fix --suggest`), and the summary counts each kind.
 
 ## Migrating from claudelint
 

--- a/docs/autofixing.md
+++ b/docs/autofixing.md
@@ -17,6 +17,28 @@ Examples: adding missing frontmatter, renaming files to kebab-case, registering 
 
 Some fixes produce cascading changes — for example, renaming a skill name creates stale references in other files. These secondary fixes are marked **SUGGEST** confidence because simple name matching may replace occurrences that aren't actually skill name references. Use `--suggest --dry-run` to review these changes before applying them.
 
+## Fixable Markers in Lint Output
+
+`skillsaw lint` marks each autofixable violation so you know when a fix run is worthwhile, and the summary counts them by confidence:
+
+```
+Errors:
+  ✗ ERROR (agentskill-valid) [*] [skills/deploy/SKILL.md]: Missing required 'name' field
+
+Warnings:
+  ⚠ WARNING (content-broken-internal-reference) [?] [SKILL.md:8]: Broken internal link: [guide](docs/guid.md) — target does not exist (did you mean 'docs/guide.md'?)
+
+Summary:
+  Errors:   1
+  Warnings: 1
+  [*] 1 violation(s) fixable with `skillsaw fix` ([?] 1 more with `skillsaw fix --suggest`)
+```
+
+- `[*]` — a **SAFE** fix exists; `skillsaw fix` resolves it.
+- `[?]` — a **SUGGEST** fix exists; it is only applied with `skillsaw fix --suggest`.
+
+The JSON format carries the same information as an additive `fixable` boolean (plus `fix_confidence`: `safe` or `suggest` when fixable) on each violation. Fixability is per violation, not per rule — a rule that can only fix some shapes of a problem (e.g. `content-unlinked-internal-reference` only wraps references whose target file exists) marks only those violations. Because `skillsaw fix` batches several violations into one fix per file, its `Fixed N issue(s)` count can differ from the number of marked violations.
+
 !!! note "Removed in 0.15"
     The deprecated `skillsaw lint --fix` flag was removed. `skillsaw fix` is the single entry point for autofixes.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,17 +122,22 @@ fingerprinting works and configuration options.
 Linting: /path/to/skills-repo
 
 Errors:
-  ✗ ERROR [skills/my-skill/SKILL.md]: Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
-  ✗ ERROR [plugins/git/.claude-plugin/plugin.json]: Missing plugin.json
+  ✗ ERROR (agentskill-name) [*] [skills/my-skill/SKILL.md:2]: Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
+  ✗ ERROR (plugin-json-required) [plugins/git/.claude-plugin/plugin.json]: Missing plugin.json
 
 Warnings:
-  ⚠ WARNING [skills/helper/SKILL.md]: Description exceeds 1024 characters (1087)
-  ⚠ WARNING [plugins/utils]: Missing README.md (recommended)
+  ⚠ WARNING (agentskill-description) [skills/helper/SKILL.md:3]: Description exceeds 1024 characters (1087)
+  ⚠ WARNING (plugin-readme) [plugins/utils]: Missing README.md (recommended)
 
 Summary:
   Errors:   2
   Warnings: 2
+  [*] 1 violation(s) fixable with `skillsaw fix`
 ```
+
+Violations that `skillsaw fix` can resolve automatically are marked with
+`[*]` (safe fixes) or `[?]` (suggested fixes, applied with
+`skillsaw fix --suggest`) — see [Autofixing](autofixing.md).
 
 ## Exit Codes
 

--- a/src/skillsaw/cli/_fix.py
+++ b/src/skillsaw/cli/_fix.py
@@ -16,6 +16,14 @@ from ._helpers import (
 )
 
 
+def _rel(path, root):
+    """Repo-relative display path, matching lint output style."""
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
 def _run_fix(args):
     missing = [p for p in args.path if not p.exists()]
     for p in missing:
@@ -84,20 +92,23 @@ def _run_fix(args):
             path_suggested.extend(rename_suggested)
 
         applied.extend((f, context.root_path) for f in path_applied)
-        suggested.extend(path_suggested)
+        suggested.extend((f, context.root_path) for f in path_suggested)
 
     c = _ansi_colors()
+
+    # Single-root runs print repo-relative paths, matching lint output.
+    # Multi-root runs keep absolute paths — the same relative name in two
+    # repos (e.g. CLAUDE.md) would be ambiguous.
+    def _display(file_path, root):
+        return _rel(file_path, root) if len(paths) == 1 else file_path
 
     if applied:
         label = "Would fix" if dry_run else "Fixed"
         print(f"{label} {len(applied)} issue(s):")
         for fix, root in applied:
-            print(f"  {c['bold']}✓ [{fix.file_path}] {fix.description}{c['reset']}")
+            rel = _rel(fix.file_path, root)
+            print(f"  {c['bold']}✓ [{_display(fix.file_path, root)}] {fix.description}{c['reset']}")
             if dry_run and fix.original_content != fix.fixed_content:
-                try:
-                    rel = fix.file_path.relative_to(root)
-                except ValueError:
-                    rel = fix.file_path
                 diff_lines = difflib.unified_diff(
                     fix.original_content.splitlines(keepends=True),
                     fix.fixed_content.splitlines(keepends=True),
@@ -120,12 +131,15 @@ def _run_fix(args):
 
     if suggested:
         print(f"\nSuggested fixes ({len(suggested)} — review before applying):")
-        for fix in suggested:
-            print(f"  ? [{fix.file_path}] {fix.description}")
+        for fix, root in suggested:
+            print(f"  ? [{_display(fix.file_path, root)}] {fix.description}")
         print("\nRun `skillsaw fix --suggest` to apply suggested fixes.")
         print("Run `skillsaw fix --suggest --dry-run` to preview changes.")
 
     if dry_run and applied:
         print(f"\n{c['yellow']}dry-run — no files were modified{c['reset']}")
+
+    if applied and not dry_run:
+        print("\nRun `skillsaw lint` to see remaining issues.")
 
     sys.exit(0)

--- a/src/skillsaw/formatters/html.py
+++ b/src/skillsaw/formatters/html.py
@@ -3,7 +3,7 @@
 import html
 from typing import List
 
-from ..rule import Rule, RuleViolation, Severity
+from ..rule import AutofixConfidence, Rule, RuleViolation, Severity
 from . import get_counts, relative_path, should_show_info
 
 
@@ -47,12 +47,22 @@ def format_html(
         key=lambda v: (severity_order[v.severity], str(v.file_path or ""), v.file_line or 0)
     )
 
+    def fix_marker(v: RuleViolation) -> str:
+        if not v.fixable:
+            return ""
+        cmd = (
+            "skillsaw fix"
+            if v.fix_confidence == AutofixConfidence.SAFE
+            else "skillsaw fix --suggest"
+        )
+        return f' <span class="fixable" title="fixable with {cmd}">*</span>'
+
     rows = ""
     for v in visible:
         rows += (
             "<tr>"
             f"<td>{severity_badge(v.severity)}</td>"
-            f"<td><code>{html.escape(v.rule_id)}</code></td>"
+            f"<td><code>{html.escape(v.rule_id)}</code>{fix_marker(v)}</td>"
             f"<td>{location(v)}</td>"
             f"<td>{html.escape(v.message)}</td>"
             "</tr>\n"
@@ -192,6 +202,11 @@ def format_html(
     }}
     .count-item {{
       font-weight: 600;
+    }}
+    .fixable {{
+      color: #2f9e44;
+      font-weight: 700;
+      cursor: help;
     }}
     .count-error {{ color: #dc3545; }}
     .count-warning {{ color: #e8a317; }}

--- a/src/skillsaw/formatters/json_fmt.py
+++ b/src/skillsaw/formatters/json_fmt.py
@@ -43,20 +43,28 @@ def format_json(
     if duration is not None:
         stats["duration_seconds"] = round(duration, 3)
 
+    def violation_entry(v: RuleViolation) -> dict:
+        entry = {
+            "rule_id": v.rule_id,
+            "severity": v.severity.value,
+            "message": v.message,
+            "file_path": relative_path(v.file_path, context.root_path),
+            "line": v.file_line,
+            "source": v.source,
+        }
+        # Additive: omitted when fixability is unknown (e.g. synthetic
+        # violations); fix_confidence only accompanies fixable violations.
+        if v.fixable is not None:
+            entry["fixable"] = v.fixable
+            if v.fixable and v.fix_confidence is not None:
+                entry["fix_confidence"] = v.fix_confidence.value
+        return entry
+
     report = {
         "version": version,
         "stats": stats,
         "violations": [
-            {
-                "rule_id": v.rule_id,
-                "severity": v.severity.value,
-                "message": v.message,
-                "file_path": relative_path(v.file_path, context.root_path),
-                "line": v.file_line,
-                "source": v.source,
-            }
-            for v in violations
-            if show_info or v.severity != Severity.INFO
+            violation_entry(v) for v in violations if show_info or v.severity != Severity.INFO
         ],
         "summary": {
             "errors": errors,

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -5,7 +5,7 @@ Text output formatter — human-readable terminal output with optional ANSI colo
 import os
 from typing import List, Optional
 
-from ..rule import Rule, RuleViolation, Severity
+from ..rule import AutofixConfidence, Rule, RuleViolation, Severity
 from ..rule_docs import rule_doc_url
 from . import get_counts, relative_path, should_show_info
 
@@ -46,13 +46,21 @@ def format_text(
     warnings_list = [v for v in violations if v.severity == Severity.WARNING]
     info_list = [v for v in violations if v.severity == Severity.INFO]
 
+    def fix_marker(v: RuleViolation) -> str:
+        """Ruff-style fixability marker: [*] safe, [?] needs --suggest."""
+        if not v.fixable:
+            return ""
+        return " [*]" if v.fix_confidence == AutofixConfidence.SAFE else " [?]"
+
     def fmt_violation(v: RuleViolation) -> str:
         icon = {"error": "✗", "warning": "⚠", "info": "ℹ"}[v.severity.value]
         rel = relative_path(v.file_path, context.root_path)
         location = ""
         if rel:
             location = f" [{rel}:{v.file_line}]" if v.file_line else f" [{rel}]"
-        return f"{icon} {v.severity.value.upper()} ({v.rule_id}){location}: {v.message}"
+        return (
+            f"{icon} {v.severity.value.upper()} ({v.rule_id}){fix_marker(v)}{location}: {v.message}"
+        )
 
     output = []
 
@@ -110,6 +118,28 @@ def format_text(
                 f"  {dim}{grade.info} info-level violation(s) count toward"
                 f" the grade — run with -v to see them{reset}"
             )
+
+    # Legend for the [*]/[?] markers and the lint-to-fix hint. Counts are
+    # over the violations shown above, so marked lines and counts agree
+    # (`skillsaw fix` groups per-file fixes and may report different totals).
+    safe_fixable = sum(1 for v in shown if v.fixable and v.fix_confidence == AutofixConfidence.SAFE)
+    suggest_fixable = sum(
+        1 for v in shown if v.fixable and v.fix_confidence != AutofixConfidence.SAFE
+    )
+    if safe_fixable and suggest_fixable:
+        output.append(
+            f"  {green}[*] {safe_fixable} violation(s) fixable with `skillsaw fix`"
+            f" ([?] {suggest_fixable} more with `skillsaw fix --suggest`){reset}"
+        )
+    elif safe_fixable:
+        output.append(
+            f"  {green}[*] {safe_fixable} violation(s) fixable with `skillsaw fix`{reset}"
+        )
+    elif suggest_fixable:
+        output.append(
+            f"  {green}[?] {suggest_fixable} violation(s) fixable with"
+            f" `skillsaw fix --suggest`{reset}"
+        )
 
     if errors == 0 and warnings == 0 and (fail_level != "info" or info == 0):
         output.append(f"\n{green}{bold}✓ All checks passed!{reset}")

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -43,6 +43,13 @@ class RuleViolation:
     # don't collide. Example: context-budget emits whole-file and
     # per-description token violations for the same SKILL.md.
     metric: Optional[str] = None
+    # Whether ``skillsaw fix`` can resolve this violation. None means
+    # unknown — e.g. synthetic violations constructed outside
+    # ``Rule.violation()``.
+    fixable: Optional[bool] = None
+    # Confidence of the fix when ``fixable``: SAFE fixes apply with plain
+    # ``skillsaw fix``, SUGGEST fixes require ``--suggest``.
+    fix_confidence: Optional["AutofixConfidence"] = None
 
     def __post_init__(self):
         if self.block is None and self.file_path is not None:
@@ -195,13 +202,25 @@ class Rule(ABC):
         block: Optional["ContentBlock"] = None,
         value: Optional[float] = None,
         metric: Optional[str] = None,
+        fixable: Optional[bool] = None,
+        fix_confidence: Optional[AutofixConfidence] = None,
     ) -> RuleViolation:
         """Create a violation for this rule.
 
         Pass ``block`` for content-based violations.  ``file_path`` is
         accepted for backward compatibility and auto-wraps into a block.
         ``metric`` disambiguates multiple ratchet violations per file.
+
+        ``fixable`` defaults from the rule: True when the rule overrides
+        ``fix()`` and declares a class-level ``autofix_confidence``.  Rules
+        whose ``fix()`` only repairs a subset of their violations must pass
+        ``fixable`` explicitly so lint output doesn't over-promise; rules
+        without a class-level confidence must also pass ``fix_confidence``.
         """
+        if fixable is None:
+            fixable = self.supports_autofix and self.autofix_confidence is not None
+        if fix_confidence is None and fixable:
+            fix_confidence = self.autofix_confidence
         return RuleViolation(
             rule_id=self.rule_id,
             severity=severity if severity is not None else self.severity,
@@ -212,4 +231,6 @@ class Rule(ABC):
             source=self._source,
             value=value,
             metric=metric,
+            fixable=fixable,
+            fix_confidence=fix_confidence,
         )

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -214,13 +214,15 @@ class Rule(ABC):
         ``fixable`` defaults from the rule: True when the rule overrides
         ``fix()`` and declares a class-level ``autofix_confidence``.  Rules
         whose ``fix()`` only repairs a subset of their violations must pass
-        ``fixable`` explicitly so lint output doesn't over-promise; rules
-        without a class-level confidence must also pass ``fix_confidence``.
+        ``fixable`` explicitly so lint output doesn't over-promise.
         """
         if fixable is None:
             fixable = self.supports_autofix and self.autofix_confidence is not None
         if fix_confidence is None and fixable:
-            fix_confidence = self.autofix_confidence
+            # Unknown confidence falls back to SUGGEST so every fixable
+            # violation carries one and no format over-promises what a
+            # plain `skillsaw fix` run will clear.
+            fix_confidence = self.autofix_confidence or AutofixConfidence.SUGGEST
         return RuleViolation(
             rule_id=self.rule_id,
             severity=severity if severity is not None else self.severity,

--- a/src/skillsaw/rules/builtin/agents/frontmatter.py
+++ b/src/skillsaw/rules/builtin/agents/frontmatter.py
@@ -36,12 +36,15 @@ class AgentFrontmatterRule(Rule):
 
         for block in context.lint_tree.find(AgentBlock):
             if block.frontmatter_error:
+                # fix() only adds missing frontmatter/fields — malformed YAML
+                # needs a human.
                 violations.append(
                     self.violation(
                         block.frontmatter_error,
                         file_path=block.path,
                         line=block.frontmatter_error_line,
                         block=block,
+                        fixable=False,
                     )
                 )
                 continue

--- a/src/skillsaw/rules/builtin/agentskills/rename_refs.py
+++ b/src/skillsaw/rules/builtin/agentskills/rename_refs.py
@@ -70,6 +70,20 @@ class AgentSkillRenameRefsRule(Rule):
         pattern_specs = [(patterns[r["old"]], r) for r in renames]
         referenced_olds: set[str] = set()
 
+        # fix() skips old names below autofix-min-segments (too ambiguous to
+        # rewrite), so only references to longer names are fixable. There is
+        # no class-level autofix_confidence, so the SUGGEST confidence of the
+        # produced fixes is declared per violation.
+        min_segments = self.config.get(
+            "autofix-min-segments",
+            self.config_schema["autofix-min-segments"]["default"],
+        )
+
+        def _fix_kwargs(old_name: str) -> dict:
+            if len(old_name.split("-")) >= min_segments:
+                return {"fixable": True, "fix_confidence": AutofixConfidence.SUGGEST}
+            return {"fixable": False}
+
         for block in gather_all_content_blocks(context):
             try:
                 content = block.path.read_text(encoding="utf-8")
@@ -92,6 +106,7 @@ class AgentSkillRenameRefsRule(Rule):
                             f"Stale reference to renamed skill '{old}' " f"(renamed to '{new}')",
                             file_path=block.path,
                             line=line_no,
+                            **_fix_kwargs(old),
                         )
                     )
                     referenced_olds.add(old)
@@ -115,6 +130,7 @@ class AgentSkillRenameRefsRule(Rule):
                         f"evals.json 'skill_name' ({skill_name!r}) references "
                         f"renamed skill (now '{rename['new']}')",
                         file_path=evals_json,
+                        **_fix_kwargs(skill_name),
                     )
                 )
                 referenced_olds.add(skill_name)

--- a/src/skillsaw/rules/builtin/agentskills/valid.py
+++ b/src/skillsaw/rules/builtin/agentskills/valid.py
@@ -280,4 +280,11 @@ class AgentSkillValidRule(Rule):
                                 )
                             )
 
+        # fix() only repairs the missing-name case (it derives the name from
+        # the directory); every other violation needs a human.
+        for v in violations:
+            if "Missing required 'name'" not in v.message:
+                v.fixable = False
+                v.fix_confidence = None
+
         return violations

--- a/src/skillsaw/rules/builtin/commands/frontmatter.py
+++ b/src/skillsaw/rules/builtin/commands/frontmatter.py
@@ -32,11 +32,14 @@ class CommandFrontmatterRule(Rule):
 
         for block in context.lint_tree.find(CommandBlock):
             if block.frontmatter_error:
+                # fix() only adds missing frontmatter/fields — malformed YAML
+                # needs a human.
                 violations.append(
                     self.violation(
                         block.frontmatter_error,
                         block=block,
                         line=block.frontmatter_error_line,
+                        fixable=False,
                     )
                 )
                 continue

--- a/src/skillsaw/rules/builtin/commands/naming.py
+++ b/src/skillsaw/rules/builtin/commands/naming.py
@@ -34,9 +34,14 @@ class CommandNamingRule(Rule):
             cmd_file = cmd_block.path
             cmd_name = cmd_file.stem
             if not self._is_kebab_case(cmd_name):
+                # fix() renames only when kebab-casing yields a distinct,
+                # valid name (e.g. '9lives' has no kebab form).
+                kebab = self._to_kebab(cmd_name)
                 violations.append(
                     self.violation(
-                        f"Command name '{cmd_name}' should use kebab-case", file_path=cmd_file
+                        f"Command name '{cmd_name}' should use kebab-case",
+                        file_path=cmd_file,
+                        fixable=self._is_kebab_case(kebab) and kebab != cmd_name,
                     )
                 )
 

--- a/src/skillsaw/rules/builtin/content/broken_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/broken_internal_reference.py
@@ -87,6 +87,7 @@ class ContentBrokenInternalReferenceRule(Rule):
                             f"Broken internal link: [{link.text}]({target}) — target does not exist",
                             block=cf,
                             line=link.body_line,
+                            fixable=False,
                         )
                     )
                     continue
@@ -99,6 +100,7 @@ class ContentBrokenInternalReferenceRule(Rule):
                             f"Broken internal link: [{link.text}]({target}) — target is outside repository",
                             block=cf,
                             line=link.body_line,
+                            fixable=False,
                         )
                     )
                     continue
@@ -109,7 +111,16 @@ class ContentBrokenInternalReferenceRule(Rule):
                         msg += f" (did you mean '{suggestion}'?)"
                     elif not link.has_dest_span:
                         msg += " (reference-style link — fix the definition manually)"
-                    violations.append(self.violation(msg, block=cf, line=link.body_line))
+                    # fix() only rewrites links that have a fuzzy-match
+                    # suggestion and an inline destination span.
+                    violations.append(
+                        self.violation(
+                            msg,
+                            block=cf,
+                            line=link.body_line,
+                            fixable=suggestion is not None and link.has_dest_span,
+                        )
+                    )
         return violations
 
     @staticmethod

--- a/src/skillsaw/rules/builtin/content/unlinked_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/unlinked_internal_reference.py
@@ -139,7 +139,10 @@ class ContentUnlinkedInternalReferenceRule(Rule):
                 msg = f"Unlinked path reference: '{path_str}' — consider wrapping in link syntax [{path_str}]({path_str})"
                 if file_exists:
                     msg += " (file exists, autofixable)"
-                violations.append(self.violation(msg, block=cf, line=body_line))
+                # fix() only wraps references whose target exists on disk.
+                violations.append(
+                    self.violation(msg, block=cf, line=body_line, fixable=file_exists)
+                )
         return violations
 
     def fix(

--- a/src/skillsaw/rules/builtin/skills/frontmatter.py
+++ b/src/skillsaw/rules/builtin/skills/frontmatter.py
@@ -43,12 +43,15 @@ class SkillFrontmatterRule(Rule):
 
             block = blocks[0]
             if block.frontmatter_error:
+                # fix() only adds missing frontmatter/fields — malformed YAML
+                # needs a human.
                 violations.append(
                     self.violation(
                         block.frontmatter_error,
                         file_path=block.path,
                         line=block.frontmatter_error_line,
                         block=block,
+                        fixable=False,
                     )
                 )
                 continue

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -222,6 +222,47 @@ class TestRuleSupportsAutofix:
         assert rule.fix(context, []) == []
 
 
+class TestViolationFixability:
+    """Rule.violation() defaults fixable from supports_autofix + confidence."""
+
+    class DeclaredSafeRule(SafeFixRule):
+        autofix_confidence = AutofixConfidence.SAFE
+
+    def test_rule_without_fix_is_not_fixable(self):
+        v = NoFixRule().violation("something wrong")
+        assert v.fixable is False
+        assert v.fix_confidence is None
+
+    def test_fix_without_declared_confidence_is_not_fixable_by_default(self):
+        # No class-level autofix_confidence means the SAFE/SUGGEST split is
+        # unknowable at check() time — such rules must opt in per violation.
+        v = SafeFixRule().violation("Contains BAD")
+        assert v.fixable is False
+        assert v.fix_confidence is None
+
+    def test_fix_with_declared_confidence_is_fixable(self):
+        v = self.DeclaredSafeRule().violation("Contains BAD")
+        assert v.fixable is True
+        assert v.fix_confidence == AutofixConfidence.SAFE
+
+    def test_explicit_fixable_false_overrides_default(self):
+        v = self.DeclaredSafeRule().violation("Contains BAD", fixable=False)
+        assert v.fixable is False
+        assert v.fix_confidence is None
+
+    def test_explicit_fixable_true_uses_class_confidence(self):
+        v = SafeFixRule().violation(
+            "Contains BAD", fixable=True, fix_confidence=AutofixConfidence.SUGGEST
+        )
+        assert v.fixable is True
+        assert v.fix_confidence == AutofixConfidence.SUGGEST
+
+    def test_direct_construction_leaves_fixability_unknown(self):
+        v = RuleViolation(rule_id="synthetic", severity=Severity.ERROR, message="boom")
+        assert v.fixable is None
+        assert v.fix_confidence is None
+
+
 class TestLinterFix:
     def test_fix_with_no_violations(self, valid_plugin):
         context = RepositoryContext(valid_plugin)

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -257,6 +257,13 @@ class TestViolationFixability:
         assert v.fixable is True
         assert v.fix_confidence == AutofixConfidence.SUGGEST
 
+    def test_explicit_fixable_true_without_confidence_falls_back_to_suggest(self):
+        # SafeFixRule has no class-level autofix_confidence — the fallback
+        # must never over-promise what a plain `skillsaw fix` run clears.
+        v = SafeFixRule().violation("Contains BAD", fixable=True)
+        assert v.fixable is True
+        assert v.fix_confidence == AutofixConfidence.SUGGEST
+
     def test_direct_construction_leaves_fixability_unknown(self):
         v = RuleViolation(rule_id="synthetic", severity=Severity.ERROR, message="boom")
         assert v.fixable is None
@@ -995,3 +1002,68 @@ class TestAgentFixMissingFrontmatterBlock:
         agent_md.write_text(fixes[0].fixed_content)
         invalidate_read_caches()
         assert rule.check(RepositoryContext(plugin_dir)) == []
+
+
+class TestFixCliOutput:
+    """In-process `skillsaw fix` runs: display paths and the re-lint hint."""
+
+    @staticmethod
+    def _make_repo(tmp_path, name):
+        repo = tmp_path / name
+        cmd_dir = repo / ".claude" / "commands"
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "deploy.md").write_text(
+            "# Deploy\n\n"
+            "Deploy the application to production.\n\n"
+            "See [the guide](docs/guid.md) for the full deployment checklist.\n"
+        )
+        docs = repo / "docs"
+        docs.mkdir()
+        (docs / "guide.md").write_text("# Guide\n\nDeployment steps live here.\n")
+        return repo
+
+    @staticmethod
+    def _run_cli(monkeypatch, capsys, *argv):
+        import sys
+
+        import skillsaw.cli as cli
+
+        monkeypatch.setattr(sys, "argv", ["skillsaw", "fix", *[str(a) for a in argv]])
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        return capsys.readouterr().out
+
+    def test_single_root_prints_relative_paths_and_relint_hint(self, tmp_path, monkeypatch, capsys):
+        repo = self._make_repo(tmp_path, "repo")
+        invalidate_read_caches()
+
+        out = self._run_cli(monkeypatch, capsys, repo)
+
+        # Applied and suggested fixes both print repo-relative paths.
+        assert "✓ [.claude/commands/deploy.md]" in out
+        assert "? [.claude/commands/deploy.md]" in out
+        assert str(repo) not in out, "fix output leaked absolute paths"
+        assert "Run `skillsaw lint` to see remaining issues." in out
+
+    def test_multi_root_keeps_absolute_paths(self, tmp_path, monkeypatch, capsys):
+        repo1 = self._make_repo(tmp_path, "repo-one")
+        repo2 = self._make_repo(tmp_path, "repo-two")
+        invalidate_read_caches()
+
+        out = self._run_cli(monkeypatch, capsys, repo1, repo2)
+
+        # The same relative name exists in both repos — output must
+        # disambiguate with absolute paths.
+        assert f"✓ [{repo1 / '.claude/commands/deploy.md'}]" in out
+        assert f"✓ [{repo2 / '.claude/commands/deploy.md'}]" in out
+
+    def test_no_relint_hint_on_dry_run(self, tmp_path, monkeypatch, capsys):
+        repo = self._make_repo(tmp_path, "repo")
+        invalidate_read_caches()
+
+        out = self._run_cli(monkeypatch, capsys, "--dry-run", repo)
+
+        assert "Would fix" in out
+        assert "dry-run — no files were modified" in out
+        assert "Run `skillsaw lint` to see remaining issues." not in out

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,7 +11,7 @@ from skillsaw.formatters.json_fmt import format_json
 from skillsaw.formatters.sarif import format_sarif
 from skillsaw.formatters.html import format_html
 from skillsaw.formatters.code_climate import format_code_climate
-from skillsaw.rule import RuleViolation, Severity
+from skillsaw.rule import AutofixConfidence, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.config import LinterConfig
 from skillsaw.linter import Linter
@@ -921,3 +921,184 @@ def test_json_includes_duration(valid_plugin):
 
     report = json.loads(format_json(violations, context, linter.rules, "0.0.0"))
     assert "duration_seconds" not in report["stats"]
+
+
+# --- Fixable markers and fix hints ---
+
+
+def _make_fixable_violations():
+    """One SAFE-fixable error, one SAFE-fixable warning shown as error,
+    one SUGGEST-fixable warning, one explicitly unfixable error."""
+    return [
+        RuleViolation(
+            rule_id="agentskill-valid",
+            severity=Severity.ERROR,
+            message="Missing required 'name' field",
+            file_path=Path("skills/foo/SKILL.md"),
+            fixable=True,
+            fix_confidence=AutofixConfidence.SAFE,
+        ),
+        RuleViolation(
+            rule_id="agent-frontmatter",
+            severity=Severity.ERROR,
+            message="Missing 'description' in frontmatter",
+            file_path=Path("agents/bar.md"),
+            fixable=True,
+            fix_confidence=AutofixConfidence.SAFE,
+        ),
+        RuleViolation(
+            rule_id="content-broken-internal-reference",
+            severity=Severity.WARNING,
+            message="Broken internal link (did you mean 'docs/guide.md'?)",
+            file_path=Path("SKILL.md"),
+            line=8,
+            fixable=True,
+            fix_confidence=AutofixConfidence.SUGGEST,
+        ),
+        RuleViolation(
+            rule_id="agentskill-valid",
+            severity=Severity.ERROR,
+            message="'description' must be a string",
+            file_path=Path("skills/baz/SKILL.md"),
+            fixable=False,
+        ),
+    ]
+
+
+def test_text_marks_safe_fixable_violations(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+
+    assert "(agentskill-valid) [*] [skills/foo/SKILL.md]:" in output
+    assert "(agent-frontmatter) [*] [agents/bar.md]:" in output
+
+
+def test_text_marks_suggest_fixable_violations(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+
+    assert "(content-broken-internal-reference) [?] [SKILL.md:8]:" in output
+
+
+def test_text_no_marker_on_unfixable_violation(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+
+    # Same rule id as a marked violation — only the fixable one is marked.
+    assert "(agentskill-valid) [skills/baz/SKILL.md]:" in output
+
+
+def test_text_no_marker_when_fixability_unknown(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    # _make_violations leaves fixable=None (e.g. synthetic violations).
+    output = format_text(_make_violations(), context, [], "0.0.0", verbose=True)
+
+    assert "[*]" not in output
+    assert "[?]" not in output
+    assert "fixable with" not in output
+
+
+def test_text_fixable_summary_splits_safe_and_suggest(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+
+    assert (
+        "[*] 2 violation(s) fixable with `skillsaw fix`"
+        " ([?] 1 more with `skillsaw fix --suggest`)" in output
+    )
+
+
+def test_text_fixable_summary_safe_only(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        v for v in _make_fixable_violations() if v.fix_confidence != AutofixConfidence.SUGGEST
+    ]
+    output = format_text(violations, context, [], "0.0.0")
+
+    assert "[*] 2 violation(s) fixable with `skillsaw fix`" in output
+    assert "--suggest" not in output
+
+
+def test_text_fixable_summary_suggest_only(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        v for v in _make_fixable_violations() if v.fix_confidence != AutofixConfidence.SAFE
+    ]
+    output = format_text(violations, context, [], "0.0.0")
+
+    assert "[?] 1 violation(s) fixable with `skillsaw fix --suggest`" in output
+    assert "[*]" not in output
+
+
+def test_text_fixable_summary_counts_only_shown_violations(valid_plugin):
+    """A hidden info-level fixable violation must not inflate the summary —
+    the counts must match the marked lines above them."""
+    context = RepositoryContext(valid_plugin)
+    violations = [
+        RuleViolation(
+            rule_id="content-unlinked-internal-reference",
+            severity=Severity.INFO,
+            message="Unlinked path reference: 'docs/x.md' (file exists, autofixable)",
+            file_path=Path("SKILL.md"),
+            line=3,
+            fixable=True,
+            fix_confidence=AutofixConfidence.SAFE,
+        ),
+    ]
+
+    hidden = format_text(violations, context, [], "0.0.0", verbose=False)
+    assert "fixable with" not in hidden
+
+    shown = format_text(violations, context, [], "0.0.0", verbose=True)
+    assert "[*] 1 violation(s) fixable with `skillsaw fix`" in shown
+
+
+def test_json_fixable_true_includes_confidence(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    report = json.loads(format_json(_make_fixable_violations(), context, [], "0.0.0"))
+
+    safe = next(v for v in report["violations"] if v["rule_id"] == "agent-frontmatter")
+    assert safe["fixable"] is True
+    assert safe["fix_confidence"] == "safe"
+
+    suggest = next(
+        v for v in report["violations"] if v["rule_id"] == "content-broken-internal-reference"
+    )
+    assert suggest["fixable"] is True
+    assert suggest["fix_confidence"] == "suggest"
+
+
+def test_json_fixable_false_omits_confidence(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    report = json.loads(format_json(_make_fixable_violations(), context, [], "0.0.0"))
+
+    unfixable = next(
+        v for v in report["violations"] if v["message"] == "'description' must be a string"
+    )
+    assert unfixable["fixable"] is False
+    assert "fix_confidence" not in unfixable
+
+
+def test_json_fixable_absent_when_unknown(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    # _make_violations leaves fixable=None (e.g. synthetic violations).
+    report = json.loads(format_json(_make_violations(), context, [], "0.0.0", verbose=True))
+
+    for v in report["violations"]:
+        assert "fixable" not in v
+        assert "fix_confidence" not in v
+
+
+def test_html_fixable_marker(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_html(_make_fixable_violations(), context, [], "1.0.0")
+
+    assert 'title="fixable with skillsaw fix"' in output
+    assert 'title="fixable with skillsaw fix --suggest"' in output
+
+
+def test_html_no_fixable_marker_when_unknown(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_html(_make_violations(), context, [], "1.0.0", verbose=True)
+
+    assert 'class="fixable"' not in output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2375,6 +2375,87 @@ class TestSafeAutofixIdempotency:
 
 
 @pytest.mark.integration
+class TestLintFixLoop:
+    """Lint output advertises fixability and fix output closes the loop."""
+
+    FIXTURE = "autofix/safe-idempotency"
+
+    def test_text_lint_marks_fixable_violations(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, fmt="text", verbose=False)
+
+        # SAFE-autofixable rules carry the [*] marker after the rule id.
+        assert "(agent-frontmatter) [*]" in r["stdout"]
+        assert "(command-frontmatter) [*]" in r["stdout"]
+        # Rules without an autofix never get a marker.
+        assert "(agentskill-unreferenced-files) [*]" not in r["stdout"]
+        assert "(agentskill-unreferenced-files) [?]" not in r["stdout"]
+        # agentskill-valid only fixes the missing-name subset.
+        assert (
+            "(agentskill-valid) [*] [skills/missing-name/SKILL.md]: "
+            "Missing required 'name' field" in r["stdout"]
+        )
+        assert (
+            "(agentskill-valid) [skills/no-frontmatter/SKILL.md]: "
+            "Missing YAML frontmatter" in r["stdout"]
+        )
+
+    def test_text_lint_summary_shows_fixable_count(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo, fmt="text", verbose=False)
+
+        m = re.search(r"\[\*\] (\d+) violation\(s\) fixable with `skillsaw fix`", r["stdout"])
+        assert m, f"missing fixable summary line in:\n{r['stdout']}"
+        # The count matches the [*]-marked violation lines above it.
+        assert int(m.group(1)) == r["stdout"].count("[*]") - 1
+
+    def test_json_lint_reports_fixable_per_violation(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        r = run_lint(repo)
+        grouped = by_rule(r)
+
+        for v in grouped["agent-frontmatter"]:
+            assert v["fixable"] is True
+            assert v["fix_confidence"] == "safe"
+
+        # agentskill-valid: only the missing-name subset is fixable.
+        for v in grouped["agentskill-valid"]:
+            if "Missing required 'name'" in v["message"]:
+                assert v["fixable"] is True
+                assert v["fix_confidence"] == "safe"
+            else:
+                assert v["fixable"] is False
+                assert "fix_confidence" not in v
+
+        # content-unlinked-internal-reference: fixable iff the target exists.
+        unlinked = grouped["content-unlinked-internal-reference"]
+        assert any(v["fixable"] for v in unlinked)
+        for v in unlinked:
+            assert v["fixable"] == ("autofixable" in v["message"])
+
+        # Rules without an autofix report fixable: false, no confidence.
+        for v in grouped["agentskill-unreferenced-files"]:
+            assert v["fixable"] is False
+            assert "fix_confidence" not in v
+
+    def test_fix_output_uses_relative_paths_and_hints_relint(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = _run_fix(repo)
+
+        assert "✓ [agents/no-fm-agent.md]" in result.stdout
+        assert str(repo) not in result.stdout, "fix output leaked absolute paths"
+        assert "Run `skillsaw lint` to see remaining issues." in result.stdout
+
+    def test_fix_no_relint_hint_when_nothing_fixed(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        _run_fix(repo)
+        result = _run_fix(repo)
+
+        assert "No auto-fixable violations found" in result.stdout
+        assert "Run `skillsaw lint`" not in result.stdout
+
+
+@pytest.mark.integration
 class TestRuleFilter:
     """Tests for --rule flag filtering."""
 


### PR DESCRIPTION
## What

`skillsaw lint` now tells you which violations `skillsaw fix` can resolve — ruff's killer affordance, previously missing entirely. Fixable violations get a `[*]` (SAFE) or `[?]` (SUGGEST) marker after the rule id, the summary counts each kind separately, JSON output carries an additive `fixable`/`fix_confidence` field per violation, and `skillsaw fix` output now matches lint's repo-relative path style and closes the loop with a re-lint hint.

## Why

Linting `tests/fixtures/autofix/safe-idempotency` reported 16 errors with zero indication that a single `skillsaw fix` run would clear almost all of them. Nothing in any formatter mentioned fixability, and fix output printed absolute paths that didn't match lint's relative style. Users had no way to discover the fix loop without reading the docs.

The SAFE/SUGGEST split in the summary is deliberate: a single combined count would confuse users when plain `skillsaw fix` doesn't clear SUGGEST-only violations.

## How

- **`RuleViolation.fixable` / `fix_confidence`** (`src/skillsaw/rule.py`): defaulted in `Rule.violation()` from the rule's `supports_autofix` + class-level `autofix_confidence`, overridable per violation. Rules with `fix()` but no declared class confidence default to not-fixable (the SAFE/SUGGEST split is unknowable) and must opt in per violation.
- **Per-violation honesty audit** of every rule that overrides `fix()`:
  - `agent-frontmatter` / `command-frontmatter` / `skill-frontmatter`: malformed-YAML violations are not fixable, only missing frontmatter/fields.
  - `agentskill-valid`: only the missing-`name` case is fixable.
  - `content-unlinked-internal-reference`: fixable only when the target file exists.
  - `content-broken-internal-reference`: fixable only with a fuzzy-match suggestion on an inline-destination link.
  - `command-naming`: fixable only when kebab-casing yields a distinct valid name.
  - `agentskill-rename-refs`: fixable only above `autofix-min-segments`, declared SUGGEST per violation (no class confidence).
  - `agentskill-name`, `marketplace-registration`: class defaults are already honest.
- **Text formatter**: marker + green legend/summary line, wired through the existing NO_COLOR handling. Counts are over the violations shown, so marked lines and counts always agree; wording counts *violations* since `skillsaw fix` groups per-file fixes and reports different totals ("Fixed 17 issue(s)" vs 18 marked violations on the same fixture — expected, not a bug).
- **JSON formatter**: additive `"fixable": true|false` (omitted when unknown, e.g. synthetic violations) plus `"fix_confidence": "safe"|"suggest"` when fixable. SARIF and code-climate untouched — their schemas have no slot.
- **HTML formatter**: small green `*` with a tooltip next to fixable rule ids.
- **`cli/_fix.py`**: reuses the existing relative-path computation for the `Fixed`/`Suggested` lines (single-root runs; multi-root runs keep absolute paths since `CLAUDE.md` in two repos would be ambiguous) and prints ``Run `skillsaw lint` to see remaining issues.`` after applying fixes.

## Before / After

`skillsaw lint` on the safe-idempotency fixture, before:

```
Errors:
  ✗ ERROR (agentskill-valid) [skills/missing-name/SKILL.md]: Missing required 'name' field
  ✗ ERROR (agentskill-valid) [skills/no-frontmatter/SKILL.md]: Missing YAML frontmatter (must start with ---)

Summary:
  Errors:   16
  Warnings: 4
```

After:

```
Errors:
  ✗ ERROR (agentskill-valid) [*] [skills/missing-name/SKILL.md]: Missing required 'name' field
  ✗ ERROR (agentskill-valid) [skills/no-frontmatter/SKILL.md]: Missing YAML frontmatter (must start with ---)

Summary:
  Errors:   16
  Warnings: 4
  [*] 18 violation(s) fixable with `skillsaw fix`
```

With a SUGGEST-fixable broken link in the mix:

```
  ⚠ WARNING (content-broken-internal-reference) [?] [SKILL.md:8]: Broken internal link: [the guide](docs/guid.md) — target does not exist (did you mean 'docs/guide.md'?)
  [*] 1 violation(s) fixable with `skillsaw fix` ([?] 1 more with `skillsaw fix --suggest`)
```

`skillsaw fix`, before:

```
Fixed 17 issue(s):
  ✓ [/tmp/.../si-test/agents/no-desc-agent.md] Added missing fields to agent frontmatter
```

After:

```
Fixed 17 issue(s):
  ✓ [agents/no-desc-agent.md] Added missing fields to agent frontmatter
  ...

Run `skillsaw lint` to see remaining issues.
```

## Testing

- `make test`: 2490 passed (full suite, includes the new tests).
- `make lint`: clean; `make update`: no generated-file churn.
- New unit tests (`tests/test_formatters.py`): marker present on SAFE/SUGGEST-fixable lines and absent otherwise; summary splits SAFE vs SUGGEST and each single-kind variant; hidden info-level fixables don't inflate the count; JSON `fixable` true/false/absent semantics and `fix_confidence` presence rules; HTML marker/tooltips.
- New unit tests (`tests/test_autofix.py`): `Rule.violation()` fixability defaults and overrides, including the no-class-confidence conservative default and direct-construction `None`.
- New integration tests (`tests/test_integration.py`, `TestLintFixLoop`, static `autofix/safe-idempotency` fixture): text markers per rule including the `agentskill-valid` subset split, summary count matches the number of marked lines, JSON per-violation fixability (incl. `content-unlinked-internal-reference` file-exists subset), fix output uses relative paths with no absolute-path leaks plus the re-lint hint, and no hint when nothing was fixed.
- Verified against a fresh `openshift-eng/ai-helpers` clone: exit 0, and no fixable line renders (all 452 info violations there come from rules without autofixes — correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixability indicators in text, HTML, JSON, and CLI output so users can see which issues are safe to fix automatically versus suggested fixes.
  * Enhanced example docs to show richer lint and fix output, including counts of fixable issues and clearer guidance on autofix usage.

* **Bug Fixes**
  * Improved path display in fix output to use clearer relative paths where possible.
  * Tightened which issues are marked fixable, reducing misleading autofix suggestions for cases that still need manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->