### PR TITLE
Add TTY-aware color (--color, FORCE_COLOR) and OSC 8 hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,11 @@ Terminal output is colored only when stdout is a terminal — piped or
 redirected output stays plain. Override with `--color always|never|auto`,
 which outranks the `FORCE_COLOR` environment variable (non-empty forces
 color on, useful in CI; `0` forces it off), which outranks `NO_COLOR`
-(present disables color). On hyperlink-capable terminals (`TERM` other
-than `dumb`), rule ids link to their documentation pages and file paths
-become clickable `file://` links, replacing the "Rule docs" URL footer
-with a one-line hint.
+(present disables color). When color is enabled on a real terminal
+(`TERM` other than `dumb`), rule ids link to their documentation pages
+and file paths become clickable `file://` links, replacing the "Rule
+docs" URL footer with a one-line hint. Hyperlinks are never emitted
+through a pipe, even when color is forced.
 
 ## Migrating from claudelint
 

--- a/README.md
+++ b/README.md
@@ -320,10 +320,10 @@ Violations that `skillsaw fix` can resolve automatically are marked with
 ### Color and hyperlinks
 
 Terminal output is colored only when stdout is a terminal — piped or
-redirected output stays plain. Override with `--color always|never|auto`,
-which outranks the `FORCE_COLOR` environment variable (non-empty forces
-color on, useful in CI; `0` forces it off), which outranks `NO_COLOR`
-(present disables color). When color is enabled on a real terminal
+redirected output stays plain. Force it with `--color` or `--no-color`,
+which outrank the `FORCE_COLOR` environment variable (non-empty forces
+color on even through a pipe, useful in CI; `0` forces it off), which
+outranks `NO_COLOR` (present disables color). When color is enabled on a real terminal
 (`TERM` other than `dumb`), rule ids link to their documentation pages
 and file paths become clickable `file://` links, replacing the "Rule
 docs" URL footer with a one-line hint. Hyperlinks are never emitted

--- a/README.md
+++ b/README.md
@@ -317,6 +317,17 @@ Violations that `skillsaw fix` can resolve automatically are marked with
 `[*]` (safe fixes) or `[?]` (suggested fixes, applied with
 `skillsaw fix --suggest`), and the summary counts each kind.
 
+### Color and hyperlinks
+
+Terminal output is colored only when stdout is a terminal — piped or
+redirected output stays plain. Override with `--color always|never|auto`,
+which outranks the `FORCE_COLOR` environment variable (non-empty forces
+color on, useful in CI; `0` forces it off), which outranks `NO_COLOR`
+(present disables color). On hyperlink-capable terminals (`TERM` other
+than `dumb`), rule ids link to their documentation pages and file paths
+become clickable `file://` links, replacing the "Rule docs" URL footer
+with a one-line hint.
+
 ## Migrating from claudelint
 
 This project was renamed from `claudelint` to `skillsaw`. To migrate:

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,8 @@ runs:
       id: lint
       shell: bash
       env:
+        # Actions stdout is not a TTY; force ANSI color in the step log.
+        FORCE_COLOR: '1'
         SKILLSAW_PATH: ${{ inputs.path }}
         SKILLSAW_STRICT: ${{ inputs.strict }}
         SKILLSAW_FAIL_ON: ${{ inputs.fail-on }}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -178,8 +178,9 @@ first:
 3. `NO_COLOR` — present (even empty) disables color
 4. Otherwise color is used only when stdout is a terminal
 
-Piped or redirected output is plain text by default. On terminals that
-aren't `TERM=dumb`, text output also emits [OSC 8
+Piped or redirected output is plain text by default. When color is
+enabled on a real terminal (`TERM` other than `dumb`), text output also
+emits [OSC 8
 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):
 rule ids link to their documentation pages, file paths become clickable
 `file://` links, and the per-rule "Rule docs" URL footer collapses to a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
 | `--no-plugins` | Skip rules from installed plugin packages (skillsaw.plugins entry points) |  |
 | `--no-progress` | Disable the interactive per-rule progress indicator (auto-disabled when stderr is not a terminal) |  |
+| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
 
 ## `skillsaw fix`
 
@@ -41,6 +42,7 @@ Automatically fix lint violations
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
 | `--no-plugins` | Skip rules from installed plugin packages (skillsaw.plugins entry points) |  |
 | `--no-progress` | Disable the interactive per-rule progress indicator (auto-disabled when stderr is not a terminal) |  |
+| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
 
 ## `skillsaw init`
 
@@ -61,6 +63,7 @@ Show documentation and effective configuration for a rule
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
+| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
 
 ## `skillsaw docs`
 
@@ -99,6 +102,7 @@ Grade the repository and write a shields.io badge JSON file
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
 | `-o`, `--output` | Badge JSON output path (default: .skillsaw-badge.json in the repository root) |  |
+| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
 
 ## `skillsaw add`
 
@@ -161,4 +165,24 @@ Add a hook to a plugin
 |------|-------------|---------|
 | `--plugin` | Target plugin name (auto-detected if unambiguous) |  |
 | `--path` | Marketplace root path |  |
+
+## Color and hyperlinks
+
+Commands that produce terminal output (`lint`, `fix`, `explain`, `badge`)
+decide whether to emit ANSI colors with the standard cascade, strongest
+first:
+
+1. `--color always` / `--color never`
+2. `FORCE_COLOR` — a non-empty value forces color on even through a pipe
+   (`0` forces it off); useful in CI logs that render ANSI
+3. `NO_COLOR` — present (even empty) disables color
+4. Otherwise color is used only when stdout is a terminal
+
+Piped or redirected output is plain text by default. On terminals that
+aren't `TERM=dumb`, text output also emits [OSC 8
+hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):
+rule ids link to their documentation pages, file paths become clickable
+`file://` links, and the per-rule "Rule docs" URL footer collapses to a
+one-line hint. Hyperlinks are never emitted through a pipe, even when
+color is forced.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
 | `--no-plugins` | Skip rules from installed plugin packages (skillsaw.plugins entry points) |  |
 | `--no-progress` | Disable the interactive per-rule progress indicator (auto-disabled when stderr is not a terminal) |  |
-| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
+| `--color`, `--no-color` | Force ANSI colors and terminal hyperlinks on (--color) or off (--no-color). Default: color only when stdout is a terminal; FORCE_COLOR and NO_COLOR are also honored. |  |
 
 ## `skillsaw fix`
 
