### PR TITLE
Await specialist sub-agents so the review panel posts a verdict

### DIFF
--- a/.agents/skills/skillsaw-review-panel/SKILL.md
+++ b/.agents/skills/skillsaw-review-panel/SKILL.md
@@ -127,7 +127,17 @@ may not share the skill's working directory.
 #### Parallel mode (default)
 
 Launch **all 6 specialist sub-agents in a single message** so they
-run concurrently, using the Agent tool with `run_in_background: true`.
+run concurrently, using the Agent tool with `run_in_background: false`.
+
+Both halves of that matter. A single message is what makes them run
+concurrently. `run_in_background: false` is what makes the dispatch
+*block* until every one returns.
+
+Do **not** use `run_in_background: true` here. A background agent
+returns immediately, so the dispatching turn ends with the reviews
+still running — and when the panel runs headlessly in CI, the turn
+ending ends the job. The workflow then exits green having posted no
+verdict at all, which is worse than failing loudly.
 
 Each sub-agent gets:
 - The specialist role name and a one-line description of its lens
@@ -153,8 +163,9 @@ If the Agent tool is not available (e.g. running in Codex or another
 client that lacks sub-agent support), fall back to serial mode
 automatically.
 
-Wait for all sub-agents to complete before proceeding to the
-Completeness Gate (Step 4).
+Synchronous dispatch means all six have returned by the time the
+tool call completes. Proceed to the Completeness Gate (Step 4) only
+with six sets of findings in hand.
 
 #### Serial mode (`--serial`)
 
@@ -183,6 +194,11 @@ list with an explanation of what was checked is success — do **not**
 retry it. If any specialist returned an error or a missing/malformed
 result, re-dispatch it **once**. If the retry also fails, record
 the failure and proceed.
+
+Never end the run here. A panel that stops after dispatching has
+produced nothing a reviewer can act on, and it looks identical to a
+clean review from the outside. If specialists are missing and cannot
+be recovered, post the verdict anyway, naming which ones failed.
 
 ### Step 5 — Run Panel Arbiter Synthesis
 

--- a/.apm/skills/skillsaw-review-panel/SKILL.md
+++ b/.apm/skills/skillsaw-review-panel/SKILL.md
@@ -127,7 +127,17 @@ may not share the skill's working directory.
 #### Parallel mode (default)
 
 Launch **all 6 specialist sub-agents in a single message** so they
-run concurrently, using the Agent tool with `run_in_background: true`.
+run concurrently, using the Agent tool with `run_in_background: false`.
+
+Both halves of that matter. A single message is what makes them run
+concurrently. `run_in_background: false` is what makes the dispatch
+*block* until every one returns.
+
+Do **not** use `run_in_background: true` here. A background agent
+returns immediately, so the dispatching turn ends with the reviews
+still running — and when the panel runs headlessly in CI, the turn
+ending ends the job. The workflow then exits green having posted no
+verdict at all, which is worse than failing loudly.
 
 Each sub-agent gets:
 - The specialist role name and a one-line description of its lens
@@ -153,8 +163,9 @@ If the Agent tool is not available (e.g. running in Codex or another
 client that lacks sub-agent support), fall back to serial mode
 automatically.
 
-Wait for all sub-agents to complete before proceeding to the
-Completeness Gate (Step 4).
+Synchronous dispatch means all six have returned by the time the
+tool call completes. Proceed to the Completeness Gate (Step 4) only
+with six sets of findings in hand.
 
 #### Serial mode (`--serial`)
 
@@ -183,6 +194,11 @@ list with an explanation of what was checked is success — do **not**
 retry it. If any specialist returned an error or a missing/malformed
 result, re-dispatch it **once**. If the retry also fails, record
 the failure and proceed.
+
+Never end the run here. A panel that stops after dispatching has
+produced nothing a reviewer can act on, and it looks identical to a
+clean review from the outside. If specialists are missing and cannot
+be recovered, post the verdict anyway, naming which ones failed.
 
 ### Step 5 — Run Panel Arbiter Synthesis
 

--- a/.claude/skills/skillsaw-review-panel/SKILL.md
+++ b/.claude/skills/skillsaw-review-panel/SKILL.md
@@ -127,7 +127,17 @@ may not share the skill's working directory.
 #### Parallel mode (default)
 
 Launch **all 6 specialist sub-agents in a single message** so they
