### PR TITLE
Tag plugin ownership on the lint tree; read it in the docs extractor

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -764,7 +764,30 @@ class RepositoryContext:
         return bool(self._discover_codex_marketplaces())
 
     def _discover_codex_marketplaces(self) -> List[Path]:
-        """Codex marketplace manifests in ``.agents/plugins/``.
+        """Codex marketplace manifests in ``.agents/plugins/``, for discovery.
+
+        The discovery-side view of the one catalog enumerator: honors the
+        ``--type`` gate, caches per context, and seeds the primary
+        entrypoint when the type was forced.
+        """
+        return self._enumerate_codex_catalogs(honor_discovery_gate=True)
+
+    def _codex_catalog_files(self) -> List[Path]:
+        """Codex catalog files present in the checkout, asked of the
+        filesystem.
+
+        Deliberately independent of ``_codex_discovery_enabled``: the
+        provenance claim set and ``codex_catalog_exists()`` read author
+        *declarations*, which a ``--type`` override does not change —
+        reading them from discovery would make ``--type marketplace``
+        restore the false positives the stand-downs exist to remove. The
+        lint tree's node discovery uses ``_discover_codex_marketplaces()``,
+        which honors the override.
+        """
+        return self._enumerate_codex_catalogs(honor_discovery_gate=False)
+
+    def _enumerate_codex_catalogs(self, *, honor_discovery_gate: bool) -> List[Path]:
+        """The one enumeration of Codex catalog files, parameterized by gating.
 
         ``marketplace.json`` is the documented path and is always taken on
         existence alone, so broken JSON still reaches the rules. A sibling
@@ -772,19 +795,32 @@ class RepositoryContext:
         ``api_marketplace.json`` — is taken on existence for the same
         reason: dropping it because its JSON is broken, or because
         ``plugins`` is not an array, hides exactly the defect
-        codex-marketplace-json-valid exists to report, and where there is
-        no primary ``marketplace.json`` it disables Codex marketplace
-        detection outright. Any other ``*.json`` still has to duck-type as
-        a marketplace, because the directory is not reserved and unrelated
-        JSON must not be linted as a catalog.
-        """
-        if self._codex_marketplace_paths is not None:
-            return self._codex_marketplace_paths
-        if not self._codex_discovery_enabled:
-            self._codex_marketplace_paths = []
-            return self._codex_marketplace_paths
+        codex-marketplace-json-valid exists to report. Any other ``*.json``
+        still has to duck-type as a marketplace, because the directory is
+        not reserved and unrelated JSON must not be linted as a catalog.
+        Every catalog counts, not just the primary — a repository whose
+        only catalog is a sibling is no less a Codex marketplace.
 
-        root = safe_resolve(self.root_path) or self.root_path
+        With ``honor_discovery_gate`` the result is the *discovery* answer:
+        gated on the ``--type`` override, cached in
+        ``_codex_marketplace_paths``, and seeded with the primary
+        entrypoint when the marketplace type was forced. Without it the
+        result is the *declaration* answer the provenance path needs —
+        filesystem-first and ``--type``-invariant, never cached through the
+        discovery slot.
+        """
+        if honor_discovery_gate:
+            if self._codex_marketplace_paths is not None:
+                return self._codex_marketplace_paths
+            if not self._codex_discovery_enabled:
+                self._codex_marketplace_paths = []
+                return self._codex_marketplace_paths
+            root = safe_resolve(self.root_path) or self.root_path
+        else:
+            resolved_root = safe_resolve(self.root_path)
+            if resolved_root is None:
+                return []
+            root = resolved_root
 
         def _inside(path: Path) -> bool:
             # A catalog that resolves outside the checkout is not this
@@ -836,68 +872,17 @@ class RepositoryContext:
                 if _looks_like_codex_catalog(_read_json_or_none(candidate)):
                     found.append(candidate)
 