@@ -42,7 +42,7 @@ Automatically fix lint violations
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
 | `--no-plugins` | Skip rules from installed plugin packages (skillsaw.plugins entry points) |  |
 | `--no-progress` | Disable the interactive per-rule progress indicator (auto-disabled when stderr is not a terminal) |  |
-| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
+| `--color`, `--no-color` | Force ANSI colors and terminal hyperlinks on (--color) or off (--no-color). Default: color only when stdout is a terminal; FORCE_COLOR and NO_COLOR are also honored. |  |
 
 ## `skillsaw init`
 
@@ -63,7 +63,7 @@ Show documentation and effective configuration for a rule
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
-| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
+| `--color`, `--no-color` | Force ANSI colors and terminal hyperlinks on (--color) or off (--no-color). Default: color only when stdout is a terminal; FORCE_COLOR and NO_COLOR are also honored. |  |
 
 ## `skillsaw docs`
 
@@ -102,7 +102,7 @@ Grade the repository and write a shields.io badge JSON file
 |------|-------------|---------|
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover) |  |
 | `-o`, `--output` | Badge JSON output path (default: .skillsaw-badge.json in the repository root) |  |
-| `--color` | When to emit ANSI colors and terminal hyperlinks (default: auto — color only when stdout is a terminal; FORCE_COLOR forces color on, NO_COLOR turns it off) (choices: always, never, auto) | `auto` |
+| `--color`, `--no-color` | Force ANSI colors and terminal hyperlinks on (--color) or off (--no-color). Default: color only when stdout is a terminal; FORCE_COLOR and NO_COLOR are also honored. |  |
 
 ## `skillsaw add`
 
@@ -172,7 +172,7 @@ Commands that produce terminal output (`lint`, `fix`, `explain`, `badge`)
 decide whether to emit ANSI colors with the standard cascade, strongest
 first:
 
-1. `--color always` / `--color never`
+1. `--color` / `--no-color`
 2. `FORCE_COLOR` — a non-empty value forces color on even through a pipe
    (`0` forces it off); useful in CI logs that render ANSI
 3. `NO_COLOR` — present (even empty) disables color

--- a/scripts/generate-site-content.py
+++ b/scripts/generate-site-content.py
@@ -518,6 +518,29 @@ def generate_rule_page(rule_id, group_name, slug, rules_data, research):
     return "\n".join(lines) + "\n"
 
 
+CLI_COLOR_SECTION = """\
+## Color and hyperlinks
+
+Commands that produce terminal output (`lint`, `fix`, `explain`, `badge`)
+decide whether to emit ANSI colors with the standard cascade, strongest
+first:
+
+1. `--color always` / `--color never`
+2. `FORCE_COLOR` — a non-empty value forces color on even through a pipe
+   (`0` forces it off); useful in CI logs that render ANSI
+3. `NO_COLOR` — present (even empty) disables color
+4. Otherwise color is used only when stdout is a terminal
+
+Piped or redirected output is plain text by default. On terminals that
+aren't `TERM=dumb`, text output also emits [OSC 8
+hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):
+rule ids link to their documentation pages, file paths become clickable
+`file://` links, and the per-rule "Rule docs" URL footer collapses to a
+one-line hint. Hyperlinks are never emitted through a pipe, even when
+color is forced.
+"""
+
+
 def generate_cli_reference(commands):
     """Generate docs/cli.md from parsed argparse data."""
     lines = [GENERATED_HEADER, "# CLI Reference\n"]
@@ -541,6 +564,7 @@ def generate_cli_reference(commands):
                 lines.append(f"| {arg['flags']} | {desc} | {default} |")
             lines.append("")
 
+    lines.append(CLI_COLOR_SECTION)
     return "\n".join(lines) + "\n"
 
 

--- a/scripts/generate-site-content.py
+++ b/scripts/generate-site-content.py
@@ -531,8 +531,9 @@ first:
 3. `NO_COLOR` — present (even empty) disables color
 4. Otherwise color is used only when stdout is a terminal
 
-Piped or redirected output is plain text by default. On terminals that
-aren't `TERM=dumb`, text output also emits [OSC 8
+Piped or redirected output is plain text by default. When color is
+enabled on a real terminal (`TERM` other than `dumb`), text output also
+emits [OSC 8
 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):
 rule ids link to their documentation pages, file paths become clickable
 `file://` links, and the per-rule "Rule docs" URL footer collapses to a

--- a/scripts/generate-site-content.py
+++ b/scripts/generate-site-content.py
@@ -525,7 +525,7 @@ Commands that produce terminal output (`lint`, `fix`, `explain`, `badge`)
 decide whether to emit ANSI colors with the standard cascade, strongest
 first:
 
-1. `--color always` / `--color never`
+1. `--color` / `--no-color`
 2. `FORCE_COLOR` — a non-empty value forces color on even through a pipe
    (`0` forces it off); useful in CI logs that render ANSI
 3. `NO_COLOR` — present (even empty) disables color

--- a/src/skillsaw/cli/_badge.py
+++ b/src/skillsaw/cli/_badge.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ..context import RepositoryContext
 from ..linter import Linter
 from ._config import load_config
-from ._helpers import _RuleProgress, _ansi_colors
+from ._helpers import _RuleProgress, _ansi_colors, color_enabled
 
 _BADGE_FILENAME = ".skillsaw-badge.json"
 
@@ -85,7 +85,7 @@ def _run_badge(args):
     badge_path.parent.mkdir(parents=True, exist_ok=True)
     badge_path.write_text(json.dumps(grade.badge_json(), indent=2) + "\n", encoding="utf-8")
 
