### PR TITLE
ci: collect coverage only on the 3.11 test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,17 @@ jobs:
           pip install -e .
           pip install pytest pytest-cov
 
+      # Coverage is only uploaded from the 3.11 job, so only 3.11 pays the
+      # measurement cost. This matters most on 3.12, where settrace-based
+      # coverage de-optimizes the specializing interpreter and roughly
+      # doubled the job time (~8 min vs ~4 min for every other version).
       - name: Run tests
+        if: matrix.python-version != '3.11'
+        run: |
+          pytest tests/ -v
+
+      - name: Run tests with coverage
+        if: matrix.python-version == '3.11'
         run: |
           pytest tests/ -v --cov=src/skillsaw --cov-report=xml --cov-report=term
 


### PR DESCRIPTION
## Summary

Every job in the test matrix ran `pytest --cov`, but Codecov only uploads the report from the 3.11 job — the coverage collected on the other five versions was thrown away. This drops `--cov` everywhere except 3.11.

The waste is worst on Python 3.12, where settrace-based coverage de-optimizes the specializing adaptive interpreter (PEP 659): across the last five main-branch runs, `test (3.12)` consistently took 6.3–8.2 minutes while every other version took 3–4 minutes. 3.13 fixed the instrumentation cost, which is why only 3.12 shows the penalty.

| Run | 3.9 | 3.10 | 3.11 | 3.12 | 3.13 | 3.14 |
|---|---|---|---|---|---|---|
| 29790841357 | 4.1 | 4.2 | 3.9 | **8.2** | 4.0 | 3.3 |
| 29782501063 | 3.6 | 4.0 | 3.2 | **6.5** | 3.8 | 3.2 |
| 29522920347 | 4.0 | 3.2 | 3.7 | **6.3** | 3.9 | 2.1 |
| 29519085210 | 3.8 | 3.9 | 4.1 | **8.0** | 3.9 | 3.5 |
| 28946087044 | 3.7 | 4.1 | 3.7 | **7.8** | 3.8 | 3.5 |

(durations in minutes)

## Changes

- `test.yml`: the `Run tests` step splits into a plain `pytest` step (all versions except 3.11) and a `--cov` step (3.11 only, matching the existing Codecov upload condition).

## Testing

- Workflow-only change; the matrix runs on this PR demonstrate it — 3.12 should land back in the ~3–4 minute band, and the 3.11 job still produces `coverage.xml` for Codecov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->