### PR TITLE
Make slop gate the verdict, not just carry a label

### DIFF
--- a/.agents/skills/skillsaw-review-panel/SKILL.md
+++ b/.agents/skills/skillsaw-review-panel/SKILL.md
@@ -24,8 +24,13 @@ Run **7 specialist reviewers + 1 arbiter** to review a skillsaw PR.
   Cheaper — codebase context is derived once and shared — but later
   specialists see earlier ones' file reads, which can bias them.
 
-Keep the panel **advisory**. It does not gate merge. It surfaces findings;
+Keep the panel **advisory** on everything except slop. It surfaces findings;
 the maintainer and PR author review and decide ship.
+
+**Slop is the exception.** Review-history residue and generated prose must not
+merge. A `BLOCKING` finding from the Slopinator gates the verdict: the
+disposition is `REQUEST_CHANGES` until the text is fixed, and no amount of
+agreement from the other specialists converts it into an `APPROVE`.
 
 ## Arguments
 
@@ -195,8 +200,11 @@ After all specialists complete, review and synthesize directly:
 
 **Follow these criteria:**
 
-- **APPROVE**: Set when no unresolved BLOCKING findings remain.
+- **APPROVE**: Set when no unresolved BLOCKING findings remain. An unresolved
+  Slopinator `BLOCKING` finding rules this out on its own — slop does not merge.
 - **REQUEST_CHANGES**: Set for BLOCKING findings that require code changes, but the change is in scope and fixable.
+  This is the disposition for unresolved slop, which is always in scope and
+  always fixable: the finding quotes the replacement text.
 - **NEEDS_DISCUSSION**: Set when findings need author input to resolve. The panel
   cannot decide without clarification — keep it here when the issue is neither a
   clean approve nor an outright change request or rejection.
@@ -213,6 +221,9 @@ After all specialists complete, review and synthesize directly:
 - Prefer existing patterns over novel ones.
 - Backward compatibility is paramount — breaking existing users is always blocking.
 - Keep core focused — prefer a plugin redirect over expanding core for niche tools.
+- Do not soften slop. A Slopinator `BLOCKING` finding is not a style nit to be
+  filtered as noise in Step 3, and it is not downgraded because the rest of the
+  change is good.
 
 Keep clean changes with no issues as a valid outcome — do not manufacture findings.
 

--- a/.agents/skills/skillsaw-review-panel/references/slopinator.md
+++ b/.agents/skills/skillsaw-review-panel/references/slopinator.md
@@ -8,10 +8,12 @@ underneath the result. This reviewer reads the writing in a change as an editor
 would — comments, docstrings, docs, commit messages, PR prose — and asks whether
 it describes the code that shipped or the process that produced it.
 
-**Slop blocks.** Residue and generated prose in shipped text are defects, not
-matters of taste, so this reviewer sets `BLOCKING` on them like any other
-specialist. That makes the precision guardrails below matter more, not less:
-read "What NOT to flag" before filing anything.
+**Slop blocks, and slop does not merge.** Residue and generated prose in
+shipped text are defects, not matters of taste. This reviewer sets `BLOCKING`
+on them, the arbiter does not downgrade them, and the verdict stays at
+`REQUEST_CHANGES` until they are fixed. What keeps that from being tyranny is
+accuracy, not timidity: "What NOT to flag" below draws the line, and inside it
+there is nothing to soften.
 
 ## Part A — Review-history residue in code
 
@@ -141,28 +143,35 @@ This reviewer becomes a nuisance the moment it polices taste. Leave these alone:
 - **Existing text the diff merely moves.** Review what the change writes, not
   every line it touches.
 
-Prefer clustering to isolated hits. One overused word is nothing; three tells in
-one paragraph is a finding. Cap the output at the strongest handful of items and
-group the rest as a single NOTE rather than filing one per instance.
+## Reporting volume
+
+In prose, prefer clustering to isolated hits: one overused word is nothing;
+three tells in one paragraph is a finding. Cap the output at the strongest
+handful of items and group the rest as a single NOTE rather than filing one per
+instance. None of this applies to Part A residue, which is reported every time
+it appears.
 
 ## Severity calibration
 
