### PR TITLE
ci: run maintenance and ecosystem-scout on Opus

### DIFF
--- a/.github/workflows/skillsaw-ecosystem-scout.yml
+++ b/.github/workflows/skillsaw-ecosystem-scout.yml
@@ -25,7 +25,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet
             --max-turns 200
-            --model claude-fable-5
+            --model claude-opus-4-8
 
       - name: Upload execution log
         if: always()

--- a/.github/workflows/skillsaw-maintenance.yml
+++ b/.github/workflows/skillsaw-maintenance.yml
@@ -26,7 +26,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
             --max-turns 200
-            --model claude-fable-5
+            --model claude-opus-4-8
 
       - name: Upload execution log
         if: always()


### PR DESCRIPTION
`skillsaw-maintenance` and `skillsaw-ecosystem-scout` were the last two agent workflows still pinned to `claude-fable-5`. `issue-solver`, `pr-review` and `review-panel` are already on `claude-opus-4-8`; this brings the remaining two in line so every LLM agent job runs the same model.

Confirmed from the [maintenance run 29916238349](https://github.com/stbenjam/skillsaw/actions/runs/29916238349) execution log that these jobs were in fact running Fable — all 348 assistant turns reported `model: claude-fable-5`.

No other change; `--max-turns` and the tool allowlist are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->