### PR TITLE
docs(openclaw-metadata): explain impact, allowed values, and fixes

### DIFF
--- a/docs/rules/openclaw-metadata.md
+++ b/docs/rules/openclaw-metadata.md
@@ -15,46 +15,35 @@ Validate metadata.openclaw fields against the openclaw spec
 
 ## Why
 
-The `metadata.openclaw` block in SKILL.md frontmatter registers the
-skill with the openclaw ecosystem. Invalid or missing fields mean the
-skill will not be indexed correctly, reducing its discoverability
-through openclaw-compatible tools.
+`metadata.openclaw` drives real runtime behavior: platform gating (`os`),
+activation requirements (`requires`), and dependency installation
+(`install`). openclaw validates it loosely and **silently ignores fields
+it doesn't recognize** — an invalid `kind`, `os`, or `archive` value
+produces no error, the skill just quietly misbehaves (e.g. an installer
+that never appears in `openclaw skills info`). This rule catches those
+mistakes at author time.
 
-## Examples
+See the [openclaw skills spec](https://docs.openclaw.ai/tools/skills) for
+the authoritative field list.
 
-**Bad:**
+## Allowed values
 
-```yaml
----
-name: deploy
-description: Deploy to staging
-metadata:
-  openclaw:
-    version: latest
----
-```
-
-**Good:**
-
-```yaml
----
-name: deploy
-description: Deploy to staging
-metadata:
-  openclaw:
-    version: "1.0.0"
-    license: MIT
-    author: acme-corp
----
-```
+| Field | Values |
+|---|---|
+| `install[].kind` | `brew`, `node`, `go`, `uv`, `download` |
+| `os`, `install[].os` | `darwin`, `linux`, `win32` |
+| `install[].archive` | `tar.gz`, `tar.bz2`, `zip` |
+| `requires` keys | `bins`, `anyBins`, `env`, `config` |
 
 ## How to fix
 
-Add or correct the fields identified in the violation message to
-match the
-[openclaw spec](https://docs.openclaw.ai/tools/skills). This rule
-only fires when `metadata.openclaw` is present — removing the block
-suppresses it entirely.
+Correct the flagged field to an allowed value. Common cases: `npm` isn't
+a kind — use `kind: node` with a `package`; `kind: download` requires a
+`url`; there is no `apt`/`dnf` kind (use `brew`, which also runs on
+Linux, or `download`).
+
+This rule only fires when `metadata.openclaw` is present — removing the
+block suppresses it entirely.
 
 ## Configuration
 

--- a/src/skillsaw/rules/docs/openclaw-metadata.md
+++ b/src/skillsaw/rules/docs/openclaw-metadata.md
@@ -1,42 +1,31 @@
 ## Why
 
-The `metadata.openclaw` block in SKILL.md frontmatter registers the
-skill with the openclaw ecosystem. Invalid or missing fields mean the
-skill will not be indexed correctly, reducing its discoverability
-through openclaw-compatible tools.
+`metadata.openclaw` drives real runtime behavior: platform gating (`os`),
+activation requirements (`requires`), and dependency installation
+(`install`). openclaw validates it loosely and **silently ignores fields
+it doesn't recognize** — an invalid `kind`, `os`, or `archive` value
+produces no error, the skill just quietly misbehaves (e.g. an installer
+that never appears in `openclaw skills info`). This rule catches those
+mistakes at author time.
 
-## Examples
+See the [openclaw skills spec](https://docs.openclaw.ai/tools/skills) for
+the authoritative field list.
 
-**Bad:**
+## Allowed values
 
-```yaml
----
-name: deploy
-description: Deploy to staging
-metadata:
-  openclaw:
-    version: latest
----
-```
-
-**Good:**
-
-```yaml
----
-name: deploy
-description: Deploy to staging
-metadata:
-  openclaw:
-    version: "1.0.0"
-    license: MIT
-    author: acme-corp
----
-```
+| Field | Values |
+|---|---|
+| `install[].kind` | `brew`, `node`, `go`, `uv`, `download` |
+| `os`, `install[].os` | `darwin`, `linux`, `win32` |
+| `install[].archive` | `tar.gz`, `tar.bz2`, `zip` |
+| `requires` keys | `bins`, `anyBins`, `env`, `config` |
 
 ## How to fix
 
-Add or correct the fields identified in the violation message to
-match the
-[openclaw spec](https://docs.openclaw.ai/tools/skills). This rule
-only fires when `metadata.openclaw` is present — removing the block
-suppresses it entirely.
+Correct the flagged field to an allowed value. Common cases: `npm` isn't
+a kind — use `kind: node` with a `package`; `kind: download` requires a
+`url`; there is no `apt`/`dnf` kind (use `brew`, which also runs on
+Linux, or `download`).
+
+This rule only fires when `metadata.openclaw` is present — removing the
+block suppresses it entirely.


### PR DESCRIPTION
Improves the [`openclaw-metadata`](https://skillsaw.org/rules/openclaw-metadata/) rule page.

The current page's **Why** is vague ("discoverability", "indexed correctly") and its Bad/Good examples use `version`/`license`/`author` — fields that aren't part of the openclaw spec at all, so they're misleading.

Rewrite (concise, but clearer):

- **Why** — openclaw silently ignores fields it doesn't recognize, so an invalid `kind`/`os`/`archive` produces no error and the skill just quietly misbehaves (e.g. an installer that never shows up in `openclaw skills info`). Explains what the rule protects against.
- **Allowed values** — compact table for the enum fields (`install[].kind`, `os`, `archive`, `requires` keys) so authors can self-serve.
- **How to fix** — concrete common cases (`npm` → `kind: node` + `package`; `download` needs `url`; no `apt`/`dnf` kind).
- Links the upstream [openclaw skills spec](https://docs.openclaw.ai/tools/skills).

Source lives in `src/skillsaw/rules/docs/openclaw-metadata.md` (also feeds `skillsaw explain`); `docs/rules/openclaw-metadata.md` regenerated via `generate-site-content`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `metadata.openclaw` settings affect runtime behavior, including platform gating, activation requirements, and dependency installation.
  * Added a clear list of accepted values and formats for supported fields.
  * Improved fix guidance with common validation mistakes and examples of correct usage.
  * Removed outdated example-based wording and noted that the rule only applies when `metadata.openclaw` is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->