-- `BLOCKING`: Slop in shipped text. Review-history residue in code comments —
-  any Part A pattern — and clusters of Part B tells dense enough that a section
-  reads as generated rather than written. Also any comment or docstring that
-  asserts something **factually false** about the shipped code: a wrong
-  invariant, a bug that never existed, a stale measurement presented as
-  current. Quote the text and quote the replacement, so the author can accept
-  it verbatim and clear the finding in one edit.
-- `SUGGESTION`: One tell in otherwise clean writing, or a passage that is
-  merely weaker than it could be.
+- `BLOCKING`: Slop in shipped text.
+  - **Every Part A instance.** One review-history comment is enough. Residue is
+    binary — a comment either describes the shipped code or it describes the
+    conversation that produced it — so the clustering rule does not apply here
+    and a single instance blocks.
+  - **Any factually false claim** in a comment or docstring: a wrong invariant,
+    a bug that never existed, a stale measurement presented as current.
+  - **Part B tells clustered** densely enough that a passage reads as generated
+    rather than written.
+
+  Quote the text and quote the replacement, so the author can clear the finding
+  in one edit.
+- `SUGGESTION`: A lone Part B tell in otherwise clean prose.
 - `NOTE`: One-line polish — a filler phrase, a Title Case heading, a single
   signature-echo docstring in a file that is otherwise fine.
 
-Blocking raises the cost of a false positive, so the clustering rule above is a
-requirement rather than a preference: one overused word is never a finding. When
-a finding turns on taste instead of on residue or a false claim, drop it to
-`NOTE` or drop it entirely.
+The clustering rule governs Part B only, where one overused word is genuinely
+nothing. Never apply it to Part A as a reason to let residue through, and never
+downgrade a finding because the rest of the change is good.
 
 Clean writing is a valid outcome. Say what was checked and move on rather than
 manufacturing findings.

--- a/.apm/skills/skillsaw-review-panel/SKILL.md
+++ b/.apm/skills/skillsaw-review-panel/SKILL.md
@@ -24,8 +24,13 @@ Run **7 specialist reviewers + 1 arbiter** to review a skillsaw PR.
   Cheaper — codebase context is derived once and shared — but later
   specialists see earlier ones' file reads, which can bias them.
 
-Keep the panel **advisory**. It does not gate merge. It surfaces findings;
+Keep the panel **advisory** on everything except slop. It surfaces findings;
 the maintainer and PR author review and decide ship.
+
+**Slop is the exception.** Review-history residue and generated prose must not
+merge. A `BLOCKING` finding from the Slopinator gates the verdict: the
+disposition is `REQUEST_CHANGES` until the text is fixed, and no amount of
+agreement from the other specialists converts it into an `APPROVE`.
 
 ## Arguments
 
@@ -195,8 +200,11 @@ After all specialists complete, review and synthesize directly:
 
 **Follow these criteria:**
 
-- **APPROVE**: Set when no unresolved BLOCKING findings remain.
+- **APPROVE**: Set when no unresolved BLOCKING findings remain. An unresolved
+  Slopinator `BLOCKING` finding rules this out on its own — slop does not merge.
 - **REQUEST_CHANGES**: Set for BLOCKING findings that require code changes, but the change is in scope and fixable.
+  This is the disposition for unresolved slop, which is always in scope and
+  always fixable: the finding quotes the replacement text.
 - **NEEDS_DISCUSSION**: Set when findings need author input to resolve. The panel
   cannot decide without clarification — keep it here when the issue is neither a
   clean approve nor an outright change request or rejection.
@@ -213,6 +221,9 @@ After all specialists complete, review and synthesize directly:
 - Prefer existing patterns over novel ones.
 - Backward compatibility is paramount — breaking existing users is always blocking.
 - Keep core focused — prefer a plugin redirect over expanding core for niche tools.
+- Do not soften slop. A Slopinator `BLOCKING` finding is not a style nit to be
+  filtered as noise in Step 3, and it is not downgraded because the rest of the
+  change is good.
 
 Keep clean changes with no issues as a valid outcome — do not manufacture findings.
 

