### PR TITLE
Automate the floating v0 tag and doc version pins in the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,27 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
+  # Users pin CI to stbenjam/skillsaw@v0 (docs/ci.md). That floating tag has to
+  # be re-pointed at every release or those users stay on the previous version.
+  # Runs after publish so @v0 never advertises a release that failed to ship.
+  floating-tag:
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Move floating major tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bash scripts/move-floating-tag.sh "$RELEASE_TAG"
+

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -6,6 +6,16 @@ PYPROJECT="$REPO_ROOT/pyproject.toml"
 INIT_PY="$REPO_ROOT/src/skillsaw/__init__.py"
 ACTION_YML="$REPO_ROOT/action.yml"
 
+# Docs carrying an install pin that must track the released version. Historical
+# "Since vX.Y.Z" lines under docs/rules/ are deliberately excluded -- only the
+# two pin patterns below are rewritten, never a bare version string.
+PINNED_DOCS=(
+    "$REPO_ROOT/README.md"
+    "$REPO_ROOT/docs/ci.md"
+    "$REPO_ROOT/docs/pre-commit.md"
+    "$REPO_ROOT/docs/getting-started.md"
+)
+
 current_version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$PYPROJECT")
 
 if [[ -z "$current_version" ]]; then
@@ -39,3 +49,23 @@ echo "Updated:"
 echo "  $PYPROJECT"
 echo "  $INIT_PY"
 echo "  $ACTION_YML"
+
+# Rewrite install pins in docs. Each file is optional -- docs get reorganized,
+# and a missing file or absent pin is not an error.
+for doc in "${PINNED_DOCS[@]}"; do
+    [[ -f "$doc" ]] || continue
+    python3 -c "
+import re, sys
+
+path, current, new = sys.argv[1:4]
+text = original = open(path).read()
+for pattern, repl in [
+    (r'skillsaw==' + re.escape(current), 'skillsaw==' + new),
+    (r'rev: v' + re.escape(current), 'rev: v' + new),
+]:
+    text = re.sub(pattern, repl, text)
+if text != original:
+    open(path, 'w').write(text)
+    print('  ' + path)
+" "$doc" "$current_version" "$new_version"
+done

--- a/scripts/move-floating-tag.sh
+++ b/scripts/move-floating-tag.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Move the floating major-version tag (e.g. v0) onto a release tag (e.g. v0.17.0).
+#
+# docs/ci.md and docs/getting-started.md tell users to pin CI to
+# stbenjam/skillsaw@v0. Both that action and stbenjam/skillsaw/review@v0
+# resolve through this one tag, and the root action installs skillsaw from the
+# checked-out action source -- so until the floating tag moves, every @v0 user
+# keeps running the previous release.
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: move-floating-tag.sh <release-tag> [--dry-run]
+
+  release-tag   A vX.Y.Z tag that already exists locally (e.g. v0.17.0).
+  --dry-run     Show what would happen without moving or pushing the tag.
+
+Moves v<major> to the release tag's commit and force-pushes it to origin.
+EOF
+    exit 1
+}
+
+release_tag=""
+dry_run=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) dry_run=true ;;
+        -h|--help) usage ;;
+        -*) echo "Error: unknown option '$arg'" >&2; usage ;;
+        *)
+            if [[ -n "$release_tag" ]]; then
+                echo "Error: unexpected extra argument '$arg'" >&2
+                usage
+            fi
+            release_tag="$arg"
+            ;;
+    esac
+done
+
+[[ -n "$release_tag" ]] || usage
+
+if [[ ! "$release_tag" =~ ^v([0-9]+)\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: '$release_tag' is not a vX.Y.Z release tag" >&2
+    exit 1
+fi
+
+major="${BASH_REMATCH[1]}"
+floating_tag="v$major"
+
+# ^{commit} resolves both annotated and lightweight tags to the commit itself.
+if ! target=$(git rev-parse --verify --quiet "${release_tag}^{commit}"); then
+    echo "Error: release tag '$release_tag' not found locally -- run 'git fetch --tags' first" >&2
+    exit 1
+fi
+
+if previous=$(git rev-parse --verify --quiet "${floating_tag}^{commit}"); then
+    if [[ "$previous" == "$target" ]]; then
+        echo "$floating_tag already points at $release_tag ($(git rev-parse --short "$target")) -- nothing to do"
+        exit 0
+    fi
+    echo "Moving $floating_tag: $(git rev-parse --short "$previous") -> $(git rev-parse --short "$target") ($release_tag)"
+else
+    echo "Creating $floating_tag at $(git rev-parse --short "$target") ($release_tag)"
+fi
+
+if [[ "$dry_run" == true ]]; then
+    echo "(dry run -- no tag written, nothing pushed)"
+    exit 0
+fi
+
+git tag -f -a "$floating_tag" -m "Floating tag for latest v$major.x.x release" "$target"
+git push -f origin "refs/tags/$floating_tag"
+
+echo "Pushed $floating_tag -> $release_tag"


### PR DESCRIPTION
## Problem

Users pin CI to `stbenjam/skillsaw@v0` (per `docs/ci.md` and
`docs/getting-started.md`), and `stbenjam/skillsaw/review@v0` resolves through
the same tag. The root action does `pip install "$ACTION_PATH"` — installing
skillsaw from the **checked-out action source**, not from PyPI. So until the
floating tag is re-pointed, every `@v0` user keeps running the previous
release's code.

Nothing moved that tag. It sat on the 0.16.0 bump commit (`b7cb23b`) through
the entire 0.17.0 release, and the `skillsaw-release` skill never mentioned it.
It has now been moved to `v0.17.0` by hand using the script added here.

Separately, `bump-version.sh` updated `pyproject.toml`, `__init__.py` and
`action.yml` but left the install pins in `docs/ci.md` and `docs/pre-commit.md`
stale — the skill instructed the releaser to find and fix them by hand every
time.

## Changes

**`scripts/move-floating-tag.sh`** (new) — moves `v<major>` onto a `vX.Y.Z`
release tag and force-pushes it. Validates the tag format, requires the release
tag to exist locally, preserves the annotated-tag form and its message, is a
no-op when already correct, and supports `--dry-run`.

**`.github/workflows/release.yml`** — new `floating-tag` job runs that script
after the PyPI `publish` job, so `@v0` never advertises a release that failed to
ship. Scoped to its own job with `contents: write`, and skipped for prereleases.

**`scripts/bump-version.sh`** — now rewrites the `skillsaw==X.Y.Z` and
`rev: vX.Y.Z` pins across `README.md`, `docs/ci.md`, `docs/pre-commit.md` and
`docs/getting-started.md`, printing each file it touched. Only those two
patterns are rewritten, so historical `Since vX.Y.Z` lines under `docs/rules/`
are untouched. Missing files and absent pins are not errors.

**`.claude/skills/skillsaw-release/SKILL.md`** — bump step now verifies the
script's output instead of hand-editing pins, and the verify step confirms `v0`
and the release tag resolve to the same commit, with the manual fallback.

## Verification

- Script exercised across all paths: dry-run, malformed tag, nonexistent tag, no
  args, and the idempotent re-run (exits 0, no push).
- Bump script tested end-to-end with a throwaway `0.17.1` bump — rewrote exactly
  the two doc pins, left `docs/rules/` alone — then reverted.
- Tag migration verified on the remote: `v0^{}` and `v0.17.0` both resolve to
  `f9819d2`.
- `make test` (2935 passed), `make lint`, and `make update` (no new diffs) all clean.
- Skill re-linted with skillsaw: A+, zero violations. Repo grade unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)