### PR TITLE
[Auto] Restore content-unlinked-internal-reference suppression in skillsaw-maintenance (A+ regression from #424)

### DIFF
--- a/.agents/skills/skillsaw-maintenance/SKILL.md
+++ b/.agents/skills/skillsaw-maintenance/SKILL.md
@@ -10,6 +10,7 @@ metadata:
 ---
 
 <!-- Repo-root-relative src/... paths below are not navigable from this skill's directory, so they stay as inline code. Links to references/*.md are real files in this skill and are navigable. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
 
 # skillsaw Maintenance
 

--- a/.agents/skills/skillsaw-maintenance/references/agentskills.md
+++ b/.agents/skills/skillsaw-maintenance/references/agentskills.md
@@ -1,5 +1,8 @@
 # agentskills.io (Agent Skills)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Spec (authoritative for prose): https://agentskills.io/specification
 - GitHub source repo: https://github.com/agentskills/agentskills — "Specification and

--- a/.agents/skills/skillsaw-maintenance/references/apm.md
+++ b/.agents/skills/skillsaw-maintenance/references/apm.md
@@ -1,5 +1,8 @@
 # APM (Agent Package Manager)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Repo: https://github.com/microsoft/apm — Microsoft's Agent Package Manager (npm-like
   dependency manager for AI agents).

--- a/.agents/skills/skillsaw-maintenance/references/claude.md
+++ b/.agents/skills/skillsaw-maintenance/references/claude.md
@@ -1,5 +1,8 @@
 # Claude Code formats
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Claude Code has several distinct formats. `.claude/` is NOT a plugin — it has its own
 layout. Each format below maps to its own skillsaw rules.
 

--- a/.agents/skills/skillsaw-maintenance/references/coderabbit.md
+++ b/.agents/skills/skillsaw-maintenance/references/coderabbit.md
@@ -1,5 +1,8 @@
 # CodeRabbit (`.coderabbit.yaml`)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Configuration reference (authoritative, auto-generated from the schema):
   https://docs.coderabbit.ai/reference/configuration

--- a/.agents/skills/skillsaw-maintenance/references/mcp.md
+++ b/.agents/skills/skillsaw-maintenance/references/mcp.md
@@ -1,5 +1,8 @@
 # Model Context Protocol (MCP)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 This covers the MCP protocol spec itself. For MCP config *as embedded in Claude Code*
 (`.mcp.json`, `mcpServers`), see also `references/claude.md`.
 

--- a/.agents/skills/skillsaw-maintenance/references/openclaw.md
+++ b/.agents/skills/skillsaw-maintenance/references/openclaw.md
@@ -1,5 +1,8 @@
 # OpenClaw
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Most drift-prone tracked spec. OpenClaw publishes **no JSON Schema**, so skillsaw's
 `openclaw-metadata` rule is the de-facto validator. The rule hand-copies value sets that
 MUST be re-checked against upstream types on every maintenance pass (see Sync notes).

--- a/.apm/skills/skillsaw-maintenance/SKILL.md
+++ b/.apm/skills/skillsaw-maintenance/SKILL.md
@@ -10,6 +10,7 @@ metadata:
 ---
 
 <!-- Repo-root-relative src/... paths below are not navigable from this skill's directory, so they stay as inline code. Links to references/*.md are real files in this skill and are navigable. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
 
 # skillsaw Maintenance
 

--- a/.apm/skills/skillsaw-maintenance/references/agentskills.md
+++ b/.apm/skills/skillsaw-maintenance/references/agentskills.md
@@ -1,5 +1,8 @@
 # agentskills.io (Agent Skills)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Spec (authoritative for prose): https://agentskills.io/specification
 - GitHub source repo: https://github.com/agentskills/agentskills — "Specification and

--- a/.apm/skills/skillsaw-maintenance/references/apm.md
+++ b/.apm/skills/skillsaw-maintenance/references/apm.md
@@ -1,5 +1,8 @@
 # APM (Agent Package Manager)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Repo: https://github.com/microsoft/apm — Microsoft's Agent Package Manager (npm-like
   dependency manager for AI agents).