--- a/.apm/skills/skillsaw-review-panel/references/slopinator.md
+++ b/.apm/skills/skillsaw-review-panel/references/slopinator.md
@@ -8,10 +8,12 @@ underneath the result. This reviewer reads the writing in a change as an editor
 would — comments, docstrings, docs, commit messages, PR prose — and asks whether
 it describes the code that shipped or the process that produced it.
 
-**Slop blocks.** Residue and generated prose in shipped text are defects, not
-matters of taste, so this reviewer sets `BLOCKING` on them like any other
-specialist. That makes the precision guardrails below matter more, not less:
-read "What NOT to flag" before filing anything.
+**Slop blocks, and slop does not merge.** Residue and generated prose in
+shipped text are defects, not matters of taste. This reviewer sets `BLOCKING`
+on them, the arbiter does not downgrade them, and the verdict stays at
+`REQUEST_CHANGES` until they are fixed. What keeps that from being tyranny is
+accuracy, not timidity: "What NOT to flag" below draws the line, and inside it
+there is nothing to soften.
 
 ## Part A — Review-history residue in code
 
@@ -141,28 +143,35 @@ This reviewer becomes a nuisance the moment it polices taste. Leave these alone:
 - **Existing text the diff merely moves.** Review what the change writes, not
   every line it touches.
 
-Prefer clustering to isolated hits. One overused word is nothing; three tells in
-one paragraph is a finding. Cap the output at the strongest handful of items and
-group the rest as a single NOTE rather than filing one per instance.
+## Reporting volume
+
+In prose, prefer clustering to isolated hits: one overused word is nothing;
+three tells in one paragraph is a finding. Cap the output at the strongest
+handful of items and group the rest as a single NOTE rather than filing one per
+instance. None of this applies to Part A residue, which is reported every time
+it appears.
 
 ## Severity calibration
 
-- `BLOCKING`: Slop in shipped text. Review-history residue in code comments —
-  any Part A pattern — and clusters of Part B tells dense enough that a section
-  reads as generated rather than written. Also any comment or docstring that
-  asserts something **factually false** about the shipped code: a wrong
-  invariant, a bug that never existed, a stale measurement presented as
-  current. Quote the text and quote the replacement, so the author can accept
-  it verbatim and clear the finding in one edit.
-- `SUGGESTION`: One tell in otherwise clean writing, or a passage that is
-  merely weaker than it could be.
+- `BLOCKING`: Slop in shipped text.
+  - **Every Part A instance.** One review-history comment is enough. Residue is
+    binary — a comment either describes the shipped code or it describes the
+    conversation that produced it — so the clustering rule does not apply here
+    and a single instance blocks.
+  - **Any factually false claim** in a comment or docstring: a wrong invariant,
+    a bug that never existed, a stale measurement presented as current.
+  - **Part B tells clustered** densely enough that a passage reads as generated
+    rather than written.
+
+  Quote the text and quote the replacement, so the author can clear the finding
+  in one edit.
+- `SUGGESTION`: A lone Part B tell in otherwise clean prose.
 - `NOTE`: One-line polish — a filler phrase, a Title Case heading, a single
   signature-echo docstring in a file that is otherwise fine.
 
-Blocking raises the cost of a false positive, so the clustering rule above is a
-requirement rather than a preference: one overused word is never a finding. When
-a finding turns on taste instead of on residue or a false claim, drop it to
-`NOTE` or drop it entirely.
+The clustering rule governs Part B only, where one overused word is genuinely
+nothing. Never apply it to Part A as a reason to let residue through, and never
+downgrade a finding because the rest of the change is good.
 
 Clean writing is a valid outcome. Say what was checked and move on rather than
 manufacturing findings.

--- a/.claude/skills/skillsaw-review-panel/SKILL.md
+++ b/.claude/skills/skillsaw-review-panel/SKILL.md
@@ -24,8 +24,13 @@ Run **7 specialist reviewers + 1 arbiter** to review a skillsaw PR.
   Cheaper — codebase context is derived once and shared — but later
   specialists see earlier ones' file reads, which can bias them.
 