-    c = _ansi_colors()
+    c = _ansi_colors(color_enabled(sys.stdout, args.color))
     grade_color = (
         c["green"]
         if grade.letter[0] in "AB"

--- a/src/skillsaw/cli/_explain.py
+++ b/src/skillsaw/cli/_explain.py
@@ -7,7 +7,7 @@ import sys
 from ..config import LinterConfig
 from ..context import RepositoryContext
 from ._config import load_config
-from ._helpers import _ansi_colors
+from ._helpers import _ansi_colors, color_enabled
 
 
 def _run_explain(args):
@@ -58,7 +58,7 @@ def _run_explain(args):
         print("Run `skillsaw list-rules` to see all rules.", file=sys.stderr)
         sys.exit(1)
 
-    c = _ansi_colors()
+    c = _ansi_colors(color_enabled(sys.stdout, args.color))
     defaults = LinterConfig.default()
     default_rule = rule_class(defaults.get_rule_config(args.rule_id))
     default_enabled = defaults.get_rule_config(args.rule_id).get("enabled", True)

--- a/src/skillsaw/cli/_fix.py
+++ b/src/skillsaw/cli/_fix.py
@@ -13,6 +13,7 @@ from ._helpers import (
     _RuleProgress,
     _ansi_colors,
     _resolve_lint_paths,
+    color_enabled,
 )
 
 
@@ -94,7 +95,7 @@ def _run_fix(args):
         applied.extend((f, context.root_path) for f in path_applied)
         suggested.extend((f, context.root_path) for f in path_suggested)
 
-    c = _ansi_colors()
+    c = _ansi_colors(color_enabled(sys.stdout, args.color))
 
     # Single-root runs print repo-relative paths, matching lint output.
     # Multi-root runs keep absolute paths — the same relative name in two

--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -144,12 +144,13 @@ def _dedup_rules(rules):
 # ---------------------------------------------------------------------------
 
 
-def color_enabled(stream, mode: str = "auto") -> bool:
+def color_enabled(stream, color: bool | None = None) -> bool:
     """Whether ANSI color should be emitted on ``stream``.
 
     Standard cascade, strongest first:
 
-    1. ``--color always`` / ``--color never`` (the ``mode`` argument)
+    1. ``--color`` / ``--no-color`` (the ``color`` argument: ``True`` forces
+       on, ``False`` forces off, ``None`` auto-detects)
     2. ``FORCE_COLOR`` — non-empty forces color on (``0`` forces it off)
     3. ``NO_COLOR`` — present (even empty) disables color
     4. ``stream.isatty()``
@@ -157,10 +158,8 @@ def color_enabled(stream, mode: str = "auto") -> bool:
     ``FORCE_COLOR`` outranks ``NO_COLOR`` so CI setups that export both
     get the color they explicitly asked for.
     """
-    if mode == "always":
-        return True
-    if mode == "never":
-        return False
+    if color is not None:
+        return color
     force = os.environ.get("FORCE_COLOR")
     if force:
         return force != "0"

--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -144,17 +144,58 @@ def _dedup_rules(rules):
 # ---------------------------------------------------------------------------
 
 
-def _ansi_colors():
-    no_color = "NO_COLOR" in os.environ
+def color_enabled(stream, mode: str = "auto") -> bool:
+    """Whether ANSI color should be emitted on ``stream``.
+
+    Standard cascade, strongest first:
+
+    1. ``--color always`` / ``--color never`` (the ``mode`` argument)
+    2. ``FORCE_COLOR`` — non-empty forces color on (``0`` forces it off)
+    3. ``NO_COLOR`` — present (even empty) disables color
+    4. ``stream.isatty()``
+
+    ``FORCE_COLOR`` outranks ``NO_COLOR`` so CI setups that export both
+    get the color they explicitly asked for.
+    """
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    force = os.environ.get("FORCE_COLOR")
+    if force:
+        return force != "0"
+    if "NO_COLOR" in os.environ:
+        return False
+    try:
+        return stream.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def hyperlinks_enabled(stream, color: bool) -> bool:
+    """Whether OSC 8 terminal hyperlinks should be emitted on ``stream``.
+
+    Requires color, a real terminal, and ``TERM`` other than ``dumb``.
+    Unlike color, hyperlinks are never forced through a pipe — CI log
+    viewers render SGR colors but display raw OSC 8 bytes as garbage.
+    """
+    if not color or os.environ.get("TERM") == "dumb":
+        return False
+    try:
+        return stream.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _ansi_colors(enabled: bool):
     return {
-        "bold": "" if no_color else "\033[1m",
-        "dim": "" if no_color else "\033[2m",
-        "green": "" if no_color else "\033[92m",
-        "red": "" if no_color else "\033[91m",
-        "yellow": "" if no_color else "\033[93m",
-        "cyan": "" if no_color else "\033[96m",
-        "reset": "" if no_color else "\033[0m",
-        "no_color": no_color,
+        "bold": "\033[1m" if enabled else "",
+        "dim": "\033[2m" if enabled else "",
+        "green": "\033[92m" if enabled else "",
+        "red": "\033[91m" if enabled else "",
+        "yellow": "\033[93m" if enabled else "",
+        "cyan": "\033[96m" if enabled else "",
+        "reset": "\033[0m" if enabled else "",
     }
 
 
@@ -177,12 +218,13 @@ def install_warning_display() -> None:
 
     def _showwarning(message, category, filename, lineno, file=None, line=None):
         if isinstance(message, CustomRuleWarning):
-            c = _ansi_colors()
+            out = sys.stderr if file is None else file
+            c = _ansi_colors(color_enabled(out))
             print(
                 f"{c['yellow']}⚠ Loading custom rule file:{c['reset']} "
                 f"{c['bold']}{message.path}{c['reset']} "
                 f"{c['dim']}(use --no-custom-rules to skip){c['reset']}",
-                file=sys.stderr if file is None else file,
+                file=out,
             )
         else:
             default_showwarning(message, category, filename, lineno, file, line)

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -16,6 +16,8 @@ from ._helpers import (
     _build_merged_context,
     _dedup_rules,
     _resolve_lint_paths,
+    color_enabled,
+    hyperlinks_enabled,
 )
 
 
@@ -208,6 +210,7 @@ def _run_lint(args):
     )
     grade = compute_grade(all_violations, content_tokens)
 
+    color = color_enabled(sys.stdout, args.color)
     stdout_output = format_report(
         args.fmt,
         all_violations,
@@ -219,6 +222,8 @@ def _run_lint(args):
         duration=lint_duration,
         grade=grade,
         fail_level=fail_level,
+        color=color,
+        hyperlinks=hyperlinks_enabled(sys.stdout, color),
     )
     print(stdout_output)
 

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -10,6 +10,21 @@ from ..context import RepositoryType
 from ..formatters import EXTENSION_MAP, FORMATS
 from ._config import _get_version
 
