### PR TITLE
ci(rule-impact): link findings to the exact file@SHA that was linted

### DIFF
--- a/.github/workflows/rule-impact.yml
+++ b/.github/workflows/rule-impact.yml
@@ -75,13 +75,16 @@ jobs:
             grep -qx "$rule" /tmp/base-known.txt && base_args="$base_args --rule $rule"
           done < /tmp/changed-rules.txt
 
-          mkdir -p /tmp/repos /tmp/out/base /tmp/out/head
+          mkdir -p /tmp/repos /tmp/out/base /tmp/out/head /tmp/out/sha
           for r in openshift-eng/ai-helpers auth0/agent-skills \
                    opendatahub-io/agent-eval-harness kubernetes-sigs/maintainer-tools \
                    RedHatProductSecurity/prodsec-skills; do
             name=$(basename "$r")
             slug=${r//\//__}  # encode org/repo into the filename for the report
             git clone --quiet --depth 1 "https://github.com/$r.git" "/tmp/repos/$name"
+            # Record the commit being linted so the report can permalink
+            # findings to the exact file@line on GitHub.
+            git -C "/tmp/repos/$name" rev-parse HEAD > "/tmp/out/sha/$slug.sha"
 
             # Findings exit 1 — only rc > 1 (crash) is fatal.
             rc=0
@@ -100,7 +103,7 @@ jobs:
           done
 
           /tmp/head-venv/bin/python scripts/rule-impact-report.py \
-            --base /tmp/out/base --head /tmp/out/head \
+            --base /tmp/out/base --head /tmp/out/head --shas /tmp/out/sha \
             --rules "$(tr '\n' ' ' < /tmp/changed-rules.txt)" > /tmp/report.md
           cat /tmp/report.md
 

--- a/scripts/rule-impact-report.py
+++ b/scripts/rule-impact-report.py
@@ -17,6 +17,7 @@ worth posting.
 import argparse
 import json
 from pathlib import Path
+from urllib.parse import quote
 
 MARKER = "<!-- rule-impact-report -->"
 SAMPLE_LIMIT = 10
@@ -30,6 +31,23 @@ def load_results(directory):
         except (OSError, ValueError):
             results[path.stem] = None
     return results
+
+
+def load_shas(directory):
+    """Map result-file stems to the commit each repo was linted at.
+
+    One ``<stem>.sha`` file per repo, containing the clone's HEAD. Missing
+    or malformed files simply drop the permalink for that repo — the report
+    falls back to plain ``file:line`` text.
+    """
+    shas = {}
+    if not directory:
+        return shas
+    for path in Path(directory).glob("*.sha"):
+        sha = path.read_text(encoding="utf-8").strip()
+        if sha and all(c in "0123456789abcdef" for c in sha.lower()):
+            shas[path.stem] = sha
+    return shas
 
 
 def repo_label(stem, link=True):
@@ -61,10 +79,18 @@ def _sample_order(key):
     return (rule_id, file_path, line is not None, line or 0, message)
 
 
-def format_sample(keys):
+def format_sample(keys, slug=None, sha=None):
+    """Render sampled violation keys, linking each location to the exact
+    file (and line) at the commit that was linted when the repo slug and
+    SHA are known."""
     lines = []
     for rule_id, file_path, line, _message in sorted(keys, key=_sample_order)[:SAMPLE_LIMIT]:
         location = f"{file_path}:{line}" if line else file_path
+        if slug and sha:
+            url = f"https://github.com/{slug}/blob/{sha}/{quote(file_path.lstrip('./'))}"
+            if line:
+                url += f"#L{line}"
+            location = f"[{location}]({url})"
         lines.append(f"- `{rule_id}` — {location}")
     if len(keys) > SAMPLE_LIMIT:
         lines.append(f"- … and {len(keys) - SAMPLE_LIMIT} more")
@@ -85,10 +111,17 @@ def main():
     parser.add_argument(
         "--rules", default="", help="Space-separated rule ids the PR changed (for the header)"
     )
+    parser.add_argument(
+        "--shas",
+        default=None,
+        help="Directory of <repo>.sha files recording the commit each repo "
+        "was linted at; findings link to the file at that commit",
+    )
     args = parser.parse_args()
 
     base_results = load_results(args.base)
     head_results = load_results(args.head)
+    shas = load_shas(args.shas)
 
     sections = []
     clean = []
@@ -118,10 +151,12 @@ def main():
             f"`{rule}` ×{count}" for rule, count in sorted(rule_counts(new | resolved).items())
         )
         lines.append(f"{' / '.join(summary)} ({by_rule})")
+        slug = repo.replace("__", "/") if "__" in repo else None
+        sha = shas.get(repo)
         if new:
-            lines += ["", "New findings:"] + format_sample(new)
+            lines += ["", "New findings:"] + format_sample(new, slug=slug, sha=sha)
         if resolved:
-            lines += ["", "Resolved:"] + format_sample(resolved)
+            lines += ["", "Resolved:"] + format_sample(resolved, slug=slug, sha=sha)
         sections.append("\n".join(lines))
 
     print(MARKER)


### PR DESCRIPTION
## Summary

The rule-impact report posted on rule-changing PRs (e.g. #432) listed findings as bare `file:line` text. Reviewers had to open the target repo and find the line at whatever HEAD happens to be now — which drifts as those repos move.

Now the workflow records each integration clone's `HEAD` (`/tmp/out/sha/<slug>.sha`) and the report renders every sampled finding as a permalink to the exact file and line **at the commit that was linted**:

> - `content-repeated-directive` — [plugins/teams/commands/health-check.md:104](https://github.com/openshift-eng/ai-helpers/blob/c4c6acb9228aceef7931a5b0c9e674d70375f024/plugins/teams/commands/health-check.md#L104)

Details:
- Whole-file findings (no line) link without the `#L` fragment
- Paths are URL-encoded (spaces etc.)
- Resolved findings link too — base and head lint the same clone, so the SHA is correct for both
- Degrades gracefully: missing/malformed `.sha` files or omitting `--shas` (hand-run local results) fall back to the old plain-text location

## Testing

- Ran the script against synthetic base/head/sha dirs covering: line-anchored links, whole-file links, URL-encoded paths, a repo with no `.sha` file, and the no-`--shas` back-compat mode — all render correctly
- Verified a constructed permalink resolves against the real ai-helpers repo via the contents API at the pinned SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)