### PR TITLE
Rename pr-review to pr-followup, improve workflow config

### DIFF
--- a/.github/workflows/skillsaw-issue-solver.yml
+++ b/.github/workflows/skillsaw-issue-solver.yml
@@ -76,7 +76,8 @@ jobs:
           # but are kept small here by passing only metadata).
           MATRIX=$(cat /tmp/issues-with-comments.json | jq -c '[.[] | {
             number: .number,
-            ultracode: ([.labels[].name] | any(. == "ultracode"))
+            ultracode: ([.labels[].name] | any(. == "ultracode")),
+            fable: ([.labels[].name] | any(. == "fable-5"))
           }]')
           echo "issues=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -130,9 +131,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           claude_args: |
-            --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
-            --max-turns 200
-            --model claude-opus-5
+            --dangerously-skip-permissions
+            ${{ !matrix.issue.ultracode && '--max-turns 200' || '' }}
+            --model ${{ matrix.issue.fable && 'claude-fable-5' || 'claude-opus-5' }}
             ${{ matrix.issue.ultracode && '--effort ultracode' || '' }}
 
       - name: Upload execution log

--- a/.github/workflows/skillsaw-pr-followup.yml
+++ b/.github/workflows/skillsaw-pr-followup.yml
@@ -90,7 +90,8 @@ jobs:
           # Build matrix
           MATRIX=$(echo "$PRS" | jq -c '[.[] | {
             number: .number,
-            ultracode: ([.labels[].name] | any(. == "ultracode"))
+            ultracode: ([.labels[].name] | any(. == "ultracode")),
+            fable: ([.labels[].name] | any(. == "fable-5"))
           }]')
           echo "prs=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -162,9 +163,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           claude_args: |
-            --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Agent,Glob,Grep,TodoWrite,TodoRead,TaskCreate,TaskUpdate,TaskList,TaskGet,EnterWorktree,ExitWorktree
-            --max-turns 100
-            --model claude-opus-5
+            --dangerously-skip-permissions
+            ${{ !matrix.pr.ultracode && '--max-turns 100' || '' }}
+            --model ${{ matrix.pr.fable && 'claude-fable-5' || 'claude-opus-5' }}
             ${{ matrix.pr.ultracode && '--effort ultracode' || '' }}
 
       - name: Upload execution log


### PR DESCRIPTION
## Summary

- Rename `skillsaw-pr-review` skill to `skillsaw-pr-followup` (name, heading, description updated across `.apm/`, `.agents/`, `.claude/`)
- Remove checkout from discover jobs — use `gh -R` flag instead since discover only calls the GitHub API
- Replace `--allowedTools` with `--dangerously-skip-permissions` in both workflows
- Remove `--max-turns` cap when `ultracode` label is present
- Add `fable-5` label support to switch model from `claude-opus-5` to `claude-fable-5`

## Test plan

- [ ] Verify `make update` produces no diff (generated files in sync)
- [ ] Verify discover jobs run without checkout (no git repo needed)
- [ ] Verify ultracode sessions have no turn limit
- [ ] Verify `fable-5` label switches model correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/stbenjam/skillsaw/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->