--- a/.apm/skills/skillsaw-maintenance/references/claude.md
+++ b/.apm/skills/skillsaw-maintenance/references/claude.md
@@ -1,5 +1,8 @@
 # Claude Code formats
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Claude Code has several distinct formats. `.claude/` is NOT a plugin — it has its own
 layout. Each format below maps to its own skillsaw rules.
 

--- a/.apm/skills/skillsaw-maintenance/references/coderabbit.md
+++ b/.apm/skills/skillsaw-maintenance/references/coderabbit.md
@@ -1,5 +1,8 @@
 # CodeRabbit (`.coderabbit.yaml`)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Configuration reference (authoritative, auto-generated from the schema):
   https://docs.coderabbit.ai/reference/configuration

--- a/.apm/skills/skillsaw-maintenance/references/mcp.md
+++ b/.apm/skills/skillsaw-maintenance/references/mcp.md
@@ -1,5 +1,8 @@
 # Model Context Protocol (MCP)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 This covers the MCP protocol spec itself. For MCP config *as embedded in Claude Code*
 (`.mcp.json`, `mcpServers`), see also `references/claude.md`.
 

--- a/.apm/skills/skillsaw-maintenance/references/openclaw.md
+++ b/.apm/skills/skillsaw-maintenance/references/openclaw.md
@@ -1,5 +1,8 @@
 # OpenClaw
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Most drift-prone tracked spec. OpenClaw publishes **no JSON Schema**, so skillsaw's
 `openclaw-metadata` rule is the de-facto validator. The rule hand-copies value sets that
 MUST be re-checked against upstream types on every maintenance pass (see Sync notes).

--- a/.claude/skills/skillsaw-maintenance/SKILL.md
+++ b/.claude/skills/skillsaw-maintenance/SKILL.md
@@ -10,6 +10,7 @@ metadata:
 ---
 
 <!-- Repo-root-relative src/... paths below are not navigable from this skill's directory, so they stay as inline code. Links to references/*.md are real files in this skill and are navigable. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
 
 # skillsaw Maintenance
 

--- a/.claude/skills/skillsaw-maintenance/references/agentskills.md
+++ b/.claude/skills/skillsaw-maintenance/references/agentskills.md
@@ -1,5 +1,8 @@
 # agentskills.io (Agent Skills)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Spec (authoritative for prose): https://agentskills.io/specification
 - GitHub source repo: https://github.com/agentskills/agentskills — "Specification and

--- a/.claude/skills/skillsaw-maintenance/references/apm.md
+++ b/.claude/skills/skillsaw-maintenance/references/apm.md
@@ -1,5 +1,8 @@
 # APM (Agent Package Manager)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Repo: https://github.com/microsoft/apm — Microsoft's Agent Package Manager (npm-like
   dependency manager for AI agents).

--- a/.claude/skills/skillsaw-maintenance/references/claude.md
+++ b/.claude/skills/skillsaw-maintenance/references/claude.md
@@ -1,5 +1,8 @@
 # Claude Code formats
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Claude Code has several distinct formats. `.claude/` is NOT a plugin — it has its own
 layout. Each format below maps to its own skillsaw rules.
 

--- a/.claude/skills/skillsaw-maintenance/references/coderabbit.md
+++ b/.claude/skills/skillsaw-maintenance/references/coderabbit.md
@@ -1,5 +1,8 @@
 # CodeRabbit (`.coderabbit.yaml`)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 ## Upstream source(s)
 - Configuration reference (authoritative, auto-generated from the schema):
   https://docs.coderabbit.ai/reference/configuration

--- a/.claude/skills/skillsaw-maintenance/references/mcp.md
+++ b/.claude/skills/skillsaw-maintenance/references/mcp.md
@@ -1,5 +1,8 @@
 # Model Context Protocol (MCP)
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 This covers the MCP protocol spec itself. For MCP config *as embedded in Claude Code*
 (`.mcp.json`, `mcpServers`), see also `references/claude.md`.
 