-Keep the panel **advisory**. It does not gate merge. It surfaces findings;
+Keep the panel **advisory** on everything except slop. It surfaces findings;
 the maintainer and PR author review and decide ship.
+
+**Slop is the exception.** Review-history residue and generated prose must not
+merge. A `BLOCKING` finding from the Slopinator gates the verdict: the
+disposition is `REQUEST_CHANGES` until the text is fixed, and no amount of
+agreement from the other specialists converts it into an `APPROVE`.
 
 ## Arguments
 
@@ -195,8 +200,11 @@ After all specialists complete, review and synthesize directly:
 
 **Follow these criteria:**
 
-- **APPROVE**: Set when no unresolved BLOCKING findings remain.
+- **APPROVE**: Set when no unresolved BLOCKING findings remain. An unresolved
+  Slopinator `BLOCKING` finding rules this out on its own — slop does not merge.
 - **REQUEST_CHANGES**: Set for BLOCKING findings that require code changes, but the change is in scope and fixable.
+  This is the disposition for unresolved slop, which is always in scope and
+  always fixable: the finding quotes the replacement text.
 - **NEEDS_DISCUSSION**: Set when findings need author input to resolve. The panel
   cannot decide without clarification — keep it here when the issue is neither a
   clean approve nor an outright change request or rejection.
@@ -213,6 +221,9 @@ After all specialists complete, review and synthesize directly:
 - Prefer existing patterns over novel ones.
 - Backward compatibility is paramount — breaking existing users is always blocking.
 - Keep core focused — prefer a plugin redirect over expanding core for niche tools.
+- Do not soften slop. A Slopinator `BLOCKING` finding is not a style nit to be
+  filtered as noise in Step 3, and it is not downgraded because the rest of the
+  change is good.
 
 Keep clean changes with no issues as a valid outcome — do not manufacture findings.
 

--- a/.claude/skills/skillsaw-review-panel/references/slopinator.md
+++ b/.claude/skills/skillsaw-review-panel/references/slopinator.md
@@ -8,10 +8,12 @@ underneath the result. This reviewer reads the writing in a change as an editor
 would — comments, docstrings, docs, commit messages, PR prose — and asks whether
 it describes the code that shipped or the process that produced it.
 
-**Slop blocks.** Residue and generated prose in shipped text are defects, not
-matters of taste, so this reviewer sets `BLOCKING` on them like any other
-specialist. That makes the precision guardrails below matter more, not less:
-read "What NOT to flag" before filing anything.
+**Slop blocks, and slop does not merge.** Residue and generated prose in
+shipped text are defects, not matters of taste. This reviewer sets `BLOCKING`
+on them, the arbiter does not downgrade them, and the verdict stays at
+`REQUEST_CHANGES` until they are fixed. What keeps that from being tyranny is
+accuracy, not timidity: "What NOT to flag" below draws the line, and inside it
+there is nothing to soften.
 
 ## Part A — Review-history residue in code
 
@@ -141,28 +143,35 @@ This reviewer becomes a nuisance the moment it polices taste. Leave these alone:
 - **Existing text the diff merely moves.** Review what the change writes, not
   every line it touches.
 
-Prefer clustering to isolated hits. One overused word is nothing; three tells in
-one paragraph is a finding. Cap the output at the strongest handful of items and
-group the rest as a single NOTE rather than filing one per instance.
+## Reporting volume
+
+In prose, prefer clustering to isolated hits: one overused word is nothing;
+three tells in one paragraph is a finding. Cap the output at the strongest
+handful of items and group the rest as a single NOTE rather than filing one per
+instance. None of this applies to Part A residue, which is reported every time
+it appears.
 
 ## Severity calibration
 
