### PR TITLE
Collapse specialist findings in review panel verdict

### DIFF
--- a/.agents/skills/skillsaw-review-panel/verdict-template.md
+++ b/.agents/skills/skillsaw-review-panel/verdict-template.md
@@ -17,29 +17,47 @@ https://skillsaw.org/plugins/ and mention the skillsaw-create-plugin skill.
 
 ### Specialist Findings
 
-**Architecture Reviewer**
+<details>
+<summary><strong>Architecture Reviewer</strong></summary>
 
 {{ARCHITECTURE_FINDINGS}}
 
-**Python Expert**
+</details>
+
+<details>
+<summary><strong>Python Expert</strong></summary>
 
 {{PYTHON_FINDINGS}}
 
-**Security & Supply Chain Reviewer**
+</details>
+
+<details>
+<summary><strong>Security & Supply Chain Reviewer</strong></summary>
 
 {{SECURITY_FINDINGS}}
 
-**QA Engineer**
+</details>
+
+<details>
+<summary><strong>QA Engineer</strong></summary>
 
 {{QA_FINDINGS}}
 
-**Technical Writer**
+</details>
+
+<details>
+<summary><strong>Technical Writer</strong></summary>
 
 {{WRITER_FINDINGS}}
 
-**Ecosystem Reviewer**
+</details>
+
+<details>
+<summary><strong>Ecosystem Reviewer</strong></summary>
 
 {{ECOSYSTEM_FINDINGS}}
+
+</details>
 
 ---
 

--- a/.apm/skills/skillsaw-review-panel/verdict-template.md
+++ b/.apm/skills/skillsaw-review-panel/verdict-template.md
@@ -17,29 +17,47 @@ https://skillsaw.org/plugins/ and mention the skillsaw-create-plugin skill.
 
 ### Specialist Findings
 
-**Architecture Reviewer**
+<details>
+<summary><strong>Architecture Reviewer</strong></summary>
 
 {{ARCHITECTURE_FINDINGS}}
 
-**Python Expert**
+</details>
+
+<details>
+<summary><strong>Python Expert</strong></summary>
 
 {{PYTHON_FINDINGS}}
 
-**Security & Supply Chain Reviewer**
+</details>
+
+<details>
+<summary><strong>Security & Supply Chain Reviewer</strong></summary>
 
 {{SECURITY_FINDINGS}}
 
-**QA Engineer**
+</details>
+
+<details>
+<summary><strong>QA Engineer</strong></summary>
 
 {{QA_FINDINGS}}
 
-**Technical Writer**
+</details>
+
+<details>
+<summary><strong>Technical Writer</strong></summary>
 
 {{WRITER_FINDINGS}}
 
-**Ecosystem Reviewer**
+</details>
+
+<details>
+<summary><strong>Ecosystem Reviewer</strong></summary>
 
 {{ECOSYSTEM_FINDINGS}}
+
+</details>
 
 ---
 

--- a/.claude/skills/skillsaw-review-panel/verdict-template.md
+++ b/.claude/skills/skillsaw-review-panel/verdict-template.md
@@ -17,29 +17,47 @@ https://skillsaw.org/plugins/ and mention the skillsaw-create-plugin skill.
 
 ### Specialist Findings
 
-**Architecture Reviewer**
+<details>
+<summary><strong>Architecture Reviewer</strong></summary>
 
 {{ARCHITECTURE_FINDINGS}}
 
-**Python Expert**
+</details>
+
+<details>
+<summary><strong>Python Expert</strong></summary>
 
 {{PYTHON_FINDINGS}}
 
-**Security & Supply Chain Reviewer**
+</details>
+
+<details>
+<summary><strong>Security & Supply Chain Reviewer</strong></summary>
 
 {{SECURITY_FINDINGS}}
 
-**QA Engineer**
+</details>
+
+<details>
+<summary><strong>QA Engineer</strong></summary>
 
 {{QA_FINDINGS}}
 
-**Technical Writer**
+</details>
+
+<details>
+<summary><strong>Technical Writer</strong></summary>
 
 {{WRITER_FINDINGS}}
 
-**Ecosystem Reviewer**
+</details>
+
+<details>
+<summary><strong>Ecosystem Reviewer</strong></summary>
 
 {{ECOSYSTEM_FINDINGS}}
+
+</details>
 
 ---
 

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -16,8 +16,8 @@
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
   <text x="56" y="46" class="subtitle">skillsaw report card</text>
   <g data-testid="stats">
-    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.10</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">41,872</tspan></tspan></text>
+    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.14</tspan> per 10k tokens</tspan></text>
+    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">28,082</tspan></tspan></text>
     <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">11</tspan> skills</tspan></text>
     <text x="24" y="139" class="label">Top rules</text>
     <text x="24" y="154" class="rule" data-testid="rule-0">1. content-actionability-score (3)</text>

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -16,8 +16,8 @@
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
   <text x="56" y="46" class="subtitle">skillsaw report card</text>
   <g data-testid="stats">
-    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.14</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">28,082</tspan></tspan></text>
+    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.10</tspan> per 10k tokens</tspan></text>
+    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">41,872</tspan></tspan></text>
     <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">11</tspan> skills</tspan></text>
     <text x="24" y="139" class="label">Top rules</text>
     <text x="24" y="154" class="rule" data-testid="rule-0">1. content-actionability-score (3)</text>

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -16,6 +16,9 @@ exclude:
   - "src/skillsaw/marketplace/templates/*"
   # Testing fixtures with intentional errors
   - "tests/fixtures/*"
+  # Git worktrees (local only, not committed)
+  - ".worktrees/*"
+  - ".claude/worktrees/*"
 
 # Additional markdown files to run content rules on (not agentic artifacts,
 # so not auto-discovered) — dogfood the review guidelines against our own


### PR DESCRIPTION
## Summary
- Wraps each specialist's findings in a `<details>` block in the review panel verdict template
- Keeps synthesis, required actions, and optional follow-ups expanded (the actionable parts)
- Reduces verbosity of the PR comment — readers can expand individual specialists on demand

Ref: https://github.com/stbenjam/skillsaw/pull/451#issuecomment-5081087424

## Test plan
- [ ] Trigger a review panel on a test PR and verify specialist findings render collapsed
- [ ] Verify synthesis and required actions are still visible without expanding

🤖 Generated with [Claude Code](https://claude.com/claude-code)