--- a/.claude/skills/skillsaw-maintenance/references/openclaw.md
+++ b/.claude/skills/skillsaw-maintenance/references/openclaw.md
@@ -1,5 +1,8 @@
 # OpenClaw
 
+<!-- Repo-root-relative src/... and cross-reference paths below are intentionally kept as prose, not navigable links. -->
+<!-- skillsaw-disable content-unlinked-internal-reference -->
+
 Most drift-prone tracked spec. OpenClaw publishes **no JSON Schema**, so skillsaw's
 `openclaw-metadata` rule is the de-facto validator. The rule hand-copies value sets that
 MUST be re-checked against upstream types on every maintenance pass (see Sync notes).

--- a/.skillsaw-badge.json
+++ b/.skillsaw-badge.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "skillsaw",
-  "message": "A",
+  "message": "A+",
   "color": "brightgreen",
   "logoSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill-rule=\"evenodd\" fill=\"#fff\" d=\"M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z\"/></svg>"
 }

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="495" height="195" viewBox="0 0 495 195" fill="none" role="img" aria-labelledby="card-title">
-  <title id="card-title">skillsaw report card for skillsaw: grade A</title>
+  <title id="card-title">skillsaw report card for skillsaw: grade A+</title>
   <style>
     .title { font: 600 16px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .subtitle { font: 400 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
@@ -16,16 +16,15 @@
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
   <text x="56" y="46" class="subtitle">skillsaw report card</text>
   <g data-testid="stats">
-    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">1.08</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">26,755</tspan></tspan></text>
+    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.04</tspan> per 10k tokens</tspan></text>
+    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">27,049</tspan></tspan></text>
     <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">10</tspan> skills</tspan></text>
     <text x="24" y="139" class="label">Top rules</text>
-    <text x="24" y="154" class="rule" data-testid="rule-0">1. content-unlinked-internal-reference (28)</text>
-    <text x="24" y="168" class="rule" data-testid="rule-1">2. content-actionability-score (1)</text>
+    <text x="24" y="154" class="rule" data-testid="rule-0">1. content-actionability-score (1)</text>
   </g>
   <g transform="translate(415.5, 97.5)">
     <circle r="46" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>
-    <circle r="46" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="262.75 289.03"/>
-    <text y="16" text-anchor="middle" class="grade-letter" data-testid="grade-letter">A</text>
+    <circle r="46" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="289.03 289.03"/>
+    <text y="16" text-anchor="middle" class="grade-letter" data-testid="grade-letter">A+</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

Follow-up to #424. That PR's progressive-disclosure refactor dropped the skillsaw scorecard from **A+ to A** by surfacing 28 `content-unlinked-internal-reference` info violations. This restores the suppression and brings the grade back to **A+**.

## Root cause

In the pre-refactor single-file layout, the top-of-`SKILL.md` block directive `<!-- skillsaw-disable content-unlinked-internal-reference -->` suppressed every repo-root-relative `src/...` path reference. That directive is **per-file** and scoped from its line to EOF (see `src/skillsaw/suppression.py`). #424 split the skill body out into `references/*.md`, moving those path references **out of the directive's scope** — so the 28 violations became active and the grade fell to A.

Restoring the directive in `SKILL.md` alone is a no-op (the refactored `SKILL.md` body has zero such violations — all links are navigable and all paths are inline code). The suppression has to be re-established **where the content now lives**.

## Change

- Re-add the exact `<!-- skillsaw-disable content-unlinked-internal-reference -->` directive to `SKILL.md`.
- Add it (with a one-line rationale comment) to each `references/*.md` that carries repo-root-relative `src/...` / cross-reference paths.
- Applied in the `.apm/` source and propagated to `.claude/` and `.agents/` via `make update`; badge/card regenerated.

## Verification

| | grade | density | content-unlinked (active) |
|---|---|---|---|
| pre-refactor (base) | A+ | 0.00 | 0 |
| after #424 | A | 1.08 | 28 |
| **this PR** | **A+** | **0.04** | **0** |

`make update` is idempotent (2nd run leaves a clean tree — `verify-update` passes).

Generated by the [skillsaw-maintenance](https://github.com/stbenjam/skillsaw) skill.