-- `BLOCKING`: Slop in shipped text. Review-history residue in code comments —
-  any Part A pattern — and clusters of Part B tells dense enough that a section
-  reads as generated rather than written. Also any comment or docstring that
-  asserts something **factually false** about the shipped code: a wrong
-  invariant, a bug that never existed, a stale measurement presented as
-  current. Quote the text and quote the replacement, so the author can accept
-  it verbatim and clear the finding in one edit.
-- `SUGGESTION`: One tell in otherwise clean writing, or a passage that is
-  merely weaker than it could be.
+- `BLOCKING`: Slop in shipped text.
+  - **Every Part A instance.** One review-history comment is enough. Residue is
+    binary — a comment either describes the shipped code or it describes the
+    conversation that produced it — so the clustering rule does not apply here
+    and a single instance blocks.
+  - **Any factually false claim** in a comment or docstring: a wrong invariant,
+    a bug that never existed, a stale measurement presented as current.
+  - **Part B tells clustered** densely enough that a passage reads as generated
+    rather than written.
+
+  Quote the text and quote the replacement, so the author can clear the finding
+  in one edit.
+- `SUGGESTION`: A lone Part B tell in otherwise clean prose.
 - `NOTE`: One-line polish — a filler phrase, a Title Case heading, a single
   signature-echo docstring in a file that is otherwise fine.
 
-Blocking raises the cost of a false positive, so the clustering rule above is a
-requirement rather than a preference: one overused word is never a finding. When
-a finding turns on taste instead of on residue or a false claim, drop it to
-`NOTE` or drop it entirely.
+The clustering rule governs Part B only, where one overused word is genuinely
+nothing. Never apply it to Part A as a reason to let residue through, and never
+downgrade a finding because the rest of the change is good.
 
 Clean writing is a valid outcome. Say what was checked and move on rather than
 manufacturing findings.

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -17,7 +17,7 @@
   <text x="56" y="46" class="subtitle">skillsaw report card</text>
   <g data-testid="stats">
     <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.19</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">31,687</tspan></tspan></text>
+    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">31,938</tspan></tspan></text>
     <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">11</tspan> skills</tspan></text>
     <text x="24" y="139" class="label">Top rules</text>
     <text x="24" y="154" class="rule" data-testid="rule-0">1. content-actionability-score (4)</text>


### PR DESCRIPTION
Follow-up to #460. This commit was pushed about a minute after #460 was
squash-merged, so it missed the merge.

## The gap

#460 gave the Slopinator a `BLOCKING` severity, but blocking in name only.
Three things on `main` today let a slop finding ship anyway:

1. `SKILL.md` still says **"Keep the panel advisory. It does not gate merge."**
   with no exception for slop.
2. `APPROVE` is "Set when no unresolved BLOCKING findings remain" — nothing
   prevents the arbiter from resolving a slop finding by filtering it as a
   style nit in the noise-filter step.
3. Part A residue inherits the prose clustering rule ("prefer clustering to
   isolated hits"), so a single review-history comment can read as below the
   reporting threshold.

## Changes

- **Carve slop out of the advisory stance.** The panel stays advisory on
  everything else; review-history residue and generated prose must not merge.
  An unresolved Slopinator `BLOCKING` rules out `APPROVE` on its own and holds
  the verdict at `REQUEST_CHANGES`.
- **Add an arbiter bias against softening slop.** It is not filtered as a style
  nit in Step 3, and not downgraded because the rest of the change is good.
- **Block on every Part A instance.** Residue is binary — a comment either
  describes the shipped code or the conversation that produced it — so the
  clustering rule now explicitly governs Part B prose only. One review-history
  comment is enough.
- Split the reporting-volume guidance out of "What NOT to flag", which the
  added sentence had pushed past the 500-token `content-section-length` limit.

The precision guardrails are unchanged: "What NOT to flag" still protects long
"why" comments, house style, domain vocabulary, version-scoped documents, and
comments a reviewer explicitly asked for.

## Scope note

The panel posts its verdict with `gh pr comment`, so `REQUEST_CHANGES` is a
disposition in a comment rather than a GitHub review state — this makes slop
gate the *verdict*, not the merge button. A hard gate would mean posting a real
review via `gh pr review --request-changes` plus branch protection, which is a
larger change to Step 6 and is deliberately not in this PR.

## Verification

- `make test` — 2965 passed, unchanged from `main`
- `make lint` — clean
- `.venv/bin/skillsaw lint .` — 0 errors, 0 warnings, grade A+, 6 info-level
  violations (the `main` baseline; the regenerated report card shows no drift)
- All three skill copies byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