-        if not found and self._codex_marketplace_forced and _keep(primary):
-            # ``_keep``, not a bare exclusion check: it also enforces
-            # containment. The registration rule writes this file back when
-            # it registers a plugin, so seeding an unchecked path would let
-            # ``fix --suggest`` rewrite a file outside the checkout through
-            # a symlinked catalog. An explicit --type says what format the
-            # repository is, not that its entrypoint may be anywhere.
-            found.append(primary)
-
-        self._codex_marketplace_paths = found
-        return found
-
-    def _codex_catalog_files(self) -> List[Path]:
-        """Codex catalog files present in the checkout, asked of the
-        filesystem.
-
-        Deliberately independent of ``_codex_discovery_enabled``: the
-        provenance claim set and ``codex_catalog_exists()`` read author
-        *declarations*, which a ``--type`` override does not change —
-        reading them from discovery would make ``--type marketplace``
-        restore the false positives the stand-downs exist to remove. The
-        lint tree's node discovery uses ``_discover_codex_marketplaces()``,
-        which honors the override.
-
-        Every catalog counts, not just the primary ``marketplace.json`` —
-        a repository whose only catalog is a sibling such as
-        ``api_marketplace.json`` is no less a Codex marketplace.
-        """
-        root = safe_resolve(self.root_path)
-        if root is None:
-            return []
-
-        def _usable(path: Path) -> bool:
-            resolved = safe_resolve(path)
-            if resolved is None or not resolved.is_relative_to(root):
-                return False
-            if self.is_path_excluded(path):
-                return False
-            return safe_exists(path) or safe_is_symlink(path)
-
-        found: List[Path] = []
-        primary = self.codex_marketplace_path()
-        primary_resolved = safe_resolve(primary)
-        if _usable(primary):
-            found.append(primary)
-        marketplace_dir = self.root_path.joinpath(*self.CODEX_MARKETPLACE_DIR)
-        if not safe_is_dir(marketplace_dir):
-            return found
-        try:
-            siblings = sorted(marketplace_dir.glob("*.json"))
-        except OSError:
-            return found
-        for candidate in siblings:
-            candidate_resolved = safe_resolve(candidate)
-            if candidate_resolved is not None and candidate_resolved == primary_resolved:
-                continue
-            if not _usable(candidate):
-                continue
-            if _is_marketplace_filename(candidate.name) or _looks_like_codex_catalog(
-                _read_json_or_none(candidate)
-            ):
-                found.append(candidate)
+        if honor_discovery_gate:
+            if not found and self._codex_marketplace_forced and _keep(primary):
+                # ``_keep``, not a bare exclusion check: it also enforces
+                # containment. The registration rule writes this file back
+                # when it registers a plugin, so seeding an unchecked path
+                # would let ``fix --suggest`` rewrite a file outside the
+                # checkout through a symlinked catalog. An explicit --type
+                # says what format the repository is, not that its
+                # entrypoint may be anywhere.
+                found.append(primary)
+            self._codex_marketplace_paths = found
         return found
 
     def codex_catalog_exists(self) -> bool:

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import html
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set
 
 from skillsaw.context import RepositoryContext, RepositoryType
 from skillsaw.formats.codex import (
@@ -37,7 +37,7 @@ from skillsaw.blocks import (
     ReadmeBlock,
     SkillBlock,
 )
-from skillsaw.lint_target import CodexPluginConfigNode, LintTarget, PluginNode, SkillNode
+from skillsaw.lint_target import CodexPluginConfigNode, PluginNode, SkillNode
 
 
 def extract_docs(
@@ -303,27 +303,11 @@ def _extract_codex_plugins(context: RepositoryContext) -> List[PluginDoc]:
         if not _is_codex_only(context, pn.path, codex_roots)
     }
     docs: List[PluginDoc] = []
-    # Resolved once for the whole catalog rather than once per plugin:
-    # matching skills by path is O(plugins x skills) stat calls otherwise,
-    # and a large catalog has hundreds of each.
-    skill_nodes = [(safe_resolve(n.path), n) for n in context.lint_tree.find(SkillNode)]
-    resolved_skills = [(r, n) for r, n in skill_nodes if r is not None]
-
-    # One pass, like the skill map above: scanning every legacy node per
-    # Codex plugin is O(codex x legacy) filesystem resolutions, and a large
-    # catalog has hundreds of each. A list, not the membership set bound
-    # above: _extract_codex_skills scans it in order for nearest-root
-    # matching.
-    plugin_roots = context.codex_plugin_roots()
-
-    legacy_by_path: Dict[Path, List[PluginNode]] = {}
-    for pn in context.lint_tree.find(PluginNode):
-        resolved_pn = safe_resolve(pn.path)
-        if resolved_pn is not None:
-            legacy_by_path.setdefault(resolved_pn, []).append(pn)
-
     for node in context.lint_tree.find(CodexPluginConfigNode):
-        plugin_resolved = safe_resolve(node.plugin_dir)
+        # The build tagged the manifest node with its owning plugin root
+        # when it attached the Codex cluster — the tree's ownership
+        # decision, read back rather than re-derived from the path.
+        plugin_resolved = node.plugin_owner
         if not node.path.is_file() or plugin_resolved is None or plugin_resolved in claude_dirs:
             continue
         if context.is_codex_installed_plugin(node.plugin_dir):
@@ -332,94 +316,39 @@ def _extract_codex_plugins(context: RepositoryContext) -> List[PluginDoc]:
             # else's plugin — the same authorship line the registration and
             # manifest-quality rules already draw.
             continue
-        legacy = legacy_by_path.get(plugin_resolved, [])
-        docs.append(
-            _extract_codex_plugin(
-                context,
-                node,
-                plugin_resolved,
-                resolved_skills,
-                legacy,
-                plugin_roots,
-                # Every plugin root, Claude and Codex: a root-level plugin's
-                # container is the tree root, and prose scoping must stop at
-                # the nearest owning plugin of either ecosystem or a nested
-                # plugin's files are republished under the root plugin.
-                set(plugin_roots) | set(legacy_by_path),
-            )
-        )
+        docs.append(_extract_codex_plugin(context, node, plugin_resolved))
     return docs
 
 
-class _OwnBlocks:
-    """A bare holder so a loose block can join ``_BlockSources``."""
+def _owned_blocks(
+    context: RepositoryContext,
+    node: CodexPluginConfigNode,
+    block_cls: type,
+    plugin_resolved: Path,
+) -> list:
+    """Blocks the tree assigned to this plugin, the manifest subtree first.
 
-    def __init__(self, blocks):
-        self._blocks = blocks
-
-    def find(self, block_cls):
-        return [b for b in self._blocks if isinstance(b, block_cls)]
-
-
-def _root_claimed_blocks(context: RepositoryContext, plugin_dir: Path) -> List["_OwnBlocks"]:
-    """Conventional files the tree root claimed before the plugin could.
-
-    A Codex plugin *at the repository root* shares ``.mcp.json`` with the
-    repository itself, and the generic root attachment runs first — so the
-    block lands on the tree root, the lint tree's ``seen`` set keeps it off
-    the Codex node, and the rules find it while ``skillsaw docs`` does not.
-    Matching by path rather than adding the whole root as a source, which
-    would pull in every other plugin's blocks as well.
+    Prose attaches to the plugin's container and config to the manifest
+    node, and a repo-root plugin's conventional ``.mcp.json`` was claimed
+    by the generic root attach before the plugin pass ran — all of them
+    carry the ``plugin_owner`` tag the build recorded, so one owner scan
+    finds every placement. The manifest subtree is listed first (and
+    deduplicated by identity) to keep the established document order.
     """
-    root = safe_resolve(plugin_dir)
-    if root is None or root != safe_resolve(context.root_path):
-        return []
-    wanted = {
-        safe_resolve(plugin_dir / ".mcp.json"),
-        safe_resolve(plugin_dir / "hooks" / "hooks.json"),
-    }
-    wanted.discard(None)
-    if not wanted:
-        return []
-    loose = [
+    blocks = node.find(block_cls)
+    have = {id(b) for b in blocks}
+    blocks.extend(
         b
-        for b in context.lint_tree.find(McpBlock) + context.lint_tree.find(HooksBlock)
-        if safe_resolve(b.path) in wanted
-    ]
-    return [_OwnBlocks(loose)] if loose else []
-
-
-class _BlockSources:
-    """Several tree nodes searched as one for `find()`.
-
-    Deduplicated by node identity: a legacy ``PluginNode`` has the Codex
-    node as a descendant, so ``find()`` on both returns the Codex node's own
-    blocks twice and the docs would list those hooks and servers twice.
-    """
-
-    def __init__(self, nodes):
-        self._nodes = nodes
-
-    def find(self, block_cls):
-        out = []
-        seen = set()
-        for node in self._nodes:
-            for block in node.find(block_cls):
-                if id(block) in seen:
-                    continue
-                seen.add(id(block))
-                out.append(block)
-        return out
+        for b in context.lint_tree.find(block_cls)
+        if id(b) not in have and b.plugin_owner == plugin_resolved
+    )
+    return blocks
 
 
 def _extract_codex_plugin(
     context: RepositoryContext,
     node: CodexPluginConfigNode,
     plugin_resolved: Path,
-    resolved_skills: List[Tuple[Path, SkillNode]],
-    legacy_nodes: List[PluginNode],
-    codex_roots: List[Path],
-    prose_roots: Optional[Set[Path]] = None,
 ) -> PluginDoc:
     """Build a PluginDoc from a Codex manifest and its subtree.
 
@@ -429,15 +358,8 @@ def _extract_codex_plugin(
     directory conventions, and dropping them would publish empty pages
     for plugins whose prose the lint tree already holds.
     """
-    if prose_roots is None:
-        prose_roots = set(codex_roots)
     plugin_dir = node.plugin_dir
     meta = _read_json_dict(node)
-    # When legacy discovery also built a PluginNode for this directory — it
-    # does for any plugin shipping commands/ — that node claimed hooks.json
-    # and .mcp.json first, and the lint tree's ``seen`` set kept them off
-    # the Codex node. Both are searched so neither placement loses them.
-    sources = _BlockSources([node, *legacy_nodes, *_root_claimed_blocks(context, plugin_dir)])
 
     author_val = meta.get("author")
     if isinstance(author_val, str):
@@ -456,49 +378,19 @@ def _extract_codex_plugin(
         homepage=_safe_url(meta.get("homepage")),
         repository=_safe_url(meta.get("repository")),
         license=str(meta.get("license", "") or ""),
-        commands=_command_docs(_scoped_prose(node, CommandBlock, plugin_resolved, prose_roots)),
-        skills=_extract_codex_skills(plugin_resolved, resolved_skills, codex_roots),
-        agents=_agent_docs(_scoped_prose(node, AgentBlock, plugin_resolved, prose_roots)),
-        hooks=_extract_hooks(sources),
+        commands=_command_docs(_owned_blocks(context, node, CommandBlock, plugin_resolved)),
+        skills=_extract_codex_skills(context, plugin_resolved),
+        agents=_agent_docs(_owned_blocks(context, node, AgentBlock, plugin_resolved)),
+        hooks=_extract_hooks(_owned_blocks(context, node, HooksBlock, plugin_resolved)),
         # meta is passed empty: the manifest's own ``mcpServers`` map is
         # already in the tree as a CodexInlineMcpBlock, and feeding it here
         # too would list every inline server twice.
-        mcp_servers=_extract_mcp_servers(sources, {}),
-        rules=_rule_docs(_scoped_prose(node, PluginRuleBlock, plugin_resolved, prose_roots)),
+        mcp_servers=_extract_mcp_servers(
+            _owned_blocks(context, node, McpBlock, plugin_resolved), {}
+        ),
+        rules=_rule_docs(_owned_blocks(context, node, PluginRuleBlock, plugin_resolved)),
         has_readme=(plugin_dir / "README.md").is_file(),
     )
-
-
-def _scoped_prose(
-    node: CodexPluginConfigNode,
-    block_cls: type,
-    plugin_resolved: Path,
-    prose_roots: Set[Path],
-):
-    """Prose blocks attached to *node*'s container, owned by this plugin.
-
-    The single tree pass attaches a Codex-only plugin's prose to its
-    container (a CodexPluginNode, or the tree root for a root-level
-    plugin). The root case can hold other plugins' blocks too, and for a
-    repo-root plugin bare containment is vacuously true for all of them —
-    so ownership uses the nearest plugin root, exactly as
-    ``_extract_codex_skills`` matches skills.
-    """
-    container = node.parent
-    if container is None:
-        return []
-    scoped = []
-    for block in container.find(block_cls):
-        resolved = safe_resolve(block.path)
-        if resolved is None or not resolved.is_relative_to(plugin_resolved):
-            continue
-        owner = next(
-            (c for c in resolved.parents if c in prose_roots),
-            plugin_resolved,
-        )
-        if owner == plugin_resolved:
-            scoped.append(block)
-    return scoped
 
 
 def _read_json_dict(node: CodexPluginConfigNode) -> dict:
@@ -567,35 +459,17 @@ def _string_list(value) -> List[str]:
     return [str(v) for v in value if v]
 
 
-def _extract_codex_skills(
-    plugin_resolved: Path,
-    resolved_skills: List[Tuple[Path, SkillNode]],
-    all_plugin_roots: List[Path],
-) -> List[SkillDoc]:
-    """Skills living under the plugin directory.
+def _extract_codex_skills(context: RepositoryContext, plugin_resolved: Path) -> List[SkillDoc]:
+    """Skills the tree assigned to this plugin.
 
-    A Codex-only plugin has no ``PluginNode`` for its skills to nest
-    inside, so they hang off the tree root and have to be matched back by
-    path rather than by subtree. Both sides arrive pre-resolved — see the
-    caller for why.
+    A nested plugin's skills nest under its container, while a repo-root
+    plugin's hang off the tree root; either way the build tagged each
+    ``SkillNode`` with its owning plugin root, so membership is a read,
+    not a path match.
     """
     docs = []
-    # Ancestor walk against a set — a scan of every root per skill is
-    # O(skills x plugins) and dominates ``skillsaw docs`` on large
-    # catalogs.
-    root_set = set(all_plugin_roots)
-    for skill_resolved, skill_node in resolved_skills:
-        if not skill_resolved.is_relative_to(plugin_resolved):
-            continue
-        # A repo root that is itself a plugin contains the nested plugins
-        # under plugins/, so their skills are relative to both roots.
-        # Nearest root wins, or the root plugin's page would duplicate and
-        # misattribute every nested plugin's skills.
-        owner = next(
-            (c for c in (skill_resolved, *skill_resolved.parents) if c in root_set),
-            plugin_resolved,
-        )
-        if owner != plugin_resolved:
+    for skill_node in context.lint_tree.find(SkillNode):
+        if skill_node.plugin_owner != plugin_resolved:
             continue
         doc = _extract_skill(skill_node)
         if doc:
@@ -638,8 +512,8 @@ def _extract_plugin(context: RepositoryContext, plugin_node: PluginNode) -> Plug
         commands=_extract_commands(plugin_node),
         skills=_extract_skills(plugin_node),
         agents=_extract_agents(plugin_node),
-        hooks=_extract_hooks(plugin_node),
-        mcp_servers=_extract_mcp_servers(plugin_node, meta),
+        hooks=_extract_hooks(plugin_node.find(HooksBlock)),
+        mcp_servers=_extract_mcp_servers(plugin_node.find(McpBlock), meta),
         rules=_extract_rules(plugin_node),
         has_readme=bool(plugin_node.find(ReadmeBlock)),
     )
@@ -744,9 +618,9 @@ def _agent_docs(blocks) -> List[AgentDoc]:
 # -- Hooks --
 
 
-def _extract_hooks(plugin_node: LintTarget) -> List[HookDoc]:
+def _extract_hooks(blocks: List[HooksBlock]) -> List[HookDoc]:
     docs = []
-    for block in plugin_node.find(HooksBlock):
+    for block in blocks:
         for event_type in sorted(block.events):
             configs = block.events[event_type]
             entries = [
@@ -768,11 +642,11 @@ def _extract_hooks(plugin_node: LintTarget) -> List[HookDoc]:
 # -- MCP Servers --
 
 
-def _extract_mcp_servers(plugin_node: LintTarget, plugin_meta: dict) -> List[McpServerDoc]:
+def _extract_mcp_servers(blocks: List[McpBlock], plugin_meta: dict) -> List[McpServerDoc]:
     servers: List[McpServerDoc] = []
     seen: set = set()
 
-    for block in plugin_node.find(McpBlock):
+    for block in blocks:
         # Not hard-coded: a Codex manifest can point ``mcpServers`` at
         # another file, or hold the map itself — in which case the block
         # borrows the manifest's path and the source really is plugin.json.

--- a/src/skillsaw/lint_target.py
+++ b/src/skillsaw/lint_target.py
@@ -18,6 +18,12 @@ class LintTarget:
     path: Path
     children: List["LintTarget"] = field(default_factory=list)
     parent: Optional["LintTarget"] = field(default=None, repr=False)
+    # Resolved root of the plugin directory that owns this node, recorded by
+    # ``build_lint_tree`` while it attaches plugin content — ownership is
+    # decided once at build time and read back by consumers such as
+    # ``skillsaw docs``, never re-derived by path matching. ``None`` for
+    # nodes no plugin owns.
+    plugin_owner: Optional[Path] = field(default=None, repr=False)
 
     @property
     def resolved_path(self) -> Path:

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -172,8 +172,26 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             return
 
         def _contained(p: Path) -> bool:
+            """Inside this plugin, and not inside a nested claimed plugin.
+
+            The recursive ``rules/`` scan of a repo-root plugin would
+            otherwise claim a catalog-sourced nested plugin's files —
+            tagging them with the outer owner and poisoning ``seen`` before
+            the nested plugin's own pass could attach them. Provenance owns
+            that boundary: any claimed plugin directory strictly between the
+            file and this plugin's root means the file is the nested
+            plugin's to attach. ``seen_plugin_dirs`` is fully populated
+            before the plugin loop makes the first call here.
+            """
             resolved = safe_resolve(p)
-            return resolved is not None and resolved.is_relative_to(plugin_resolved)
+            if resolved is None:
+                return False
+            for ancestor in resolved.parents:
+                if ancestor == plugin_resolved:
+                    return True
+                if ancestor in seen_plugin_dirs:
+                    return False
+            return False
 
         for dirname, block_cls, pattern in (
             ("commands", CommandBlock, "*.md"),

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -98,18 +98,22 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         parent: LintTarget,
         p: Path,
         block_cls: type,
+        owner: Path | None = None,
     ) -> None:
         resolved = p.resolve()
         if resolved in seen or not p.exists() or _is_excluded(p):
             return
         seen.add(resolved)
         seen_roles.add((resolved, block_cls))
-        parent.children.append(block_cls(path=p))
+        block = block_cls(path=p)
+        block.plugin_owner = owner
+        parent.children.append(block)
 
     def _add_parser_block(
         parent: LintTarget,
         p: Path,
         block_cls: type,
+        owner: Path | None = None,
     ) -> None:
         """Attach a structured document once for each parser role.
 
@@ -129,12 +133,19 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # file; poisoning ``seen`` with that path would silently drop the
         # file from every content and prose rule that attaches later.
         seen_roles.add(role)
-        parent.children.append(block_cls(path=p))
+        block = block_cls(path=p)
+        block.plugin_owner = owner
+        parent.children.append(block)
 
     # Nearest-root ownership, with the roots resolved once per context.
     _codex_owner = context.codex_plugin_owning
 
-    def _add_codex_block(parent: CodexPluginConfigNode, p: Path, block_cls: type) -> None:
+    def _add_codex_block(
+        parent: CodexPluginConfigNode,
+        p: Path,
+        block_cls: type,
+        owner: Path | None = None,
+    ) -> None:
         """Role-aware block attachment for a path that must stay inside its plugin.
 
         The conventional Codex files (``hooks/hooks.json``, ``.mcp.json``)
@@ -146,9 +157,9 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         resolved = safe_resolve(p)
         if root is None or resolved is None or not resolved.is_relative_to(root):
             return
-        _add_parser_block(parent, p, block_cls)
+        _add_parser_block(parent, p, block_cls, owner=owner)
 
-    def _add_plugin_prose(parent: LintTarget, plugin_dir: Path) -> None:
+    def _add_plugin_prose(parent: LintTarget, plugin_dir: Path, owner: Path) -> None:
         """The one prose attach for every plugin container.
 
         ``commands/``, ``agents/``, ``rules/`` and README follow the same
@@ -180,10 +191,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 continue
             for md in files:
                 if _contained(md):
-                    _add_block(parent, md, block_cls)
+                    _add_block(parent, md, block_cls, owner=owner)
         readme = plugin_dir / "README.md"
         if _contained(readme):
-            _add_block(parent, readme, ReadmeBlock)
+            _add_block(parent, readme, ReadmeBlock, owner=owner)
 
     def _add_openai_metadata(
         parent: LintTarget,
@@ -302,6 +313,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         seen_plugin_dirs.add(resolved_candidate)
         plugin_dirs.append(candidate)
 
+    root_plugin_owner: Path | None = None
     for plugin_path in plugin_dirs:
         prov = context.provenance(plugin_path)
         # Compiled-output filtering is a Claude/APM concept; a Codex claim
@@ -325,12 +337,32 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             container = CodexPluginNode(path=plugin_path)
             codex_plugin_nodes[resolved_plugin] = container
 
+        if container is not root:
+            container.plugin_owner = resolved_plugin
+        else:
+            # A repo-root Codex plugin shares conventional config paths
+            # with the repository itself, and the generic root attach ran
+            # first — so those blocks live on the tree root while the
+            # ownership is still this plugin's. Decided here, once, so
+            # readers like ``skillsaw docs`` never re-match the paths.
+            root_plugin_owner = resolved_plugin
+            claimed = {
+                safe_resolve(plugin_path / ".mcp.json"),
+                safe_resolve(plugin_path / "hooks" / "hooks.json"),
+            } - {None}
+            for child in root.children:
+                if (
+                    isinstance(child, (McpBlock, HooksBlock))
+                    and safe_resolve(child.path) in claimed
+                ):
+                    child.plugin_owner = resolved_plugin
+
         # Prose: the conventions are identical in both ecosystems, so one
         # attach covers commands/, agents/, rules/ and README — with
         # containment, because a symlinked command file is an external
         # file under an in-repo name whichever ecosystem claims the
         # directory.
-        _add_plugin_prose(container, plugin_path)
+        _add_plugin_prose(container, plugin_path, resolved_plugin)
 
         # Conventional configs. Codex-claimed directories get hooks and
         # MCP exclusively through the Codex cluster below — it attaches
@@ -339,15 +371,21 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # file's commands into CI diagnostics. Pure-Claude plugins keep
         # their established attach.
         if not prov.codex:
-            _add_block(container, plugin_path / "hooks" / "hooks.json", HooksBlock)
-            _add_block(container, plugin_path / ".mcp.json", McpBlock)
+            _add_block(
+                container, plugin_path / "hooks" / "hooks.json", HooksBlock, owner=resolved_plugin
+            )
+            _add_block(container, plugin_path / ".mcp.json", McpBlock, owner=resolved_plugin)
         # settings.json is Claude-side configuration with no Codex
         # counterpart: attached only for Claude-style directories, which
         # also keeps _add_block's bare resolve() away from content a
         # hostile Codex-only checkout controls.
         if prov.claude or not prov.codex:
-            _add_block(container, plugin_path / "settings.json", SettingsBlock)
-            _add_block(container, plugin_path / "settings.local.json", SettingsBlock)
+            _add_block(
+                container, plugin_path / "settings.json", SettingsBlock, owner=resolved_plugin
+            )
+            _add_block(
+                container, plugin_path / "settings.local.json", SettingsBlock, owner=resolved_plugin
+            )
 
         # Codex manifest cluster, for any directory Codex claims (dual
         # directories hang it off their PluginNode).
@@ -362,6 +400,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             # checks, and executable commands; the linter filters
             # violations filed against the excluded manifest itself.
             node = CodexPluginConfigNode(path=manifest)
+            node.plugin_owner = resolved_plugin
             _add_openai_metadata(
                 node,
                 plugin_path / "agents" / "openai.yaml",
@@ -374,25 +413,31 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             # deduplication keeps the dual-ecosystem attach above from
             # doubling findings; containment keeps a symlinked hooks.json
             # from pulling an external file's commands into this plugin.
-            _add_codex_block(node, plugin_path / "hooks" / "hooks.json", HooksBlock)
+            _add_codex_block(
+                node, plugin_path / "hooks" / "hooks.json", HooksBlock, owner=resolved_plugin
+            )
             # A manifest may point ``hooks`` at other files, or write them
             # inline; both carry the same executable commands. Inline
             # payloads have no file of their own, so they borrow the
             # manifest path, which is already claimed — appended directly.
             for declared_hooks in codex_declared_hook_files(plugin_path):
-                _add_parser_block(node, declared_hooks, HooksBlock)
+                _add_parser_block(node, declared_hooks, HooksBlock, owner=resolved_plugin)
             for inline_hooks in codex_inline_hooks(plugin_path):
-                node.children.append(CodexInlineHooksBlock(path=manifest, inline_data=inline_hooks))
+                inline_block = CodexInlineHooksBlock(path=manifest, inline_data=inline_hooks)
+                inline_block.plugin_owner = resolved_plugin
+                node.children.append(inline_block)
             # Same treatment for MCP: the conventional .mcp.json, declared
             # files, and inline maps are all commands the host will spawn.
             # One document can legitimately be declared as both ``hooks``
             # and ``mcpServers``; one attach per parser role lets both
             # rule families see it without doubling either.
-            _add_codex_block(node, plugin_path / ".mcp.json", McpBlock)
+            _add_codex_block(node, plugin_path / ".mcp.json", McpBlock, owner=resolved_plugin)
             for declared_mcp in codex_declared_mcp_files(plugin_path):
-                _add_parser_block(node, declared_mcp, McpBlock)
+                _add_parser_block(node, declared_mcp, McpBlock, owner=resolved_plugin)
             for inline_mcp in codex_inline_mcp_servers(plugin_path):
-                node.children.append(CodexInlineMcpBlock(path=manifest, inline_data=inline_mcp))
+                inline_block = CodexInlineMcpBlock(path=manifest, inline_data=inline_mcp)
+                inline_block.plugin_owner = resolved_plugin
+                node.children.append(inline_block)
             container.children.append(node)
 
         if container is not root:
@@ -443,10 +488,15 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             node = plugin_nodes.get(candidate) or codex_plugin_nodes.get(candidate)
             if node is not None:
                 parent_plugin = node
+                skill_node.plugin_owner = candidate
                 break
         if parent_plugin is not None:
             parent_plugin.children.append(skill_node)
         else:
+            # A repo-root Codex plugin has no container of its own, so its
+            # skills hang off the tree root; the ownership tag keeps them
+            # attributable to the plugin all the same.
+            skill_node.plugin_owner = root_plugin_owner
             root.children.append(skill_node)
 
     # --- .coderabbit.yaml ---

--- a/tests/codex/test_docs_rendering.py
+++ b/tests/codex/test_docs_rendering.py
@@ -4,10 +4,12 @@ import json
 
 import pytest
 
+from skillsaw.blocks import PluginRuleBlock
 from skillsaw.docs.extractor import extract_docs
 from skillsaw.docs.html_renderer import render_html
 from skillsaw.docs.markdown_renderer import render_markdown
 from skillsaw.context import RepositoryContext
+from skillsaw.lint_target import CodexPluginNode
 
 from ._helpers import _write_plugin, _codex_plugin_repo, _codex_marketplace_repo
 
@@ -712,6 +714,61 @@ class TestDocsRenderTotality:
         joined = "\n".join(md_pages.values())
         assert "go" in joined
         assert "helper" in joined  # name fell back to the file stem
+
+
+class TestNestedPluginUnderRules:
+    def test_a_nested_plugins_files_are_not_claimed_by_the_root_scan(self, tmp_path):
+        """A catalog-sourced plugin nested below a repo-root plugin's rules/
+        keeps its own files: the root's recursive rules/**/*.md scan must
+        not tag them with the outer owner (which would also poison the
+        ``seen`` set and block the nested plugin's own attach), and the
+        generated docs must attribute them to the nested plugin only."""
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {"name": "outer", "version": "1.0.0", "description": "The outer plugin."},
+        )
+        (repo / "rules").mkdir()
+        (repo / "rules" / "policy.md").write_text(
+            "Always follow the outer repository policy.\n", encoding="utf-8"
+        )
+        (repo / ".agents" / "plugins").mkdir(parents=True)
+        (repo / ".agents" / "plugins" / "marketplace.json").write_text(
+            json.dumps(
+                {
+                    "name": "cat",
+                    "plugins": [
+                        {
+                            "name": "inner-plugin",
+                            "source": {"source": "local", "path": "./rules/nested"},
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        nested = _write_plugin(
+            repo / "rules" / "nested",
+            {"name": "inner-plugin", "version": "1.0.0", "description": "The nested plugin."},
+        )
+        (nested / "rules").mkdir()
+        (nested / "rules" / "inner.md").write_text(
+            "Always follow the inner plugin rule.\n", encoding="utf-8"
+        )
+
+        context = RepositoryContext(repo)
+
+        # Lint tree: each rule file is owned by, and attached under, the
+        # plugin that ships it.
+        owners = {b.path.name: b.plugin_owner for b in context.lint_tree.find(PluginRuleBlock)}
+        assert owners == {"policy.md": repo.resolve(), "inner.md": nested.resolve()}
+        nested_containers = context.lint_tree.find(CodexPluginNode)
+        assert [n.path for n in nested_containers] == [nested]
+        assert {b.path.name for b in nested_containers[0].find(PluginRuleBlock)} == {"inner.md"}
+
+        # Docs: no duplication, no misattribution.
+        docs = extract_docs(context)
+        rules_by_plugin = {p.name: [r.name for r in p.rules] for p in docs.plugins}
+        assert rules_by_plugin == {"outer": ["policy"], "inner-plugin": ["inner"]}
 
 
 class TestNonStringNamesDoNotCrashSorting:


### PR DESCRIPTION
## Summary

Internal plumbing refactor into `codex-plugin-rules` — no rule logic, message text, or discovery semantics change.

**Ownership is decided once, at build time.** `LintTarget` gains a `plugin_owner` field (the resolved root of the owning plugin directory, `None` when no plugin owns the node). `build_lint_tree` records it on everything the plugin pass attaches: prose (`commands/`, `agents/`, `rules/`, README), conventional and declared hooks/MCP config, inline payload blocks, the `CodexPluginConfigNode`, containers, and nested `SkillNode`s. A repo-root Codex plugin's conventional `.mcp.json`/`hooks.json` — claimed by the generic root attach before the plugin pass runs — is tagged in the same pass, so the ownership answer lives in exactly one place.

**The docs extractor reads that answer instead of re-deriving it.** The duck-typed shims (`_OwnBlocks`, `_BlockSources`, `_root_claimed_blocks`) and the nearest-root path matching in `_scoped_prose` / `_extract_codex_skills` are deleted. `_extract_hooks` / `_extract_mcp_servers` now take plain block lists; a single `_owned_blocks` helper (manifest subtree first, then owner-tagged strays, deduplicated by identity) preserves the established document order, and skill membership is one owner comparison. The dead legacy-`PluginNode` merging machinery goes with it — under the one-pass tree a Codex-only directory never gets a `PluginNode`.

**The twin Codex catalog enumerators collapse into one.** `RepositoryContext._discover_codex_marketplaces()` and `_codex_catalog_files()` are now thin wrappers over `_enumerate_codex_catalogs(honor_discovery_gate=...)`. The gated variant keeps the `--type` gate, the per-context cache, and the forced-type primary seed; the ungated variant keeps the documented filesystem-first, `--type`-invariant behavior the provenance path requires (never cached through the discovery slot).

## Verification

- `make test`: 3472 passed. `make lint` clean; `make update` produced no generated-file drift.
- **Docs byte-stability** (baseline generated at the branch point, compared with recursive `diff -r`): `skillsaw docs --format markdown` and `--format html` outputs are byte-identical before vs. after for `tests/fixtures/codex/clean`, `tests/fixtures/codex/broken`, and the openai/plugins corpus (181 markdown pages + HTML index).
- **Real-corpus canary**: `skillsaw lint <openai/plugins> --format json` — 973 violations before and after; the full violation lists compare equal, not just the counts.
- `openshift-eng/ai-helpers`: exits 1 identically before and after this change — its own custom `plugins-doc-up-to-date` rule reports that repo's checked-in `docs/` as stale, a pre-existing condition at the `codex-plugin-rules` branch point (and itself a fourth byte-for-byte docs comparison that this refactor passes).
- Diffstat: 4 files changed, 185 insertions(+), 270 deletions(−) — net −85 lines in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)