+_COLOR_HELP = (
+    "When to emit ANSI colors and terminal hyperlinks (default: auto — "
+    "color only when stdout is a terminal; FORCE_COLOR forces color on, "
+    "NO_COLOR turns it off)"
+)
+
+
+def _add_color_flag(subparser) -> None:
+    subparser.add_argument(
+        "--color",
+        choices=["always", "never", "auto"],
+        default="auto",
+        help=_COLOR_HELP,
+    )
+
 
 def _build_parser():
     """Build the main argument parser with all subcommands.
@@ -145,6 +160,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Disable the interactive per-rule progress indicator "
         "(auto-disabled when stderr is not a terminal)",
     )
+    _add_color_flag(lint_parser)
 
     # --- fix ---
     fix_parser = subparsers.add_parser(
@@ -211,6 +227,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Disable the interactive per-rule progress indicator "
         "(auto-disabled when stderr is not a terminal)",
     )
+    _add_color_flag(fix_parser)
 
     # --- init ---
     init_parser = subparsers.add_parser(
@@ -259,6 +276,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         type=Path,
         help="Path to .skillsaw.yaml config file (default: auto-discover)",
     )
+    _add_color_flag(explain_parser)
 
     # --- docs ---
     docs_parser = subparsers.add_parser(
@@ -377,6 +395,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         default=None,
         help="Badge JSON output path (default: .skillsaw-badge.json in the repository root)",
     )
+    _add_color_flag(badge_parser)
 
     # --- add ---
     subparsers.add_parser(

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -11,17 +11,18 @@ from ..formatters import EXTENSION_MAP, FORMATS
 from ._config import _get_version
 
 _COLOR_HELP = (
-    "When to emit ANSI colors and terminal hyperlinks (default: auto — "
-    "color only when stdout is a terminal; FORCE_COLOR forces color on, "
-    "NO_COLOR turns it off)"
+    "Force ANSI colors and terminal hyperlinks on (--color) or off "
+    "(--no-color). Default: color only when stdout is a terminal; "
+    "FORCE_COLOR and NO_COLOR are also honored."
 )
 
 
 def _add_color_flag(subparser) -> None:
     subparser.add_argument(
         "--color",
-        choices=["always", "never", "auto"],
-        default="auto",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        dest="color",
         help=_COLOR_HELP,
     )
 

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -102,6 +102,8 @@ def format_report(
     duration: Optional[float] = None,
     grade=None,
     fail_level: str = "error",
+    color: bool = False,
+    hyperlinks: bool = False,
 ) -> str:
     """
     Format lint results in the specified format.
