### PR TITLE
[Auto] Bump version to 0.17.0

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -1,7 +1,7 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
 
-version: "0.16.0"
+version: "0.17.0"
 
 rules:
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: 'skillsaw version to install (e.g. "0.12.1"). Defaults to the version this action was released with.'
     required: false
-    default: '0.16.0'
+    default: '0.17.0'
   strict:
     description: 'Treat warnings as errors'
     required: false

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -196,7 +196,7 @@ Quality report, available since skillsaw 0.11.3):
 ```yaml
 skillsaw:
   script:
-    - pip install skillsaw==0.16.0
+    - pip install skillsaw==0.17.0
     - skillsaw lint --output gitlab:gl-code-quality-report.json .
   artifacts:
     reports:

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -11,7 +11,7 @@ Add skillsaw to your repository's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/stbenjam/skillsaw
-    rev: v0.16.0
+    rev: v0.17.0
     hooks:
       - id: skillsaw
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skillsaw"
-version = "0.16.0"
+version = "0.17.0"
 description = "A configurable linter for agent skills, plugins, and AI coding assistant context"
 readme = "README.md"
 authors = [

--- a/src/skillsaw/__init__.py
+++ b/src/skillsaw/__init__.py
@@ -2,7 +2,7 @@
 skillsaw - A configurable linter for agent skills, plugins, and AI coding assistant context
 """
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 from .rule import Rule, RuleViolation, Severity, AutofixConfidence, AutofixResult
 from .context import RepositoryContext


### PR DESCRIPTION
Version bump for the 0.17.0 release.

Updates `pyproject.toml`, `src/skillsaw/__init__.py`, `action.yml`, the
generated `.skillsaw.yaml.example`, and the pinned install references in
`docs/ci.md` and `docs/pre-commit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated Skillsaw to version 0.17.0 across the package, GitHub Action, configuration examples, and setup documentation.
  * New installations and automated workflows now use Skillsaw 0.17.0 by default.

* **Documentation**
  * Updated CI and pre-commit setup instructions to reference version 0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->