### PR TITLE
Update all workflows to use claude-opus-5

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-opus-5' }}
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_INFO_VERSION: "1.0.65"
           GH_AW_INFO_AGENT_VERSION: "1.0.65"
           GH_AW_INFO_CLI_VERSION: "v0.81.6"

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || vars.GH_AW_DEFAULT_MODEL_COPILOT || 'claude-opus-5' }}
           GH_AW_INFO_VERSION: "1.0.65"
           GH_AW_INFO_AGENT_VERSION: "1.0.65"
           GH_AW_INFO_CLI_VERSION: "v0.81.6"

--- a/.github/workflows/skillsaw-ecosystem-scout.yml
+++ b/.github/workflows/skillsaw-ecosystem-scout.yml
@@ -25,7 +25,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet
             --max-turns 200
-            --model claude-opus-4-8
+            --model claude-opus-5
 
       - name: Upload execution log
         if: always()

--- a/.github/workflows/skillsaw-issue-solver.yml
+++ b/.github/workflows/skillsaw-issue-solver.yml
@@ -95,7 +95,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
             --max-turns 200
-            --model claude-opus-4-8
+            --model claude-opus-5
 
       - name: Upload execution log
         if: always()

--- a/.github/workflows/skillsaw-maintenance.yml
+++ b/.github/workflows/skillsaw-maintenance.yml
@@ -26,7 +26,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
             --max-turns 200
-            --model claude-opus-4-8
+            --model claude-opus-5
 
       - name: Upload execution log
         if: always()

--- a/.github/workflows/skillsaw-pr-review.yml
+++ b/.github/workflows/skillsaw-pr-review.yml
@@ -104,7 +104,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
             --max-turns 100
-            --model claude-opus-4-8
+            --model claude-opus-5
 
       - name: Save last run timestamp
         if: always()

--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -42,7 +42,7 @@ jobs:
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Glob,Grep,TaskCreate,TaskUpdate,TaskList,TaskGet
             --max-turns 50
-            --model claude-opus-4-8
+            --model claude-opus-5
 
       - name: Upload execution log
         if: always()


### PR DESCRIPTION
## Summary
- Update all 5 Claude Code Action workflow files from `claude-opus-4-8` to `claude-opus-5`
- Update the `issue-triage.lock.yml` fallback model from `claude-sonnet-4.6` to `claude-opus-5`

### Files modified
| File | Old model | New model |
|------|-----------|-----------|
| `skillsaw-review-panel.yml` | `claude-opus-4-8` | `claude-opus-5` |
| `skillsaw-issue-solver.yml` | `claude-opus-4-8` | `claude-opus-5` |
| `skillsaw-pr-review.yml` | `claude-opus-4-8` | `claude-opus-5` |
| `skillsaw-maintenance.yml` | `claude-opus-4-8` | `claude-opus-5` |
| `skillsaw-ecosystem-scout.yml` | `claude-opus-4-8` | `claude-opus-5` |
| `issue-triage.lock.yml` | `claude-sonnet-4.6` (fallback default) | `claude-opus-5` |

## Test plan
- [ ] Verify workflows trigger correctly with the new model
- [ ] Confirm `claude-opus-5` is a valid model identifier for claude-code-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated automated workflow intelligence to use Claude Opus 5.
  * Applied the newer model configuration across issue triage, ecosystem scouting, issue solving, maintenance, pull request reviews, and review panels.
  * Existing workflow triggers, permissions, steps, and arguments remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->