### PR TITLE
Group lint text output by file with aligned rows, deduped messages, and --statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,16 +323,27 @@ generation options.
 
 ## Example Output
 
+Violations are grouped by file — each file appears once as a header with its
+problems listed beneath it in `line`, severity, rule, message columns.
+Identical messages repeated within a file collapse to a single row that lists
+the extra line numbers.
+
 ```
 Linting: /path/to/skills-repo
 
-Errors:
-  ✗ ERROR (agentskill-name) [*] [skills/my-skill/SKILL.md:2]: Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
-  ✗ ERROR (plugin-json-required) [plugins/git/.claude-plugin/plugin.json]: Missing plugin.json
+Violations:
 
-Warnings:
-  ⚠ WARNING (agentskill-description) [skills/helper/SKILL.md:3]: Description exceeds 1024 characters (1087)
-  ⚠ WARNING (plugin-readme) [plugins/utils]: Missing README.md (recommended)
+plugins/git/.claude-plugin/plugin.json
+     ✗ error    plugin-json-required        Missing plugin.json
+
+plugins/utils
+     ⚠ warning  plugin-readme               Missing README.md (recommended)
+
+skills/helper/SKILL.md
+  3  ⚠ warning  agentskill-description      Description exceeds 1024 characters (1087)
+
+skills/my-skill/SKILL.md
+  2  ✗ error    agentskill-name        [*]  Name 'My Skill' must contain only lowercase letters, numbers, and hyphens
 
 Summary:
   Errors:   2
@@ -343,6 +354,18 @@ Summary:
 Violations that `skillsaw fix` can resolve automatically are marked with
 `[*]` (safe fixes) or `[?]` (suggested fixes, applied with
 `skillsaw fix --suggest`), and the summary counts each kind.
+
+Add `--statistics` for a ruff-style per-rule count, highest first:
+
+```
+skillsaw lint --statistics
+
+Statistics:
+  5  content-weak-language
+  2  agentskill-description
+  1  plugin-json-required
+  8 violation(s) across 3 rule(s)
+```
 
 ### Color and hyperlinks
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,6 +19,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Overrides the config file's strict/fail-on settings. (choices: error, warning, info) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
+| `--statistics` | Print per-rule violation counts, highest first (text format only) |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo. |  |
 | `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |
 | `--skip-rule` | Skip these rules (repeatable). Cannot be combined with --rule. |  |

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -227,6 +227,15 @@ def _run_lint(args):
     )
     print(stdout_output)
 
