### PR TITLE
feat: add marketplace and plugin configuration

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "skillsaw-marketplace",
+  "interface": {
+    "displayName": "skillsaw"
+  },
+  "plugins": [
+    {
+      "name": "skillsaw",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "skillsaw",
+  "version": "1.0.0",
+  "description": "A configurable linter for agent skills, plugins, and AI coding assistant context",
+  "author": {
+    "name": "stbenjam"
+  },
+  "skills": "./skills/"
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,15 @@ fingerprinting works and configuration options.
 
     Then type **`/skillsaw-onboard`** and follow the prompts.
 
+=== "Codex"
+
+    ```bash
+    codex plugin marketplace add stbenjam/skillsaw
+    codex plugin add skillsaw@skillsaw-marketplace
+    ```
+
+    Start a new Codex session, then invoke **`$skillsaw-onboard`**.
+
 === "Other AI coding agents"
 
     Paste this into your coding agent:

--- a/tests/test_codex_marketplace.py
+++ b/tests/test_codex_marketplace.py
@@ -1,0 +1,24 @@
+"""Codex marketplace distribution metadata."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codex_marketplace_exposes_the_root_skill_bundle() -> None:
+    """Codex's documented selector must resolve to the root skill bundle."""
+    marketplace = json.loads(
+        (ROOT / ".agents" / "plugins" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    manifest = json.loads((ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
+
+    assert marketplace["name"] == "skillsaw-marketplace"
+    plugin = next(item for item in marketplace["plugins"] if item["name"] == manifest["name"])
+    assert plugin["source"] == {"source": "local", "path": "./"}
+    assert plugin["policy"]["installation"] == "AVAILABLE"
+    assert manifest["name"] == "skillsaw"
+    assert manifest["skills"] == "./skills/"
+    skills_dir = ROOT / manifest["skills"]
+    assert skills_dir.is_dir()
+    assert any(skills_dir.glob("*/SKILL.md"))


### PR DESCRIPTION
## Summary

Add Codex marketplace distribution for Skillsaw

## Changes

- Add marketplace and Codex plugin manifests exposing the root skill bundle
- Document Codex installation and onboarding steps
- Add coverage test for marketplace metadata and skill-bundle resolution

## Why?

I use an automated script for setting up a new machine for development and part of that script has a section to [handle plugin installation for both Claude Code and OpenAI Codex](https://github.com/skyth3r/dotfiles/blob/a043361c69f76ffe7dad0c9fa2484abb5069ec22/install.sh#L305). I noticed that while the Claude marketplace metadata existed for this skill, the equivalent for Codex did not and so I've decided to contribute this myself following the [docs from OpenAI](https://developers.openai.com/plugins/build/plugins#package-and-distribute-plugins).

This allows Codex users to install the skill with two commands (similar to the Claude Code setup):
```
codex plugin marketplace add stbenjam/skillsaw
codex plugin add skillsaw@skillsaw-marketplace
```

## Test plan
- [x] `make test` — full suite passes
- [x]  `make lint` — black formatting clean
- [x]  `make update` — Ran but no changes made
- [ ]  Cloned openshift-eng/ai-helpers, ran skillsaw, exit 0 - Skipped (no changes made that should affect this)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex plugin support with installation metadata and access to the project’s skills.
  * Added setup instructions for installing the plugin and starting the onboarding workflow.

* **Tests**
  * Added validation to ensure the plugin marketplace entry, metadata, and available skills are correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->