### PR TITLE
Remove --max-turns limit from review panel workflow

### DIFF
--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -41,7 +41,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Glob,Grep,TaskCreate,TaskUpdate,TaskList,TaskGet
-            --max-turns 50
             --model claude-opus-5
 
       - name: Upload execution log


### PR DESCRIPTION
## Summary
- Removes the `--max-turns 50` constraint from the `skillsaw-review-panel.yml` workflow
- The review panel was hitting this cap and failing (see [job run](https://github.com/stbenjam/skillsaw/actions/runs/30212914181/job/89822070447?pr=451))
- Follows the same change made in #456 for the `issue_solver` and `pr_followup` workflows

## Test plan
- [ ] Verify the review panel workflow runs without hitting a turn limit on the next `panel-review` label trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)