+    if getattr(args, "statistics", False) and args.fmt == "text":
+        from ..formatters.text import format_statistics
+
+        stats = format_statistics(
+            all_violations, verbose=args.verbose, fail_level=fail_level, color=color
+        )
+        if stats:
+            print(f"\n{stats}")
+
     report_cache = {}
     for output_path, fmt in output_formats.items():
         if fmt not in report_cache:

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -110,6 +110,12 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         "json or gitlab/code-climate). Can be specified multiple times.",
     )
     lint_parser.add_argument(
+        "--statistics",
+        action="store_true",
+        dest="statistics",
+        help="Print per-rule violation counts, highest first (text format only)",
+    )
+    lint_parser.add_argument(
         "--type",
         dest="repo_types",
         action="append",

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -60,56 +60,97 @@ def format_text(
 
     errors, warnings, info = get_counts(violations)
 
-    errors_list = [v for v in violations if v.severity == Severity.ERROR]
-    warnings_list = [v for v in violations if v.severity == Severity.WARNING]
-    info_list = [v for v in violations if v.severity == Severity.INFO]
-
     # Synthetic rule IDs (e.g. invalid-config) have no documentation page —
     # only link rules that actually ran as builtins.
     builtin_ids = {r.rule_id for r in rules if getattr(r, "_source", "builtin") == "builtin"}
+
+    shown = [v for v in violations if v.severity != Severity.INFO or show_info]
+
+    output = []
+    _sev_color = {Severity.ERROR: red, Severity.WARNING: yellow, Severity.INFO: blue}
+    _sev_icon = {Severity.ERROR: "✗", Severity.WARNING: "⚠", Severity.INFO: "ℹ"}
+    _sev_order = {Severity.ERROR: 0, Severity.WARNING: 1, Severity.INFO: 2}
 
     def fix_marker(v: RuleViolation) -> str:
         """Ruff-style fixability marker: [*] safe, [?] needs --suggest."""
         if not v.fixable:
             return ""
-        return " [*]" if v.fix_confidence == AutofixConfidence.SAFE else " [?]"
+        return "[*]" if v.fix_confidence == AutofixConfidence.SAFE else "[?]"
 
-    def fmt_violation(v: RuleViolation) -> str:
-        icon = {"error": "✗", "warning": "⚠", "info": "ℹ"}[v.severity.value]
-        rel = relative_path(v.file_path, context.root_path)
-        location = ""
-        if rel:
-            loc_text = f"{rel}:{v.file_line}" if v.file_line else rel
-            if hyperlinks:
-                uri = _file_uri(v.file_path)
-                if uri:
-                    loc_text = _osc8(uri, loc_text)
-            location = f" [{loc_text}]"
-        rule_ref = v.rule_id
-        if hyperlinks and v.rule_id in builtin_ids:
-            rule_ref = _osc8(rule_doc_url(v.rule_id), v.rule_id)
-        return (
-            f"{icon} {v.severity.value.upper()} ({rule_ref}){fix_marker(v)}{location}: {v.message}"
-        )
+    def _extra_lines_note(extra: List[int]) -> str:
+        """Trailing annotation for a collapsed run of identical violations."""
+        if not extra:
+            return ""
+        if len(extra) <= 5:
+            joined = ", ".join(str(n) for n in extra)
+            label = "line" if len(extra) == 1 else "lines"
+            return f"  (also on {label} {joined})"
+        return f"  (also on {len(extra)} more lines)"
 
-    output = []
+    if shown:
+        # Group by file, then collapse identical (rule, severity, message) runs
+        # within a file into one row that lists every line they hit. Files are
+        # sorted by path; rows by first line then severity — the same order
+        # eslint/ruff settled on.
+        by_file = {}
+        file_key = {}  # rel -> file_path (for the header hyperlink)
+        for v in shown:
+            rel = relative_path(v.file_path, context.root_path) or "(no file)"
+            by_file.setdefault(rel, {})
+            file_key.setdefault(rel, v.file_path)
+            key = (v.rule_id, v.severity, v.message)
+            group = by_file[rel].get(key)
+            if group is None:
+                by_file[rel][key] = {
+                    "violation": v,
+                    "lines": [] if v.file_line is None else [v.file_line],
+                }
+            elif v.file_line is not None:
+                group["lines"].append(v.file_line)
 
-    if errors_list:
-        output.append(f"\n{red}{bold}Errors:{reset}")
-        for v in errors_list:
-            output.append(f"  {fmt_violation(v)}")
+        # Flatten into rows so column widths can be aligned across the report.
+        rows = []  # (rel, first_line, severity, rule_id, marker, message)
+        for rel in sorted(by_file):
+            for group in by_file[rel].values():
+                v = group["violation"]
+                lines = sorted(group["lines"])
+                first = lines[0] if lines else None
+                message = v.message + _extra_lines_note(lines[1:])
+                rows.append((rel, first, v.severity, v.rule_id, fix_marker(v), message))
 
-    if warnings_list:
-        output.append(f"\n{yellow}{bold}Warnings:{reset}")
-        for v in warnings_list:
-            output.append(f"  {fmt_violation(v)}")
+        line_w = max((len(str(r[1])) for r in rows if r[1] is not None), default=0)
+        rule_w = max(len(r[3]) for r in rows)
+        any_marker = any(r[4] for r in rows)
 
-    if show_info and info_list:
-        output.append(f"\n{blue}{bold}Info:{reset}")
-        for v in info_list:
-            output.append(f"  {fmt_violation(v)}")
+        output.append(f"\n{bold}Violations:{reset}")
+        current_file = None
+        for rel, first, severity, rule_id, marker, message in sorted(
+            rows, key=lambda r: (r[0], r[1] if r[1] is not None else -1, _sev_order[r[2]])
+        ):
+            if rel != current_file:
+                current_file = rel
+                header = rel
+                if hyperlinks and file_key[rel] is not None:
+                    uri = _file_uri(file_key[rel])
+                    if uri:
+                        header = _osc8(uri, rel)
+                output.append(f"\n{bold}{header}{reset}")
 
-    shown = errors_list + warnings_list + (info_list if show_info else [])
+            sc = _sev_color[severity]
+            line_txt = "" if first is None else str(first)
+            sev_cell = f"{sc}{_sev_icon[severity]} {severity.value:<7}{reset}"
+            rule_pad = " " * (rule_w - len(rule_id))
+            if hyperlinks and rule_id in builtin_ids:
+                rule_cell = _osc8(rule_doc_url(rule_id), rule_id) + rule_pad
+            else:
+                rule_cell = rule_id + rule_pad
+            marker_cell = ""
+            if any_marker:
+                marker_cell = f"  {green}{marker:<3}{reset}" if marker else "     "
+            output.append(
+                f"  {line_txt:>{line_w}}  {sev_cell}  {rule_cell}{marker_cell}  {message}"
+            )
+
     documented = sorted({v.rule_id for v in shown if v.rule_id in builtin_ids})
     if documented:
         if hyperlinks:
@@ -151,8 +192,9 @@ def format_text(
                 f" the grade — run with -v to see them{reset}"
             )
 
-    # Legend for the [*]/[?] markers and the lint-to-fix hint. Counts are
-    # over the violations shown above, so marked lines and counts agree
+    # Legend for the [*]/[?] markers and the lint-to-fix hint. Counts are over
+    # the violations shown above; a collapsed row may cover several fixable
+    # violations under one marker, so the count can exceed the visible markers
     # (`skillsaw fix` groups per-file fixes and may report different totals).
     safe_fixable = sum(1 for v in shown if v.fixable and v.fix_confidence == AutofixConfidence.SAFE)
     suggest_fixable = sum(
@@ -177,3 +219,37 @@ def format_text(
         output.append(f"\n{green}{bold}✓ All checks passed!{reset}")
 
     return "\n".join(output)
+
+
+def format_statistics(
+    violations: List[RuleViolation],
+    verbose: bool = False,
+    fail_level: str = "error",
+    color: bool = False,
+) -> str:
+    """Ruff-style per-rule violation counts, highest first.
+
+    Text-format only; counts the same violations the report shows (info
+    included only with -v or ``fail-on: info``). Returns "" when nothing is
+    shown so the caller can skip printing.
+    """
+    show_info = should_show_info(verbose, fail_level)
+    shown = [v for v in violations if v.severity != Severity.INFO or show_info]
+    if not shown:
+        return ""
+
+    bold = "\033[1m" if color else ""
+    dim = "\033[2m" if color else ""
+    reset = "\033[0m" if color else ""
+
+    counts = {}
+    for v in shown:
+        counts[v.rule_id] = counts.get(v.rule_id, 0) + 1
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    count_w = max(len(str(c)) for _, c in ranked)
+
+    lines = [f"{bold}Statistics:{reset}"]
+    for rule_id, count in ranked:
+        lines.append(f"  {count:>{count_w}}  {rule_id}")
+    lines.append(f"  {dim}{len(shown)} violation(s) across {len(ranked)} rule(s){reset}")
+    return "\n".join(lines)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -244,9 +244,9 @@ def test_text_includes_rule_id(valid_plugin):
     violations = _make_violations()
 
     output = format_text(violations, context, [], "0.0.0", verbose=True)
-    assert "(plugin-json-required)" in output
-    assert "(command-naming)" in output
-    assert "(plugin-json-valid)" in output
+    assert "plugin-json-required" in output
+    assert "command-naming" in output
+    assert "plugin-json-valid" in output
 
 
 def test_text_verbose_shows_info(valid_plugin):
@@ -264,6 +264,114 @@ def test_text_non_verbose_hides_info(valid_plugin):
 
     output = format_text(violations, context, [], "0.0.0", verbose=False)
     assert "Info:" not in output
+
+
+# --- Text formatter: file grouping, dedup, statistics ---
+
+
+def _grouping_violations():
+    """Two files; one file has a rule+message repeated on three lines."""
+    return [
+        RuleViolation(
+            rule_id="content-terminology",
+            severity=Severity.INFO,
+            message='Use "skill" not "Skill"',
+            file_path=Path("a/SKILL.md"),
+            line=40,
+        ),
+        RuleViolation(
+            rule_id="content-terminology",
+            severity=Severity.INFO,
+            message='Use "skill" not "Skill"',
+            file_path=Path("a/SKILL.md"),
+            line=42,
+        ),
+        RuleViolation(
+            rule_id="content-terminology",
+            severity=Severity.INFO,
+            message='Use "skill" not "Skill"',
+            file_path=Path("a/SKILL.md"),
+            line=55,
+        ),
+        RuleViolation(
+            rule_id="content-terminology",
+            severity=Severity.INFO,
+            message='Use "skill" not "Skill"',
+            file_path=Path("b/README.md"),
+            line=3,
+        ),
+    ]
+
+
+def test_text_groups_violations_under_file_header(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_make_violations(), context, [], "0.0.0", verbose=True)
+    lines = output.splitlines()
+
+    # Each violation's file appears once as its own header line, and the
+    # rows for that file follow it.
+    assert "plugins/foo/commands/Bad_Name.md" in lines
+    assert "plugins/foo/.claude-plugin/plugin.json" in lines
+    assert "\nViolations:" in output
+
+
+def test_text_collapses_repeated_message_within_file(valid_plugin):
+    """A rule+message repeated in one file collapses to a single row listing
+    the extra line numbers; a different file keeps its own row."""
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_grouping_violations(), context, [], "0.0.0", verbose=True)
+
+    # The three a/SKILL.md hits collapse to one row with a line list.
+    assert "(also on lines 42, 55)" in output
+    # content-terminology appears once per file (a/SKILL.md + b/README.md).
+    assert output.count('Use "skill" not "Skill"') == 2
+
+
+def test_text_sorts_files_and_lines(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text(_grouping_violations(), context, [], "0.0.0", verbose=True)
+    lines = output.splitlines()
+
+    # Files are alphabetical: a/SKILL.md before b/README.md.
+    assert lines.index("a/SKILL.md") < lines.index("b/README.md")
+
+
+def test_text_no_violations_section_when_clean(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    output = format_text([], context, [], "0.0.0")
+    assert "Violations:" not in output
+    assert "All checks passed" in output
+
+
+def test_statistics_ranks_rules_by_count():
+    from skillsaw.formatters.text import format_statistics
+
+    output = format_statistics(_grouping_violations(), verbose=True)
+    assert "Statistics:" in output
+    assert "content-terminology" in output
+    # 4 violations, one rule.
+    assert "4  content-terminology" in output
+    assert "4 violation(s) across 1 rule(s)" in output
+
+
+def test_statistics_empty_when_nothing_shown():
+    from skillsaw.formatters.text import format_statistics
+
+    # All info; without verbose/fail-on info they are not shown.
+    assert format_statistics(_grouping_violations(), verbose=False) == ""
+
+
+def test_statistics_descending_order():
+    from skillsaw.formatters.text import format_statistics
+
+    violations = [
+        RuleViolation("rule-a", Severity.ERROR, "x", Path("f.md"), 1),
+        RuleViolation("rule-b", Severity.ERROR, "y", Path("f.md"), 2),
+        RuleViolation("rule-b", Severity.ERROR, "z", Path("f.md"), 3),
+    ]
+    output = format_statistics(violations)
+    lines = [ln.strip() for ln in output.splitlines()]
+    assert lines.index("2  rule-b") < lines.index("1  rule-a")
 
 
 # --- JSON formatter ---
@@ -1034,24 +1142,36 @@ def _make_fixable_violations():
 def test_text_marks_safe_fixable_violations(valid_plugin):
     context = RepositoryContext(valid_plugin)
     output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+    lines = output.splitlines()
 
-    assert "(agentskill-valid) [*] [skills/foo/SKILL.md]:" in output
-    assert "(agent-frontmatter) [*] [agents/bar.md]:" in output
+    # Violations are grouped under a per-file header; the [*] marker is a
+    # column on the matching rule's row.
+    assert "skills/foo/SKILL.md" in lines
+    assert any("agentskill-valid" in ln and "[*]" in ln for ln in lines)
+    assert "agents/bar.md" in lines
+    assert any("agent-frontmatter" in ln and "[*]" in ln for ln in lines)
 
 
 def test_text_marks_suggest_fixable_violations(valid_plugin):
     context = RepositoryContext(valid_plugin)
     output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+    lines = output.splitlines()
 
-    assert "(content-broken-internal-reference) [?] [SKILL.md:8]:" in output
+    assert "SKILL.md" in lines  # top-level SKILL.md file header
+    assert any("content-broken-internal-reference" in ln and "[?]" in ln for ln in lines)
 
 
 def test_text_no_marker_on_unfixable_violation(valid_plugin):
     context = RepositoryContext(valid_plugin)
     output = format_text(_make_fixable_violations(), context, [], "0.0.0")
+    lines = output.splitlines()
 
-    # Same rule id as a marked violation — only the fixable one is marked.
-    assert "(agentskill-valid) [skills/baz/SKILL.md]:" in output
+    # Same rule id as a marked violation elsewhere — the unfixable one's row
+    # (under its own file) carries no marker.
+    assert "skills/baz/SKILL.md" in lines
+    row = lines[lines.index("skills/baz/SKILL.md") + 1]
+    assert "agentskill-valid" in row
+    assert "[*]" not in row and "[?]" not in row
 
 
 def test_text_no_marker_when_fixability_unknown(valid_plugin):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1383,6 +1383,33 @@ class TestExitCodes:
         results = sarif["runs"][0]["results"]
         assert any(res["level"] == "note" for res in results)
 
+    def test_text_groups_violations_by_file(self, tmp_path):
+        """Text output lists each violated file once as a header, with its
+        rows grouped beneath it rather than scattered per-severity."""
+        repo = copy_fixture("agentskills", tmp_path)
+        r = run_lint(repo, fmt="text", verbose=True)
+        assert "Violations:" in r["stdout"]
+        lines = r["stdout"].splitlines()
+        # A file header line appears exactly once even when the file has
+        # violations from several rules.
+        header = "broken/Bad_Formatter/SKILL.md"
+        assert lines.count(header) == 1
+
+    def test_statistics_flag_prints_per_rule_counts(self, tmp_path):
+        repo = copy_fixture("agentskills", tmp_path)
+        r = run_lint(repo, "--statistics", fmt="text", verbose=True)
+        assert "Statistics:" in r["stdout"]
+        assert "content-weak-language" in r["stdout"]
+        assert "violation(s) across" in r["stdout"]
+
+    def test_statistics_flag_noop_without_violations(self, tmp_path):
+        repo = copy_fixture("agentskills", tmp_path)
+        # Without -v the info-only files still leave errors/warnings, so use a
+        # clean subtree to confirm the block is omitted when nothing is shown.
+        clean = repo / "clean" / "database-migrate"
+        r = run_lint(clean, "--statistics", fmt="text", verbose=False)
+        assert "Statistics:" not in r["stdout"]
+
 
 # ── Output Formats ───────────────────────────────────────────────
 
@@ -2514,21 +2541,24 @@ class TestLintFixLoop:
         repo = copy_fixture(self.FIXTURE, tmp_path)
         r = run_lint(repo, fmt="text", verbose=False)
 
-        # SAFE-autofixable rules carry the [*] marker after the rule id.
-        assert "(agent-frontmatter) [*]" in r["stdout"]
-        assert "(command-frontmatter) [*]" in r["stdout"]
+        lines = r["stdout"].splitlines()
+
+        def row(rule_id, message):
+            return next(ln for ln in lines if rule_id in ln and message in ln)
+
+        # SAFE-autofixable rules carry the [*] marker in their row's column.
+        assert any("agent-frontmatter" in ln and "[*]" in ln for ln in lines)
+        assert any("command-frontmatter" in ln and "[*]" in ln for ln in lines)
         # Rules without an autofix never get a marker.
-        assert "(agentskill-unreferenced-files) [*]" not in r["stdout"]
-        assert "(agentskill-unreferenced-files) [?]" not in r["stdout"]
-        # agentskill-valid only fixes the missing-name subset.
-        assert (
-            "(agentskill-valid) [*] [skills/missing-name/SKILL.md]: "
-            "Missing required 'name' field" in r["stdout"]
+        assert not any(
+            "agentskill-unreferenced-files" in ln and ("[*]" in ln or "[?]" in ln) for ln in lines
         )
-        assert (
-            "(agentskill-valid) [skills/no-frontmatter/SKILL.md]: "
-            "Missing YAML frontmatter" in r["stdout"]
-        )
+        # agentskill-valid only fixes the missing-name subset. Both files are
+        # grouped under their own header; the marker lives on the row.
+        assert "skills/missing-name/SKILL.md" in lines
+        assert "[*]" in row("agentskill-valid", "Missing required 'name' field")
+        no_fm = row("agentskill-valid", "Missing YAML frontmatter")
+        assert "[*]" not in no_fm and "[?]" not in no_fm
 
     def test_text_lint_summary_shows_fixable_count(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)


### PR DESCRIPTION
Closes #413.

## What

Rewrites the default text formatter so violations are **grouped by file** — the layout eslint/ruff settled on — instead of three flat per-severity lists in rule-execution order.

- One relative-path header per file; rows underneath in aligned `line` / severity / rule / message columns, with the `[*]`/`[?]` fixability marker as its own column.
- **Within-file dedup:** a repeated `(rule, severity, message)` run collapses to one row that lists the extra line numbers (`(also on lines 42, 55)`).
- Files sort by path; rows by first line then severity.
- New `--statistics` flag (text only): ruff-style per-rule counts, highest first, with a total footer.

JSON/SARIF/HTML formatters and the `Scanned:` / `Summary:` / grade / `Rule docs` blocks are untouched. Hyperlink behavior is preserved (file headers and rule ids remain clickable under `--color` on a real terminal).

### Before

```
Errors:
  ✗ ERROR (agentskill-name) [*] [skills/my-skill/SKILL.md:2]: Name 'My Skill' must ...
Warnings:
  ⚠ WARNING (agentskill-description) [skills/helper/SKILL.md:3]: Description exceeds ...
```

### After

```
Violations:

skills/helper/SKILL.md
  3  ⚠ warning  agentskill-description      Description exceeds 1024 characters (1087)

skills/my-skill/SKILL.md
  2  ✗ error    agentskill-name        [*]  Name 'My Skill' must contain only ...
```

## Design decision

The issue proposed a second dedup layer that folds verbatim-identical messages *across* files under the first occurrence. I **dropped that** on purpose: it fights the by-file grouping and hides which files the repeats live in. Within-file collapsing keeps every location visible. (Confirmed with the repo owner before implementing.)

## Testing

- New unit tests for grouping, within-file collapse, file/line sorting, and `--statistics` (ranking, empty case, descending order).
- New integration tests: grouped-by-file headers, `--statistics` output, and the no-op-when-clean case.
- Updated the old per-severity/inline-format assertions in `tests/test_formatters.py` and `tests/test_integration.py`.
- Full suite: 2617 passed. `make lint` clean, `make update` regenerated `docs/cli.md`.
- Smoke-tested against `openshift-eng/ai-helpers` (452 info violations) — exit 0, output is dramatically more scannable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)