-run concurrently, using the Agent tool with `run_in_background: true`.
+run concurrently, using the Agent tool with `run_in_background: false`.
+
+Both halves of that matter. A single message is what makes them run
+concurrently. `run_in_background: false` is what makes the dispatch
+*block* until every one returns.
+
+Do **not** use `run_in_background: true` here. A background agent
+returns immediately, so the dispatching turn ends with the reviews
+still running — and when the panel runs headlessly in CI, the turn
+ending ends the job. The workflow then exits green having posted no
+verdict at all, which is worse than failing loudly.
 
 Each sub-agent gets:
 - The specialist role name and a one-line description of its lens
@@ -153,8 +163,9 @@ If the Agent tool is not available (e.g. running in Codex or another
 client that lacks sub-agent support), fall back to serial mode
 automatically.
 
-Wait for all sub-agents to complete before proceeding to the
-Completeness Gate (Step 4).
+Synchronous dispatch means all six have returned by the time the
+tool call completes. Proceed to the Completeness Gate (Step 4) only
+with six sets of findings in hand.
 
 #### Serial mode (`--serial`)
 
@@ -183,6 +194,11 @@ list with an explanation of what was checked is success — do **not**
 retry it. If any specialist returned an error or a missing/malformed
 result, re-dispatch it **once**. If the retry also fails, record
 the failure and proceed.
+
+Never end the run here. A panel that stops after dispatching has
+produced nothing a reviewer can act on, and it looks identical to a
+clean review from the outside. If specialists are missing and cannot
+be recovered, post the verdict anyway, naming which ones failed.
 
 ### Step 5 — Run Panel Arbiter Synthesis
 

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -17,7 +17,7 @@
   <text x="56" y="46" class="subtitle">skillsaw report card</text>
   <g data-testid="stats">
     <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.21</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">28,908</tspan></tspan></text>
+    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">29,118</tspan></tspan></text>
     <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">11</tspan> skills</tspan></text>
     <text x="24" y="139" class="label">Top rules</text>
     <text x="24" y="154" class="rule" data-testid="rule-0">1. content-actionability-score (4)</text>


### PR DESCRIPTION
## The bug

The parallel dispatch added in #458 launches the six specialists with `run_in_background: true`. A background agent returns immediately, so the dispatching turn ends with every review still in flight. Interactively that's fine — the completion notifications arrive and work resumes. Headlessly it isn't: **when the turn ends, the CI job ends.**

The panel has posted no verdict since #458 landed.

## Evidence

Run [30216174198](https://github.com/stbenjam/skillsaw/actions/runs/30216174198) on #451 — exited `success` after 3m22s, 22 turns, having posted nothing. From its own execution log, the six dispatches and then the **final** message:

> Six specialists are running in parallel against PR #451 […] I'll synthesize the verdict and post it as a single PR comment once all six report back.

They had been launched moments earlier. None had returned. The turn ended; the job ended.

The failure mode is the bad kind: `is_error: false`, a green check, and no findings — **indistinguishable from a clean review** unless you go read the execution artifact. Compare run 30214646754 (pre-#458, serial) which took ~14 minutes and posted a full verdict.

## The fix

Dispatch synchronously — `run_in_background: false`, still all six in a single message.

Both halves matter, and the skill now says so explicitly:

- **a single message** is what makes them run concurrently
- **`run_in_background: false`** is what makes the call block until all six return

So #458's parallelism is fully preserved; only the fire-and-forget goes. Six concurrent reviews, awaited.

I also added a line to the Completeness Gate: the run must never end there. If specialists are missing and can't be recovered, post the verdict anyway naming which ones failed — a partial verdict beats silence that reads as approval.

## Verification

- `make update` regenerates cleanly; all three copies (`.apm/`, `.agents/`, `.claude/`) verified byte-identical
- `.venv/bin/skillsaw lint .apm/skills/skillsaw-review-panel/` — 0 errors, 0 warnings, A+
- `make lint` clean, `make test` 2965 passed

## Note on overlap

There's a second PR in flight adding a seventh specialist to this same skill. It touches the roster table and frontmatter; this touches Step 3's dispatch mechanics and Step 4. Different regions, so they should merge cleanly in either order — but worth landing this one first, since without it the new specialist would never report either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)