### PR TITLE
Remove --max-turns limits from issue_solver and pr_followup

### DIFF
--- a/.github/workflows/skillsaw-issue-solver.yml
+++ b/.github/workflows/skillsaw-issue-solver.yml
@@ -133,7 +133,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --dangerously-skip-permissions
-            ${{ !matrix.issue.ultracode && '--max-turns 200' || '' }}
             --model ${{ matrix.issue.fable && 'claude-fable-5' || 'claude-opus-5' }}
             ${{ matrix.issue.ultracode && '--effort ultracode' || '' }}
 

--- a/.github/workflows/skillsaw-pr-followup.yml
+++ b/.github/workflows/skillsaw-pr-followup.yml
@@ -165,7 +165,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --dangerously-skip-permissions
-            ${{ !matrix.pr.ultracode && '--max-turns 100' || '' }}
             --model ${{ matrix.pr.fable && 'claude-fable-5' || 'claude-opus-5' }}
             ${{ matrix.pr.ultracode && '--effort ultracode' || '' }}
 


### PR DESCRIPTION
## Summary

- Remove `--max-turns 200` from the issue_solver workflow
- Remove `--max-turns 100` from the pr_followup workflow

These caps truncate agent work on complex tasks, losing progress mid-solve. Without them, Claude runs to completion naturally.

## Evidence

Failed run where work was truncated by the turns limit:
https://github.com/stbenjam/skillsaw/actions/runs/30209909213/job/89814287177

## Test plan

- [x] Changes are minimal — only the two `--max-turns` lines removed
- [ ] Verify next issue_solver and pr_followup runs complete without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated issue-solving and pull-request follow-up workflows to remove fixed limits on processing turns.
  * Preserved existing model selection and enhanced-effort settings for applicable tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->