@@ -120,6 +122,9 @@ def format_report(
         fail_level: Effective severity threshold that fails the run — with
             ``fail-on: info`` every format must include the info violations
             that caused the failure even without -v
+        color: Emit ANSI colors (text format only — resolved by the caller
+            via ``color_enabled()``; file outputs stay plain)
+        hyperlinks: Emit OSC 8 terminal hyperlinks (text format only)
     """
     if fmt == "text":
         from .text import format_text
@@ -134,6 +139,8 @@ def format_report(
             duration,
             grade,
             fail_level,
+            color=color,
+            hyperlinks=hyperlinks,
         )
     elif fmt == "json":
         from .json_fmt import format_json

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -2,7 +2,7 @@
 Text output formatter — human-readable terminal output with optional ANSI colors.
 """
 
-import os
+from pathlib import Path
 from typing import List, Optional
 
 from ..rule import AutofixConfidence, Rule, RuleViolation, Severity
@@ -20,6 +20,22 @@ def format_duration(seconds: float) -> str:
     return f"{minutes}m {secs}s"
 
 
+def _osc8(url: str, text: str) -> str:
+    """Wrap text in an OSC 8 terminal hyperlink."""
+    return f"\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"
+
+
+def _file_uri(file_path) -> Optional[str]:
+    """file:// URI for a violation path, or None when one can't be built."""
+    try:
+        path = Path(file_path)
+        if not path.is_absolute():
+            path = path.resolve()
+        return path.as_uri()
+    except (OSError, ValueError):
+        return None
+
+
 def format_text(
     violations: List[RuleViolation],
     context,
@@ -30,21 +46,27 @@ def format_text(
     duration: Optional[float] = None,
     grade=None,
     fail_level: str = "error",
+    color: bool = False,
+    hyperlinks: bool = False,
 ) -> str:
     show_info = should_show_info(verbose, fail_level)
-    no_color = "NO_COLOR" in os.environ
-    red = "" if no_color else "\033[91m"
-    yellow = "" if no_color else "\033[93m"
-    blue = "" if no_color else "\033[94m"
-    green = "" if no_color else "\033[92m"
-    bold = "" if no_color else "\033[1m"
-    reset = "" if no_color else "\033[0m"
+    red = "\033[91m" if color else ""
+    yellow = "\033[93m" if color else ""
+    blue = "\033[94m" if color else ""
+    green = "\033[92m" if color else ""
+    bold = "\033[1m" if color else ""
+    dim = "\033[2m" if color else ""
+    reset = "\033[0m" if color else ""
 
     errors, warnings, info = get_counts(violations)
 
     errors_list = [v for v in violations if v.severity == Severity.ERROR]
     warnings_list = [v for v in violations if v.severity == Severity.WARNING]
     info_list = [v for v in violations if v.severity == Severity.INFO]
+
+    # Synthetic rule IDs (e.g. invalid-config) have no documentation page —
+    # only link rules that actually ran as builtins.
+    builtin_ids = {r.rule_id for r in rules if getattr(r, "_source", "builtin") == "builtin"}
 
     def fix_marker(v: RuleViolation) -> str:
         """Ruff-style fixability marker: [*] safe, [?] needs --suggest."""
@@ -57,9 +79,17 @@ def format_text(
         rel = relative_path(v.file_path, context.root_path)
         location = ""
         if rel:
-            location = f" [{rel}:{v.file_line}]" if v.file_line else f" [{rel}]"
+            loc_text = f"{rel}:{v.file_line}" if v.file_line else rel
+            if hyperlinks:
+                uri = _file_uri(v.file_path)
+                if uri:
+                    loc_text = _osc8(uri, loc_text)
+            location = f" [{loc_text}]"
+        rule_ref = v.rule_id
+        if hyperlinks and v.rule_id in builtin_ids:
+            rule_ref = _osc8(rule_doc_url(v.rule_id), v.rule_id)
         return (
-            f"{icon} {v.severity.value.upper()} ({v.rule_id}){fix_marker(v)}{location}: {v.message}"
+            f"{icon} {v.severity.value.upper()} ({rule_ref}){fix_marker(v)}{location}: {v.message}"
         )
 
     output = []
@@ -80,14 +110,18 @@ def format_text(
             output.append(f"  {fmt_violation(v)}")
 
     shown = errors_list + warnings_list + (info_list if show_info else [])
-    # Synthetic rule IDs (e.g. invalid-config) have no documentation page —
-    # only link rules that actually ran as builtins.
-    builtin_ids = {r.rule_id for r in rules if getattr(r, "_source", "builtin") == "builtin"}
     documented = sorted({v.rule_id for v in shown if v.rule_id in builtin_ids})
     if documented:
-        output.append(f"\n{bold}Rule docs{reset} (or run `skillsaw explain <rule-id>`):")
-        for rule_id in documented:
-            output.append(f"  {rule_doc_url(rule_id)}")
+        if hyperlinks:
+            # Rule ids above are clickable — the per-rule URL list is noise.
+            output.append(
+                f"\n{dim}Rule ids link to their docs — or run"
+                f" `skillsaw explain <rule-id>`.{reset}"
+            )
+        else:
+            output.append(f"\n{bold}Rule docs{reset} (or run `skillsaw explain <rule-id>`):")
+            for rule_id in documented:
+                output.append(f"  {rule_doc_url(rule_id)}")
 
     output.append(f"\n{bold}Scanned:{reset}")
     repo_types_str = ", ".join(context.repo_type_names(include_unknown=False))
@@ -104,7 +138,6 @@ def format_text(
     if show_info:
         output.append(f"  {blue}Info:     {info}{reset}")
     if baseline_suppressed:
-        dim = "" if no_color else "\033[2m"
         output.append(f"  {dim}Baseline: {baseline_suppressed} suppressed{reset}")
     if grade is not None:
         grade_color = {"A": green, "B": green, "C": yellow, "D": red, "F": red}[grade.letter[0]]
@@ -113,7 +146,6 @@ def format_text(
             f"({grade.density:.2f} weighted violations per 10k tokens)"
         )
         if grade.info and not show_info:
-            dim = "" if no_color else "\033[2m"
             output.append(
                 f"  {dim}{grade.info} info-level violation(s) count toward"
                 f" the grade — run with -v to see them{reset}"

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for the CLI color/hyperlink capability cascade (GH-415).
+
+``color_enabled`` implements the standard precedence every mature CLI
+ships: --color always|never > FORCE_COLOR > NO_COLOR > stream.isatty().
+``hyperlinks_enabled`` additionally requires a real terminal that is not
+``TERM=dumb`` — OSC 8 sequences are never forced through a pipe.
+"""
+
+import pytest
+
+from skillsaw.cli._helpers import _ansi_colors, color_enabled, hyperlinks_enabled
+
+
+class _Stream:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+TTY = _Stream(True)
+PIPE = _Stream(False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_color_env(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+
+
+# --- color_enabled: isatty default ---
+
+
+def test_tty_defaults_to_color():
+    assert color_enabled(TTY) is True
+
+
+def test_pipe_defaults_to_plain():
+    assert color_enabled(PIPE) is False
+
+
+def test_stream_without_isatty_defaults_to_plain():
+    assert color_enabled(object()) is False
+
+
+# --- color_enabled: NO_COLOR overrides isatty ---
+
+
+def test_no_color_disables_on_tty(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert color_enabled(TTY) is False
+
+
+def test_no_color_empty_string_still_disables(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "")
+    assert color_enabled(TTY) is False
+
+
+# --- color_enabled: FORCE_COLOR overrides NO_COLOR ---
+
+
+def test_force_color_enables_on_pipe(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert color_enabled(PIPE) is True
+
+
+def test_force_color_beats_no_color(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert color_enabled(PIPE) is True
+
+
+def test_force_color_zero_disables_on_tty(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "0")
+    assert color_enabled(TTY) is False
+
+
+def test_force_color_empty_falls_through_to_isatty(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "")
+    assert color_enabled(TTY) is True
+    assert color_enabled(PIPE) is False
+
+
+# --- color_enabled: --color flag overrides everything ---
+
+
+def test_color_always_beats_no_color_and_pipe(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert color_enabled(PIPE, mode="always") is True
+
+
+def test_color_never_beats_force_color_and_tty(monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert color_enabled(TTY, mode="never") is False
+
+
+# --- hyperlinks_enabled ---
+
+
+def test_hyperlinks_on_color_tty():
+    assert hyperlinks_enabled(TTY, color=True) is True
+
+
+def test_hyperlinks_require_color():
+    assert hyperlinks_enabled(TTY, color=False) is False
+
+
+def test_hyperlinks_never_through_pipe():
+    """Even forced color (CI logs) must not emit OSC 8 through a pipe."""
+    assert hyperlinks_enabled(PIPE, color=True) is False
+
+
+def test_hyperlinks_suppressed_on_dumb_terminal(monkeypatch):
+    monkeypatch.setenv("TERM", "dumb")
+    assert hyperlinks_enabled(TTY, color=True) is False
+
+
+def test_hyperlinks_allowed_on_capable_terminal(monkeypatch):
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert hyperlinks_enabled(TTY, color=True) is True
+
+
+# --- _ansi_colors ---
+
+
+def test_ansi_colors_enabled_has_codes():
+    c = _ansi_colors(True)
+    assert c["red"] == "\033[91m"
+    assert c["reset"] == "\033[0m"
+
+
+def test_ansi_colors_disabled_is_all_empty():
+    c = _ansi_colors(False)
+    assert all(v == "" for v in c.values())

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -2,7 +2,7 @@
 Unit tests for the CLI color/hyperlink capability cascade (GH-415).
 
 ``color_enabled`` implements the standard precedence every mature CLI
-ships: --color always|never > FORCE_COLOR > NO_COLOR > stream.isatty().
+ships: --color/--no-color > FORCE_COLOR > NO_COLOR > stream.isatty().
 ``hyperlinks_enabled`` additionally requires a real terminal that is not
 ``TERM=dumb`` — OSC 8 sequences are never forced through a pipe.
 """
@@ -84,17 +84,17 @@ def test_force_color_empty_falls_through_to_isatty(monkeypatch):
     assert color_enabled(PIPE) is False
 
 
-# --- color_enabled: --color flag overrides everything ---
+# --- color_enabled: --color / --no-color flag overrides everything ---
 
 
-def test_color_always_beats_no_color_and_pipe(monkeypatch):
+def test_color_flag_beats_no_color_and_pipe(monkeypatch):
     monkeypatch.setenv("NO_COLOR", "1")
-    assert color_enabled(PIPE, mode="always") is True
+    assert color_enabled(PIPE, color=True) is True
 
 
-def test_color_never_beats_force_color_and_tty(monkeypatch):
+def test_no_color_flag_beats_force_color_and_tty(monkeypatch):
     monkeypatch.setenv("FORCE_COLOR", "1")
-    assert color_enabled(TTY, mode="never") is False
+    assert color_enabled(TTY, color=False) is False
 
 
 # --- hyperlinks_enabled ---

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -191,19 +191,24 @@ def test_text_shows_all_checks_passed(valid_plugin):
     assert "All checks passed" in output
 
 
-def test_text_includes_ansi_by_default(valid_plugin, monkeypatch):
-    monkeypatch.delenv("NO_COLOR", raising=False)
+def test_text_includes_ansi_when_color_enabled(valid_plugin):
     context = RepositoryContext(valid_plugin)
     config = LinterConfig.default()
     linter = Linter(context, config)
     violations = linter.run()
 
-    output = format_text(violations, context, linter.rules, "0.0.0")
+    output = format_text(violations, context, linter.rules, "0.0.0", color=True)
     assert "\033[" in output
 
 
-def test_text_no_ansi_when_no_color(valid_plugin, monkeypatch):
-    monkeypatch.setenv("NO_COLOR", "")
+def test_text_plain_by_default(valid_plugin, monkeypatch):
+    """Without an explicit color=True the text report never emits ANSI.
+
+    Callers resolve TTY-ness via color_enabled(); the formatter itself must
+    stay plain even when NO_COLOR is unset (regression for leaked escapes
+    in piped output and --output text files, GH-415).
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
     context = RepositoryContext(valid_plugin)
     config = LinterConfig.default()
     linter = Linter(context, config)
@@ -213,14 +218,13 @@ def test_text_no_ansi_when_no_color(valid_plugin, monkeypatch):
     assert "\033[" not in output
 
 
-def test_text_no_ansi_when_no_color_value(valid_plugin, monkeypatch):
-    monkeypatch.setenv("NO_COLOR", "1")
+def test_text_no_ansi_when_color_disabled(valid_plugin):
     context = RepositoryContext(valid_plugin)
     config = LinterConfig.default()
     linter = Linter(context, config)
     violations = linter.run()
 
-    output = format_text(violations, context, linter.rules, "0.0.0")
+    output = format_text(violations, context, linter.rules, "0.0.0", color=False)
     assert "\033[" not in output
 
 
@@ -621,6 +625,68 @@ def test_text_no_rule_docs_for_synthetic_rule_ids(valid_plugin):
 
     output = format_text(violations, context, linter.rules, "1.0.0")
     assert "https://skillsaw.org/rules/invalid-config/" not in output
+
+
+# --- OSC 8 hyperlinks (text formatter) ---
+
+
+def _hyperlink_violations():
+    return [
+        RuleViolation(
+            rule_id="command-naming",
+            severity=Severity.WARNING,
+            message="Command file should use kebab-case",
+            file_path=Path("plugins/foo/commands/Bad_Name.md"),
+            line=3,
+        ),
+        RuleViolation(
+            rule_id="invalid-config",
+            severity=Severity.WARNING,
+            message="Unknown rule 'bogus-rule' in config",
+        ),
+    ]
+
+
+def test_text_hyperlinks_link_rule_ids_and_paths(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    config = LinterConfig.default()
+    linter = Linter(context, config)
+    linter.run()
+
+    output = format_text(
+        _hyperlink_violations(), context, linter.rules, "1.0.0", color=True, hyperlinks=True
+    )
+    assert "\x1b]8;;https://skillsaw.org/rules/command-naming/\x1b\\command-naming" in output
+    assert "\x1b]8;;file://" in output
+    # Synthetic rule ids have no docs page and must not be linked.
+    assert "\x1b]8;;https://skillsaw.org/rules/invalid-config/" not in output
+
+
+def test_text_hyperlinks_collapse_rule_docs_footer(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    config = LinterConfig.default()
+    linter = Linter(context, config)
+    linter.run()
+
+    output = format_text(
+        _hyperlink_violations(), context, linter.rules, "1.0.0", color=True, hyperlinks=True
+    )
+    assert "Rule docs" not in output
+    assert "https://skillsaw.org/rules/command-naming/\x1b\\" in output  # only as a link
+    assert "skillsaw explain" in output  # the one-line hint remains
+
+
+def test_text_no_osc8_without_hyperlinks(valid_plugin):
+    """Color alone (e.g. FORCE_COLOR through a pipe) keeps the plain footer."""
+    context = RepositoryContext(valid_plugin)
+    config = LinterConfig.default()
+    linter = Linter(context, config)
+    linter.run()
+
+    output = format_text(_hyperlink_violations(), context, linter.rules, "1.0.0", color=True)
+    assert "\x1b]8;;" not in output
+    assert "Rule docs" in output
+    assert "https://skillsaw.org/rules/command-naming/" in output
 
 
 def test_sarif_synthetic_descriptor_for_unknown_rule_id(valid_plugin):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2760,14 +2760,14 @@ class TestColorOutput:
         result = self._run_piped(repo, env=_color_env(FORCE_COLOR="1", NO_COLOR="1"))
         assert "\x1b[" in result.stdout
 
-    def test_color_always_beats_no_color_through_pipe(self, tmp_path):
+    def test_color_flag_beats_no_color_through_pipe(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
-        result = self._run_piped(repo, "--color", "always", env=_color_env(NO_COLOR="1"))
+        result = self._run_piped(repo, "--color", env=_color_env(NO_COLOR="1"))
         assert "\x1b[" in result.stdout
 
-    def test_color_never_beats_force_color(self, tmp_path):
+    def test_no_color_beats_force_color(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
-        result = self._run_piped(repo, "--color", "never", env=_color_env(FORCE_COLOR="1"))
+        result = self._run_piped(repo, "--no-color", env=_color_env(FORCE_COLOR="1"))
         assert "\x1b[" not in result.stdout
 
     def test_output_text_file_is_always_plain(self, tmp_path):
@@ -2800,9 +2800,9 @@ class TestColorOutput:
         assert "Rule docs" in output
 
     @pytest.mark.skipif(os.name != "posix", reason="pty requires POSIX")
-    def test_color_never_on_tty(self, tmp_path):
+    def test_no_color_on_tty(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
-        output = _run_lint_in_pty(repo, _color_env(TERM="xterm-256color"), "--color", "never")
+        output = _run_lint_in_pty(repo, _color_env(TERM="xterm-256color"), "--no-color")
         assert "\x1b[" not in output
         assert "\x1b]8" not in output
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2640,28 +2640,29 @@ class TestNoCustomRulesLint:
         ), "Custom-rule notice should be human-readable, not the warnings-module format"
         assert "_load_custom_rule" not in result.stderr
 
-    def test_custom_rule_warning_colors_respect_no_color(self, tmp_path):
+    def test_custom_rule_warning_colors_respect_color_cascade(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
         sentinel = tmp_path / "sentinel.txt"
-        base_env = {**os.environ, "SKILLSAW_SENTINEL": str(sentinel)}
+        base_env = {k: v for k, v in os.environ.items() if k not in ("NO_COLOR", "FORCE_COLOR")}
+        base_env["SKILLSAW_SENTINEL"] = str(sentinel)
         args = [sys.executable, "-m", "skillsaw", "lint", str(repo)]
 
-        env = {k: v for k, v in base_env.items() if k != "NO_COLOR"}
-        result = subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
-        colored = [ln for ln in result.stderr.splitlines() if "Loading custom rule file" in ln]
-        assert colored, f"missing custom-rule notice on stderr: {result.stderr}"
-        assert "\x1b[" in colored[0], "Notice should be colored when NO_COLOR is unset"
+        def notice_lines(env):
+            result = subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+            lines = [ln for ln in result.stderr.splitlines() if "Loading custom rule file" in ln]
+            assert lines, f"missing custom-rule notice on stderr: {result.stderr}"
+            return lines
 
-        result = subprocess.run(
-            args,
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env={**base_env, "NO_COLOR": "1"},
-        )
-        plain = [ln for ln in result.stderr.splitlines() if "Loading custom rule file" in ln]
-        assert plain, f"missing custom-rule notice on stderr: {result.stderr}"
+        # FORCE_COLOR beats both NO_COLOR and the captured (non-TTY) stderr.
+        colored = notice_lines({**base_env, "FORCE_COLOR": "1", "NO_COLOR": "1"})
+        assert "\x1b[" in colored[0], "Notice should be colored when FORCE_COLOR is set"
+
+        plain = notice_lines({**base_env, "NO_COLOR": "1"})
         assert "\x1b[" not in plain[0], "Notice must not contain ANSI codes under NO_COLOR"
+
+        # Captured stderr is a pipe, not a terminal — plain by default.
+        piped = notice_lines(base_env)
+        assert "\x1b[" not in piped[0], "Notice must not be colored when stderr is not a TTY"
 
     def test_no_warning_when_custom_rules_skipped(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
@@ -2680,6 +2681,130 @@ class TestNoCustomRulesLint:
         assert (
             "Loading custom rule file" not in result.stderr
         ), "Warning should not appear when --no-custom-rules is used"
+
+
+# ── TTY-aware color and OSC 8 hyperlinks (GH-415) ────────────────
+
+
+def _color_env(**extra):
+    """os.environ without ambient color overrides, plus explicit extras."""
+    env = {k: v for k, v in os.environ.items() if k not in ("NO_COLOR", "FORCE_COLOR")}
+    env.update(extra)
+    return env
+
+
+def _run_lint_in_pty(repo, env, *extra_args):
+    """Run `skillsaw lint` with stdout attached to a pseudo-terminal."""
+    import pty
+
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "skillsaw", "lint", *extra_args, str(repo)],
+            stdout=slave,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            env=env,
+        )
+    finally:
+        os.close(slave)
+    chunks = []
+    try:
+        while True:
+            try:
+                data = os.read(master, 65536)
+            except OSError:
+                break  # EIO: child closed the pty
+            if not data:
+                break
+            chunks.append(data)
+        proc.wait(timeout=60)
+    finally:
+        os.close(master)
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+@pytest.mark.integration
+class TestColorOutput:
+    """Color is gated on TTY-ness with the --color/FORCE_COLOR/NO_COLOR cascade."""
+
+    FIXTURE = "single-plugin"
+
+    def _run_piped(self, repo, *extra_args, env=None):
+        args = [sys.executable, "-m", "skillsaw", "lint", *extra_args, str(repo)]
+        return subprocess.run(
+            args, capture_output=True, text=True, timeout=60, env=env or _color_env()
+        )
+
+    def test_piped_output_is_plain_by_default(self, tmp_path):
+        """`skillsaw lint | less` must not leak raw ANSI escapes (GH-415)."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run_piped(repo)
+        assert "\x1b[" not in result.stdout
+        assert "\x1b]8" not in result.stdout
+        # Piped output keeps the parse-stable Rule docs footer.
+        assert "Rule docs" in result.stdout
+        assert "https://skillsaw.org/rules/" in result.stdout
+
+    def test_force_color_enables_ansi_through_pipe(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run_piped(repo, env=_color_env(FORCE_COLOR="1"))
+        assert "\x1b[" in result.stdout
+        # Hyperlinks stay off through a pipe even when color is forced —
+        # CI log viewers render SGR but show OSC 8 bytes as garbage.
+        assert "\x1b]8" not in result.stdout
+        assert "Rule docs" in result.stdout
+
+    def test_force_color_beats_no_color(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run_piped(repo, env=_color_env(FORCE_COLOR="1", NO_COLOR="1"))
+        assert "\x1b[" in result.stdout
+
+    def test_color_always_beats_no_color_through_pipe(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run_piped(repo, "--color", "always", env=_color_env(NO_COLOR="1"))
+        assert "\x1b[" in result.stdout
+
+    def test_color_never_beats_force_color(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = self._run_piped(repo, "--color", "never", env=_color_env(FORCE_COLOR="1"))
+        assert "\x1b[" not in result.stdout
+
+    def test_output_text_file_is_always_plain(self, tmp_path):
+        """--output text files must stay plain even when stdout color is forced."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        report = tmp_path / "report.txt"
+        result = self._run_piped(
+            repo, "--output", f"text:{report}", env=_color_env(FORCE_COLOR="1")
+        )
+        assert "\x1b[" in result.stdout
+        assert "\x1b[" not in report.read_text()
+
+    @pytest.mark.skipif(os.name != "posix", reason="pty requires POSIX")
+    def test_tty_gets_color_and_hyperlinks(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        output = _run_lint_in_pty(repo, _color_env(TERM="xterm-256color"))
+        assert "\x1b[" in output
+        assert "\x1b]8;;https://skillsaw.org/rules/" in output
+        assert "\x1b]8;;file://" in output
+        # The per-rule URL footer collapses when rule ids are clickable.
+        assert "Rule docs" not in output
+        assert "skillsaw explain" in output
+
+    @pytest.mark.skipif(os.name != "posix", reason="pty requires POSIX")
+    def test_term_dumb_suppresses_hyperlinks_but_not_color(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        output = _run_lint_in_pty(repo, _color_env(TERM="dumb"))
+        assert "\x1b[" in output
+        assert "\x1b]8" not in output
+        assert "Rule docs" in output
+
+    @pytest.mark.skipif(os.name != "posix", reason="pty requires POSIX")
+    def test_color_never_on_tty(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        output = _run_lint_in_pty(repo, _color_env(TERM="xterm-256color"), "--color", "never")
+        assert "\x1b[" not in output
+        assert "\x1b]8" not in output
 
 
 # ── Baseline ─────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Makes ANSI color TTY-aware with the standard `--color always|never|auto` > `FORCE_COLOR` > `NO_COLOR` > `isatty()` cascade, and adds OSC 8 terminal hyperlinks (clickable rule ids and file paths) on capable terminals.

Fixes #415

## Why

Color was gated solely on `NO_COLOR` presence — there was no `isatty()` check on stdout anywhere, so `skillsaw lint | less` or redirecting to a file leaked raw `^[[91m` escapes. That is the one place a polished CLI looks broken, and it also meant `--output text:file.txt` wrote ANSI into report files.

## How

- **`color_enabled(stream, mode)`** in `cli/_helpers.py` implements the cascade: explicit `--color` flag > `FORCE_COLOR` (non-empty forces on, `0` forces off, and it outranks `NO_COLOR` so CI setups exporting both get what they asked for) > `NO_COLOR` (present, even empty, disables) > `stream.isatty()`.
- **`--color always|never|auto`** added to the four ANSI-emitting subcommands: `lint`, `fix`, `explain`, `badge`. Each resolves the bool once against `sys.stdout`; `_ansi_colors()` now takes that bool instead of reading the environment.
- **`format_report`/`format_text`** take `color`/`hyperlinks` kwargs and no longer read the environment — `--output text:` file reports are always plain, even with `FORCE_COLOR=1`.
- **stderr notices** (custom-rule warning) gate on `sys.stderr` capability separately from stdout.
- **OSC 8 hyperlinks** (`hyperlinks_enabled`: color AND `isatty()` AND `TERM != dumb`): rule ids link to their skillsaw.org docs page, file paths become clickable `file://` links, and the per-rule "Rule docs" URL footer collapses to a one-line dim hint. The PR #409 fixable markers/fix-hint styling routes through the same gate.
- **`action.yml`** exports `FORCE_COLOR: '1'` for the lint step (one env line, placed to merge cleanly with #408) — Actions stdout is not a TTY, so without it every Actions user would silently lose colored logs.
- **Docs**: cascade + hyperlink section in README and in the generated `docs/cli.md` (via `scripts/generate-site-content.py`).

### Before / after

| Context | Before | After |
|---|---|---|
| TTY | colored, URL footer | colored + clickable rule ids/paths, footer collapsed to one hint line |
| `lint \| less` / `> file` | raw `^[[91m` escapes leak | plain text, byte-compatible with today's `NO_COLOR` output (footer kept) |
| GitHub Actions | colored (NO_COLOR unset) | still colored via `FORCE_COLOR=1` in action.yml; no OSC 8 garbage |
| `--output text:report.txt` | ANSI written into the file | always plain |

Hyperlinks are deliberately never forced through a pipe (even `--color always` / `FORCE_COLOR`): CI log viewers render SGR colors but display raw OSC 8 bytes as garbage, and keeping pipes OSC 8-free keeps piped output stable for anything parsing it. This is a slight tightening of the issue's "color enabled AND TERM != dumb" wording, per its own note that footer collapse is for "hyperlink-capable (TTY) mode".

## Testing

- `make test` — 2524 passed (full suite), including:
  - `tests/test_color.py` (new): cascade precedence units — each level overriding the next, `FORCE_COLOR=0`, empty-value edge cases, `TERM=dumb`, streams without `isatty`
  - `tests/test_formatters.py`: OSC 8 link presence/absence, footer collapse, plain-by-default regression tests (replacing the color-by-default asserts)
  - `tests/test_integration.py::TestColorOutput` (new, `single-plugin` fixture): plain piped output, `FORCE_COLOR=1` through a real subprocess pipe, `FORCE_COLOR` beating `NO_COLOR`, `--color always` into a pipe, `--color never` beating `FORCE_COLOR` and on a pty, real pseudo-tty runs asserting OSC 8 + collapsed footer, `TERM=dumb` suppression, `--output text:` file stays plain
  - stderr notice test converted to the cascade (FORCE_COLOR leg, NO_COLOR leg, piped-plain leg)
- `make lint` clean; `make update` run (docs/cli.md regenerated)
- `skillsaw lint` against openshift-eng/ai-helpers: exit 0, `| cat -v` shows **zero** escape sequences piped; pty run verified by eye (colors, clickable links, collapsed footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared `--color` option across key CLI commands to control ANSI colors in output.
  * Terminal-friendly hyperlinks now appear in supported terminals for rule references and file locations.

* **Bug Fixes**
  * Output coloring now respects terminal detection and color-related environment settings more consistently.
  * Piped output stays plain, while interactive terminals can show richer formatting.

* **Documentation**
  * Updated CLI and README examples to explain color and hyperlink behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->