### PR TITLE
docs(openclaw-metadata): capitalize "OpenClaw" project name in prose

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -289,7 +289,7 @@ rules:
     enabled: true
     severity: error
 
-  # Validate metadata.openclaw fields against the openclaw spec
+  # Validate metadata.openclaw fields against the OpenClaw spec
   openclaw-metadata:
     enabled: auto
     severity: warning

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -52,7 +52,7 @@ organized into the following categories:
 | [`mcp-valid-json`](mcp-valid-json.md) | MCP configuration must be valid JSON with proper mcpServers structure | error | - | MCP (Model Context Protocol) |
 | [`mcp-prohibited`](mcp-prohibited.md) | Repository should not enable non-allowlisted MCP servers | error (disabled) | - | MCP (Model Context Protocol) |
 | [`rules-valid`](rules-valid.md) | .claude/rules/ files must be markdown with valid optional paths frontmatter | error (auto) | - | Rules Directory |
-| [`openclaw-metadata`](openclaw-metadata.md) | Validate metadata.openclaw fields against the openclaw spec | warning (auto) | - | OpenClaw |
+| [`openclaw-metadata`](openclaw-metadata.md) | Validate metadata.openclaw fields against the OpenClaw spec | warning (auto) | - | OpenClaw |
 | [`instruction-file-valid`](instruction-file-valid.md) | Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) must be valid and non-empty | warning (auto) | - | Instruction Files |
 | [`instruction-imports-valid`](instruction-imports-valid.md) | Import references (@path) in AGENTS.md, CLAUDE.md, and GEMINI.md must point to existing files | warning (auto) | - | Instruction Files |
 | [`context-budget`](context-budget.md) | Warn when instruction or config files exceed recommended token limits | warning (auto) | - | Context Budget |

--- a/docs/rules/openclaw-metadata.md
+++ b/docs/rules/openclaw-metadata.md
@@ -3,7 +3,7 @@
 
 # openclaw-metadata
 
-Validate metadata.openclaw fields against the openclaw spec
+Validate metadata.openclaw fields against the OpenClaw spec
 
 | | |
 |---|---|
@@ -17,13 +17,13 @@ Validate metadata.openclaw fields against the openclaw spec
 
 `metadata.openclaw` drives real runtime behavior: platform gating (`os`),
 activation requirements (`requires`), and dependency installation
-(`install`). openclaw validates it loosely and **silently ignores fields
+(`install`). OpenClaw validates it loosely and **silently ignores fields
 it doesn't recognize** — an invalid `kind`, `os`, or `archive` value
 produces no error, the skill just quietly misbehaves (e.g. an installer
 that never appears in `openclaw skills info`). This rule catches those
 mistakes at author time.
 
-See the [openclaw skills spec](https://docs.openclaw.ai/tools/skills) for
+See the [OpenClaw skills spec](https://docs.openclaw.ai/tools/skills) for
 the authoritative field list.
 
 ## Allowed values

--- a/docs/rules/openclaw.md
+++ b/docs/rules/openclaw.md
@@ -3,9 +3,9 @@
 
 # OpenClaw
 
-Validates `metadata.openclaw` in SKILL.md frontmatter against the [openclaw spec](https://docs.openclaw.ai/tools/skills). Only fires when `metadata.openclaw` is present.
+Validates `metadata.openclaw` in SKILL.md frontmatter against the [OpenClaw spec](https://docs.openclaw.ai/tools/skills). Only fires when `metadata.openclaw` is present.
 
 | Rule ID | Description | Default Severity | Autofix |
 |---------|-------------|------------------|---------|
-| [`openclaw-metadata`](openclaw-metadata.md) | Validate metadata.openclaw fields against the openclaw spec | warning (auto) | - |
+| [`openclaw-metadata`](openclaw-metadata.md) | Validate metadata.openclaw fields against the OpenClaw spec | warning (auto) | - |
 

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -81,10 +81,10 @@ RULE_GROUPS = [
         None,
     ),
     (
-        "Openclaw",
+        "OpenClaw",
         ["openclaw-metadata"],
         "Validates `metadata.openclaw` in SKILL.md frontmatter against the "
-        "[openclaw spec](https://docs.openclaw.ai/tools/skills). Only fires "
+        "[OpenClaw spec](https://docs.openclaw.ai/tools/skills). Only fires "
         "when `metadata.openclaw` is present.",
     ),
     (

--- a/scripts/generate-site-content.py
+++ b/scripts/generate-site-content.py
@@ -115,7 +115,7 @@ RULE_GROUPS = [
         "openclaw",
         ["openclaw-metadata"],
         "Validates `metadata.openclaw` in SKILL.md frontmatter against the "
-        "[openclaw spec](https://docs.openclaw.ai/tools/skills). Only fires "
+        "[OpenClaw spec](https://docs.openclaw.ai/tools/skills). Only fires "
         "when `metadata.openclaw` is present.",
     ),
     (

--- a/src/skillsaw/rules/builtin/openclaw/metadata.py
+++ b/src/skillsaw/rules/builtin/openclaw/metadata.py
@@ -14,7 +14,7 @@ VALID_ARCHIVE_TYPES = {"tar.gz", "tar.bz2", "zip"}
 
 
 class OpenclawMetadataRule(Rule):
-    """Validate metadata.openclaw in SKILL.md frontmatter against the openclaw spec"""
+    """Validate metadata.openclaw in SKILL.md frontmatter against the OpenClaw spec"""
 
     repo_types = {
         RepositoryType.AGENTSKILLS,
@@ -29,7 +29,7 @@ class OpenclawMetadataRule(Rule):
 
     @property
     def description(self) -> str:
-        return "Validate metadata.openclaw fields against the openclaw spec"
+        return "Validate metadata.openclaw fields against the OpenClaw spec"
 
     def default_severity(self) -> Severity:
         return Severity.WARNING

--- a/src/skillsaw/rules/docs/openclaw-metadata.md
+++ b/src/skillsaw/rules/docs/openclaw-metadata.md
@@ -2,13 +2,13 @@
 
 `metadata.openclaw` drives real runtime behavior: platform gating (`os`),
 activation requirements (`requires`), and dependency installation
-(`install`). openclaw validates it loosely and **silently ignores fields
+(`install`). OpenClaw validates it loosely and **silently ignores fields
 it doesn't recognize** — an invalid `kind`, `os`, or `archive` value
 produces no error, the skill just quietly misbehaves (e.g. an installer
 that never appears in `openclaw skills info`). This rule catches those
 mistakes at author time.
 
-See the [openclaw skills spec](https://docs.openclaw.ai/tools/skills) for
+See the [OpenClaw skills spec](https://docs.openclaw.ai/tools/skills) for
 the authoritative field list.
 
 ## Allowed values


### PR DESCRIPTION
Follow-up to #421 addressing [gemini-code-assist's review feedback](https://github.com/stbenjam/skillsaw/pull/421#discussion_r-) — the project name should be capitalized **OpenClaw** in prose.

Capitalizes "OpenClaw" in the rule doc body, the rule `description`, and the two generator description strings. **Prose only** — code spans (`metadata.openclaw`, the `openclaw skills info` command), the rule id, slug, and URLs stay lowercase. `docs/rules/*` regenerated from source.

12 insertions / 12 deletions; all 93 docs + openclaw tests pass.