### PR TITLE
Prune review-sediment comments; keep load-bearing invariants

### DIFF
--- a/src/skillsaw/cli/_helpers.py
+++ b/src/skillsaw/cli/_helpers.py
@@ -68,13 +68,12 @@ def _resolve_lint_paths(paths):
                 widened = resolved.parent
             elif resolved.name == "plugins" and resolved.parent.name == ".agents":
                 widened = resolved.parent.parent
-            # Bounded: Codex documents a *user-level* catalog at
+            # Bounded: Codex documents a user-level catalog at
             # ``~/.agents/plugins/marketplace.json``, and widening that
             # walks all of $HOME — printing findings (and secrets) from
             # unrelated private projects. Same for the filesystem root.
-            # Resolved comparison: a symlinked $HOME (routine on macOS and
-            # NFS) otherwise slips past the bound and the walk covers the
-            # entire home directory.
+            # Resolved comparison, or a symlinked $HOME slips past the
+            # bound.
             if widened is not resolved:
                 try:
                     bounds = (Path.home().resolve(), Path(widened.anchor))

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -14,9 +14,8 @@ import json
 import logging
 import os
 
-# Dependency-light format helper — safe to import at module top because it
-# pulls in nothing from skillsaw (importing rules.builtin here would trigger
-# that package's __init__ while ``context`` is still mid-import → cycle).
+# Safe to import at module top: formats.codex pulls in nothing from
+# skillsaw, so no import cycle while ``context`` is mid-import.
 from .formats.codex import (
     CODEX_PLUGIN_MANIFEST as _CODEX_PLUGIN_MANIFEST,
     codex_declared_skill_dirs,
@@ -36,9 +35,8 @@ logger = logging.getLogger(__name__)
 def merge_plugin_dirs(plugins: List[Path], codex_plugins: List[Path]) -> List[Path]:
     """Claude and Codex plugin directories, deduplicated by resolved path.
 
-    Module-level so the CLI's merged multi-path context can share it with
-    :meth:`RepositoryContext.distinct_plugin_dirs` without borrowing a
-    method across duck types.
+    Shared by the CLI's merged multi-path context and
+    :meth:`RepositoryContext.distinct_plugin_dirs`.
     """
     seen: Dict[Path, Path] = {}
     for p in (*plugins, *codex_plugins):
@@ -52,21 +50,17 @@ def merge_plugin_dirs(plugins: List[Path], codex_plugins: List[Path]) -> List[Pa
 def _pattern_variants(pattern: str) -> Tuple[str, ...]:
     """Expand *pattern* into the fnmatch patterns it is tried as.
 
-    :mod:`fnmatch` has no special handling for ``**`` — it behaves exactly
-    like ``*`` (which already crosses ``/``) — so a leading ``**/`` demands
-    at least one directory before the rest of the pattern and never matches
-    at the start of a relative path: ``**/templates/**`` misses a top-level
-    ``templates/``. To honor gitignore-style semantics where ``**/`` also
-    matches zero leading directories, a variant with the ``**/`` prefix
-    stripped is tried as well. The original pattern is always kept, making
-    the expansion a strict superset of plain fnmatch.
+    :mod:`fnmatch` treats ``**`` exactly like ``*`` (which already crosses
+    ``/``), so a leading ``**/`` demands at least one directory and misses a
+    top-level match. To honor gitignore semantics where ``**/`` also matches
+    zero leading directories, a variant with the prefix stripped is tried as
+    well; the original pattern is always kept, so the expansion is a strict
+    superset of plain fnmatch.
 
-    Deliberately NOT expanded: a trailing ``/**`` matches strictly inside
-    the directory, never the directory entry itself. Widening it silently
-    suppressed violations *addressed to* a directory — the built-in
-    ``**/template/**`` content exclude swallowed a ``Missing SKILL.md``
-    error for any skill directory named ``template``, with no user
-    configuration involved.
+    A trailing ``/**`` must NOT be widened to match the directory entry
+    itself: doing so suppressed violations addressed to the directory — the
+    built-in ``**/template/**`` content exclude swallowed ``Missing
+    SKILL.md`` for any skill directory named ``template``.
     """
     variants = {pattern}
     if pattern.startswith("**/"):
@@ -79,9 +73,7 @@ def path_matches_patterns(path: Path, root: Path, patterns: List[str]) -> bool:
 
     Patterns use :mod:`fnmatch` syntax where ``*`` crosses ``/``, extended
     with one gitignore-style rule via :func:`_pattern_variants`: a leading
-    ``**/`` also matches at the start of the relative path, so
-    ``**/templates/**`` excludes both a top-level ``templates/`` and a
-    nested ``a/templates/``.
+    ``**/`` also matches at the start of the relative path.
 
     The single exclusion predicate shared by the context, the lint tree, and
     the linter's per-rule excludes. *root* must be resolved; paths outside
@@ -92,11 +84,9 @@ def path_matches_patterns(path: Path, root: Path, patterns: List[str]) -> bool:
     try:
         rel = str(path.resolve().relative_to(root))
     except (ValueError, OSError, RuntimeError):
-        # OSError/RuntimeError: a symlink loop under *path* (version-
-        # dependent which one). Violation filtering runs this on every
-        # reported path, so raising here aborts the lint that was about
-        # to report the loop's own diagnostic. Unresolvable paths simply
-        # never match an exclude.
+        # OSError/RuntimeError: a symlink loop under *path*. Raising here
+        # would abort the lint that was about to report the loop's own
+        # diagnostic — unresolvable paths simply never match an exclude.
         return False
     return any(
         fnmatch.fnmatch(rel, variant) for pat in patterns for variant in _pattern_variants(pat)
@@ -120,14 +110,9 @@ class RepositoryType(Enum):
 
 # Repository types whose lint tree can hold Agent Skills. One shared set so a
 # newly supported host cannot be wired into some skill rules and forgotten in
-# the rest. Defined here rather than in a rule package because independent
-# rule packages (agentskills, openclaw, codex) all need it, and none should
-# import another's private helpers. CODEX_PLUGIN belongs here because a Codex
-# plugin ships ``skills/<name>/SKILL.md`` in the same format — most visibly
-# for a plugin installed under ``.codex/plugins/``, which no other repository
-# type covers. CODEX_MARKETPLACE for the same reason MARKETPLACE is here: a
-# catalog repository holds the plugins, and their skills are discovered
-# whether or not the CODEX_PLUGIN type was also inferred.
+# the rest. The Codex types belong here because Codex plugins ship
+# ``skills/<name>/SKILL.md`` in the same format, and a catalog repository's
+# plugin skills are discovered whether or not CODEX_PLUGIN was also inferred.
 SKILL_REPO_TYPES = {
     RepositoryType.AGENTSKILLS,
     RepositoryType.SINGLE_PLUGIN,
@@ -161,11 +146,9 @@ ALL_INSTRUCTION_FORMATS = frozenset(
 def _is_marketplace_filename(name: str) -> bool:
     """Whether *name* is a Codex catalog by name alone.
 
-    A bare ``endswith`` also claims ``notamarketplace.json``, which then
-    skips the duck-typing fallback and gets linted as a catalog on the
-    strength of its spelling. ``openai/plugins`` splits its listing into
-    ``api_marketplace.json``, so the qualifier is a real pattern — it just
-    has to end at a separator.
+    Qualified names (``openai/plugins`` ships ``api_marketplace.json``) must
+    end at a separator — a bare ``endswith`` would also claim
+    ``notamarketplace.json`` and lint it as a catalog on spelling alone.
     """
     lowered = name.lower()
     if lowered == "marketplace.json":
@@ -176,8 +159,8 @@ def _is_marketplace_filename(name: str) -> bool:
 def _looks_like_codex_catalog(data: Any) -> bool:
     """Positive catalog evidence: a ``plugins`` list with a sourced entry.
 
-    The key shape alone also matches a version-pin sibling like
-    ``plugin-versions.json`` ({name, version} entries, no sources) — a file
+    The key shape alone also matches version-pin siblings like
+    ``plugin-versions.json`` ({name, version} entries, no sources), which
     Codex never reads. One predicate shared by discovery and
     ``codex_catalog_exists`` so the Claude stand-down can never trigger on
     a sibling discovery itself refuses to lint.
@@ -192,9 +175,8 @@ def _looks_like_codex_catalog(data: Any) -> bool:
 def _read_json_or_none(path: Path) -> Any:
     """Parsed JSON at *path*, or ``None`` when absent or unparseable.
 
-    Goes through the shared cached reader so a UTF-8 BOM is stripped and
-    repeated reads of the same manifest cost nothing — discovery, the
-    validity rule, and the registration rule all read these files.
+    Uses the shared cached reader: strips a UTF-8 BOM, and repeated reads
+    of the same manifest cost nothing.
     """
     data, error = read_json(path)
     return None if error else data
@@ -205,22 +187,21 @@ class PluginProvenance:
     """Who claims a plugin directory, decided once and read everywhere.
 
     The single source of truth for every ecosystem-provenance question:
-    which ecosystems declared the directory (``claude``, ``codex``), on
-    what evidence, and whether it is vendor-installed content. Rules and
-    the lint tree consult this record — never a fresh filesystem probe —
-    so two call sites cannot disagree about ownership, and a directory
-    can never fall between per-ecosystem attach paths.
+    which ecosystems declared the directory (``claude``, ``codex``), and
+    whether it is vendor-installed content. Rules and the lint tree consult
+    this record — never a fresh filesystem probe — so two call sites cannot
+    disagree about ownership and a directory can never fall between
+    per-ecosystem attach paths.
 
     Evidence is filesystem-first (markers, contained manifests, catalog
-    listings), deliberately independent of ``--type`` overrides: an
-    override changes what discovery walks, not what the author declared.
+    listings) and independent of ``--type`` overrides: an override changes
+    what discovery walks, not what the author declared.
 
     Adding an ecosystem means adding its evidence probe to
-    ``RepositoryContext.provenance`` — the declarative format gates
-    (``Rule.provenance_scope`` via ``in_format_scope``) read
-    ``ecosystems`` and need no per-rule visits. See the "Ecosystem
-    provenance" section of the development rules
-    (.apm/instructions/development.instructions.md).
+    ``RepositoryContext.provenance``; the declarative format gates
+    (``Rule.provenance_scope`` via ``in_format_scope``) read ``ecosystems``
+    and need no per-rule visits. See "Ecosystem provenance" in the
+    development rules.
     """
 
     ecosystems: FrozenSet[str]
@@ -305,20 +286,16 @@ class RepositoryContext:
         self._codex_roots: Optional[List[Path]] = None
         self._codex_claims: Optional[Set[Path]] = None
         self._provenance_cache: Dict[Path, PluginProvenance] = {}
-        # An explicit --type override is a statement about what the caller
-        # wants linted, not just which rules fire. Probing for Codex anyway
-        # would attach its manifests, hooks, MCP files and skills to the
-        # tree, where the generic rules would lint content the override was
-        # meant to exclude. Detection, by contrast, has to probe first —
-        # the Codex types are derived from what discovery finds.
+        # An explicit --type override states what the caller wants linted:
+        # probing for Codex anyway would attach manifests, hooks, MCP files
+        # and skills the override was meant to exclude.
         self._codex_discovery_enabled = (
             bool(_CODEX_TYPES & set(repo_types)) if repo_types is not None else True
         )
-        # An explicit type is also the caller's statement that the format
-        # *is* Codex, so the entrypoint is seeded even when the marker file
-        # is missing. Otherwise ``--type codex-plugin`` on a repository
+        # A forced Codex type seeds the entrypoint even when the marker file
+        # is missing — otherwise ``--type codex-plugin`` on a repository
         # without ``.codex-plugin/`` would discover no plugin, create no
-        # node, and report nothing — the requested check would never run.
+        # node, and never run the requested check.
         self._codex_plugin_forced = repo_types is not None and (
             RepositoryType.CODEX_PLUGIN in repo_types
         )
@@ -342,10 +319,7 @@ class RepositoryContext:
         self.instruction_files: List[Path] = self._discover_instruction_files()
         self.detected_formats: Set[str] = set()
         # Plugin-contributed extension state, registered by the Linter after
-        # plugin loading (see Linter._register_plugin_extensions):
-        # detected custom repository type names, lint tree contributors as
-        # (plugin name, callable) pairs, and errors raised by contributors
-        # during tree construction (surfaced as violations by the Linter).
+        # plugin loading (see Linter._register_plugin_extensions).
         self.plugin_repo_types: Set[str] = set()
         # Content globs contributed by detected plugin repo types. Kept
         # separate from ``content_paths`` (user config), which the Linter
@@ -358,10 +332,9 @@ class RepositoryContext:
         # shared context (e.g. two Linters over one context) are no-ops.
         self._plugin_extensions_registered = False
         self._lint_tree: Optional["LintTarget"] = None
-        # Filters discovery results and computes detected_formats — excludes
-        # must be applied before format detection so excluded files (e.g.
-        # *.instructions.md under an excluded directory) don't flip format
-        # flags like HAS_COPILOT.
+        # Excludes must be applied before format detection so excluded files
+        # (e.g. *.instructions.md under an excluded directory) don't flip
+        # format flags like HAS_COPILOT.
         self.apply_excludes()
 
     @property
@@ -435,12 +408,9 @@ class RepositoryContext:
     def apply_excludes(self) -> None:
         """Filter discovery results by exclude_patterns and refresh derived state.
 
-        Filters plugins, skills, and instruction_files, then recomputes
-        ``detected_formats`` and drops any cached lint tree so state derived
-        from the (now filtered) lists cannot go stale. Called by the
-        constructor; legacy callers that mutate ``exclude_patterns`` after
-        construction must call it again. Filtering only narrows — previously
-        excluded paths are not rediscovered.
+        Called by the constructor; callers that mutate ``exclude_patterns``
+        after construction must call it again. Filtering only narrows —
+        previously excluded paths are not rediscovered.
         """
         if self.exclude_patterns:
             codex_before = list(self.codex_plugins)
@@ -455,10 +425,9 @@ class RepositoryContext:
             codex_paths_changed = self.codex_plugins != codex_before
             codex_catalog_changed = any(self.is_path_excluded(path) for path in marketplaces_before)
             codex_set_changed = codex_paths_changed or codex_catalog_changed
-            # Most excludes do not affect Codex discovery, so avoid probing
-            # every plugin directory again. A newly excluded catalog is the
-            # exception: it may be the only source for a plugin whose own path
-            # does not match the exclusion.
+            # Re-probe only when needed: a newly excluded catalog may be the
+            # only source for a plugin whose own path does not match the
+            # exclusion.
             if codex_catalog_changed:
                 self._codex_marketplace_paths = None
             if self._codex_discovery_enabled and codex_set_changed:
@@ -469,14 +438,11 @@ class RepositoryContext:
             roots_after = {r for r in (safe_resolve(p) for p in self.codex_plugins) if r}
             dropped = roots_before - roots_after
             if dropped:
-                # Skills were discovered from the old plugin set. A skill
-                # under a plugin that just left it would otherwise stay in
-                # ``skills`` and be attached as a standalone node, so the
-                # generic skill and content rules would keep linting exactly
-                # the vendor content the exclusion removed.
-                # A dual-host plugin may leave the Codex set while remaining
-                # an active Claude plugin. Its skills still have a surviving
-                # owner and must not be pruned with Codex-only content.
+                # Prune skills owned by plugins that just left the Codex set;
+                # otherwise they attach as standalone nodes and keep linting
+                # the very content the exclusion removed. Skills of a
+                # dual-host plugin that remains an active Claude plugin still
+                # have a surviving owner and must not be pruned.
                 claude_roots = {r for r in (safe_resolve(p) for p in self.plugins) if r}
                 self.skills = [
                     sk
@@ -647,10 +613,8 @@ class RepositoryContext:
 
         A bare ``plugins/`` directory has always inferred MARKETPLACE. A
         Codex catalog explains the children it claims, so only a child it
-        does not claim (or a dual-marker child, which still needs the
-        Claude marketplace that would publish it) keeps that inference.
-        A repository with no Codex evidence keeps its historical type
-        exactly.
+        does not claim (or a dual-marker child) keeps that inference. A
+        repository with no Codex evidence keeps its historical type exactly.
         """
         plugins_dir = self.root_path / "plugins"
         if not safe_is_dir(plugins_dir):
@@ -664,8 +628,8 @@ class RepositoryContext:
         except OSError:
             return False
         if not children:
-            # Empty keeps its historical meaning unless a Codex catalog is
-            # the reason the directory exists at all.
+            # An empty plugins/ keeps its historical meaning unless a Codex
+            # catalog is the reason the directory exists at all.
             return not self.codex_catalog_exists()
         return any(not self.is_codex_only_plugin(item) for item in children)
 
@@ -742,8 +706,7 @@ class RepositoryContext:
     # would report contradictory violations.
     CODEX_MARKETPLACE_DIR = (".agents", "plugins")
     CODEX_MARKETPLACE_FILENAME = "marketplace.json"
-    # The definition lives in formats.codex with the manifest readers;
-    # this alias gives context-holding callers one import site.
+    # Alias for the formats.codex definition, one import site for callers.
     CODEX_PLUGIN_MANIFEST = _CODEX_PLUGIN_MANIFEST
     # Where Codex installs plugins a developer added to their own checkout,
     # as opposed to plugins the repository authors.
@@ -762,9 +725,7 @@ class RepositoryContext:
         return bool(self._discover_codex_marketplaces())
 
     def _discover_codex_marketplaces(self) -> List[Path]:
-        """Codex marketplace manifests in ``.agents/plugins/``, for discovery.
-
-        The discovery-side view of the one catalog enumerator: honors the
+        """Discovery-side view of the one catalog enumerator: honors the
         ``--type`` gate, caches per context, and seeds the primary
         entrypoint when the type was forced.
         """
@@ -774,36 +735,29 @@ class RepositoryContext:
         """Codex catalog files present in the checkout, asked of the
         filesystem.
 
-        Deliberately independent of ``_codex_discovery_enabled``: the
+        Independent of ``_codex_discovery_enabled`` by design: the
         provenance claim set and ``codex_catalog_exists()`` read author
         *declarations*, which a ``--type`` override does not change —
         reading them from discovery would make ``--type marketplace``
-        restore the false positives the stand-downs exist to remove. The
-        lint tree's node discovery uses ``_discover_codex_marketplaces()``,
-        which honors the override.
+        restore the false positives the stand-downs exist to remove.
         """
         return self._enumerate_codex_catalogs(honor_discovery_gate=False)
 
     def _enumerate_codex_catalogs(self, *, honor_discovery_gate: bool) -> List[Path]:
         """The one enumeration of Codex catalog files, parameterized by gating.
 
-        ``marketplace.json`` is the documented path and is always taken on
-        existence alone, so broken JSON still reaches the rules. A sibling
-        *named* like a catalog — openai/plugins ships a second one as
-        ``api_marketplace.json`` — is taken on existence for the same
-        reason: dropping it because its JSON is broken, or because
-        ``plugins`` is not an array, hides exactly the defect
-        codex-marketplace-json-valid exists to report. Any other ``*.json``
-        still has to duck-type as a marketplace, because the directory is
-        not reserved and unrelated JSON must not be linted as a catalog.
-        Every catalog counts, not just the primary — a repository whose
-        only catalog is a sibling is no less a Codex marketplace.
+        ``marketplace.json`` and marketplace-named siblings (openai/plugins
+        ships ``api_marketplace.json``) are taken on existence alone, so
+        broken JSON still reaches codex-marketplace-json-valid instead of
+        hiding the very defect it reports. Any other ``*.json`` must
+        duck-type as a marketplace — the directory is not reserved, and
+        unrelated JSON must not be linted as a catalog. Every catalog
+        counts, not just the primary.
 
         With ``honor_discovery_gate`` the result is the *discovery* answer:
-        gated on the ``--type`` override, cached in
-        ``_codex_marketplace_paths``, and seeded with the primary
-        entrypoint when the marketplace type was forced. Without it the
-        result is the *declaration* answer the provenance path needs —
+        gated on the ``--type`` override, cached, and seeded with the
+        primary entrypoint when the marketplace type was forced. Without it
+        the result is the *declaration* answer the provenance path needs —
         filesystem-first and ``--type``-invariant, never cached through the
         discovery slot.
         """
@@ -821,28 +775,24 @@ class RepositoryContext:
             root = resolved_root
 
         def _inside(path: Path) -> bool:
-            # A catalog that resolves outside the checkout is not this
+            # A catalog resolving outside the checkout is not this
             # repository's to read — and codex-marketplace-registration
-            # writes the catalog back when it registers a plugin, so
-            # following a symlink out would overwrite an external file.
+            # writes the catalog back, so following a symlink out would
+            # overwrite an external file.
             return contained_resolve(path, root) is not None
 
         def _keep(path: Path) -> bool:
-            # Exclusions are applied here rather than at each reader: the
-            # lint tree filters them, but ``skillsaw docs`` reads this list
-            # directly, so an excluded catalog would otherwise still supply
-            # published pages and the generated title.
+            # Exclusions applied here, not at each reader: ``skillsaw docs``
+            # reads this list directly, so an excluded catalog would
+            # otherwise still supply published pages and the generated title.
             return _inside(path) and not self.is_path_excluded(path)
 
         found: List[Path] = []
         primary = self.codex_marketplace_path()
-        # Existence, not is_file(): a directory in place of the reserved
-        # entrypoint is unusable, and it has to stay discovered for
-        # codex-marketplace-json-valid to say so.
-        # ``is_symlink()`` as well as ``exists()``: a dangling in-repository
-        # symlink is an unusable catalog, and dropping it would declassify
-        # the repository rather than let the rule report it — the same
-        # reasoning plugin discovery applies to a missing manifest.
+        # Existence or a (possibly dangling) symlink, not is_file(): a
+        # directory or dangling link at the reserved entrypoint is an
+        # unusable catalog, and dropping it would declassify the repository
+        # instead of letting codex-marketplace-json-valid report it.
         if (safe_exists(primary) or safe_is_symlink(primary)) and _keep(primary):
             found.append(primary)
 
@@ -854,10 +804,9 @@ class RepositoryContext:
             except OSError:
                 siblings = []
             for candidate in siblings:
-                # Resolved comparison, not ``candidate == primary``: on a
-                # case-insensitive filesystem ``MARKETPLACE.JSON`` is the
-                # primary under a different spelling, and a path-equality
-                # test would list the same file twice.
+                # Resolved comparison: on a case-insensitive filesystem
+                # ``MARKETPLACE.JSON`` is the primary under a different
+                # spelling, and path equality would list the file twice.
                 candidate_resolved = safe_resolve(candidate)
                 if candidate_resolved is not None and candidate_resolved == primary_resolved:
                     continue
@@ -871,13 +820,10 @@ class RepositoryContext:
 
         if honor_discovery_gate:
             if not found and self._codex_marketplace_forced and _keep(primary):
-                # ``_keep``, not a bare exclusion check: it also enforces
-                # containment. The registration rule writes this file back
-                # when it registers a plugin, so seeding an unchecked path
-                # would let ``fix --suggest`` rewrite a file outside the
-                # checkout through a symlinked catalog. An explicit --type
-                # says what format the repository is, not that its
-                # entrypoint may be anywhere.
+                # ``_keep`` also enforces containment: the registration rule
+                # writes this file back, so seeding an unchecked path would
+                # let ``fix --suggest`` rewrite a file outside the checkout
+                # through a symlinked catalog.
                 found.append(primary)
             self._codex_marketplace_paths = found
         return found
@@ -889,10 +835,8 @@ class RepositoryContext:
     def codex_plugin_roots(self) -> List[Path]:
         """Resolved Codex plugin roots, computed once per context.
 
-        ``codex_plugin_owning`` runs per skill inside agentskill-evals and
-        agentskill-rename-refs, so resolving every root on each call costs
-        roughly ``2 x skills x plugins`` filesystem round-trips on a large
-        catalog.
+        ``codex_plugin_owning`` runs per skill, so resolving every root on
+        each call would cost ~``skills x plugins`` filesystem round-trips.
         """
         if self._codex_roots is None:
             self._codex_roots = [
@@ -903,9 +847,9 @@ class RepositoryContext:
     def distinct_plugin_dirs(self) -> List[Path]:
         """Every discovered plugin directory, Claude and Codex, deduplicated.
 
-        A dual-ecosystem directory appears once. The scan statistics count
-        this rather than ``self.plugins``, which holds only Claude-style
-        directories and reports zero for a manifest-only Codex catalog.
+        The scan statistics count this rather than ``self.plugins``, which
+        holds only Claude-style directories and reports zero for a
+        manifest-only Codex catalog.
         """
         return merge_plugin_dirs(self.plugins, self.codex_plugins)
 
@@ -916,19 +860,16 @@ class RepositoryContext:
     def _discover_codex_plugins(self) -> List[Path]:
         """Discover directories holding a ``.codex-plugin/plugin.json`` manifest.
 
-        Probes the documented layouts rather than walking the repository:
-        the repo root (single-plugin repos), ``plugins/*`` (the layout the
-        Codex docs prescribe for repo marketplaces), ``.codex/plugins/*``
-        (the documented personal-install pattern), and every local source
-        declared by the Codex marketplace. Explicit probes keep discovery
-        O(entries) instead of adding a second whole-repo walk.
+        Probes the documented layouts rather than walking the repository —
+        the repo root, ``plugins/*``, ``.codex/plugins/*``, and every local
+        source declared by the Codex marketplace — keeping discovery
+        O(entries) instead of a second whole-repo walk.
 
         The reserved ``.codex-plugin/`` directory is the evidence, not the
-        manifest inside it. A directory whose ``plugin.json`` was deleted,
-        misspelled, or replaced by a directory is still a Codex plugin with
-        a broken entrypoint; dropping it here would take the repository's
-        ``CODEX_PLUGIN`` type with it and leave the defect unreported.
-        ``codex-plugin-json-valid`` reports the missing manifest.
+        manifest inside it: a directory whose ``plugin.json`` is missing or
+        broken is still a Codex plugin, and dropping it here would take the
+        ``CODEX_PLUGIN`` type with it and leave the defect unreported
+        (``codex-plugin-json-valid`` reports the missing manifest).
         """
         found: List[Path] = []
         seen: Set[Path] = set()
@@ -942,30 +883,23 @@ class RepositoryContext:
             return resolved if resolved == root or resolved.is_relative_to(root) else None
 
         def _add(directory: Path) -> None:
-            # Both halves are checked, because either can be the symlink.
-            # ``plugins/foo`` pointing out of the repository is the obvious
-            # one; ``plugins/foo/.codex-plugin`` pointing out while ``foo``
-            # itself is a real directory is the subtler one, and ``is_dir()``
-            # follows it just the same. Either way skillsaw would read an
-            # out-of-tree manifest — and codex-plugin-structure would list
-            # the external directory's filenames under an in-repo path.
+            # Either half can be the symlink out of the repository:
+            # ``plugins/foo`` itself, or ``plugins/foo/.codex-plugin`` under
+            # a real directory. Both would make skillsaw read an out-of-tree
+            # manifest, so both are containment-checked.
             resolved = _contained(directory)
             if resolved is None or resolved in seen:
                 return
-            # Contained within *this plugin*, not merely within the
+            # The marker must resolve within *this plugin*, not merely the
             # repository: `plugins/a/.codex-plugin -> plugins/b/.codex-plugin`
-            # stays in the checkout, so a repo-wide check accepts it and
-            # plugin A is then discovered and documented using B's manifest.
+            # stays in the checkout, and a repo-wide check would let plugin A
+            # be discovered and documented using B's manifest.
             #
-            # ``is_dir()`` is the wrong question for the first half: it is
-            # false for a regular file named ``.codex-plugin`` and for a
-            # dangling symlink, and both of those occupy the reserved name
-            # just as surely as a directory does. Discarding them silently
-            # un-types the repository, so a plugin whose manifest directory
-            # was clobbered reports nothing at all. Existence — or a symlink
-            # entry, which ``exists()`` denies when it dangles — keeps the
-            # plugin; codex-plugin-json-valid then reports the unreadable
-            # manifest.
+            # Existence-or-symlink, not ``is_dir()``: a regular file or
+            # dangling symlink occupies the reserved name just as surely as
+            # a directory, and discarding it would silently un-type the
+            # repository; keeping it lets codex-plugin-json-valid report the
+            # unreadable manifest.
             manifest_dir = directory / self.CODEX_PLUGIN_MANIFEST[0]
             if not (safe_exists(manifest_dir) or safe_is_symlink(manifest_dir)):
                 return
@@ -1002,11 +936,10 @@ class RepositoryContext:
             _add(source)
 
         if not found and self._codex_plugin_forced:
-            # Only when the root has no marker at all. Discovery rejects a
-            # ``.codex-plugin`` that resolves outside the checkout, and
-            # seeding the root unconditionally would hand that rejected
-            # marker straight back, and every rule would then read the
-            # external manifest the containment gate exists to refuse.
+            # Seed only when the root has no marker at all: discovery
+            # rejects a ``.codex-plugin`` that resolves outside the
+            # checkout, and unconditional seeding would hand that rejected
+            # marker straight back past the containment gate.
             marker = self.root_path / self.CODEX_PLUGIN_MANIFEST[0]
             if not (safe_exists(marker) or safe_is_symlink(marker)) and _contained(self.root_path):
                 found.append(self.root_path)
@@ -1023,8 +956,7 @@ class RepositoryContext:
         """
         resolved: List[Path] = []
         # Filesystem-enumerated, not discovery-gated: these feed the
-        # provenance claim set, which must answer identically under any
-        # ``--type`` override.
+        # provenance claim set, which must be ``--type``-invariant.
         for marketplace_file in self._codex_catalog_files():
             data = _read_json_or_none(marketplace_file)
             if not isinstance(data, dict):
@@ -1049,9 +981,8 @@ class RepositoryContext:
         """Every resolved directory Codex claims, computed once per context.
 
         The union of discovered plugin roots and the catalogs' local
-        sources. Provenance checks consult this once per ``plugins/``
-        child, and rebuilding the claim list on each call would make
-        repository detection quadratic in the catalog size.
+        sources. Rebuilding it on each call would make repository detection
+        quadratic in the catalog size.
         """
         if self._codex_claims is None:
             claims = {r for r in (safe_resolve(p) for p in self.codex_plugins) if r is not None}
@@ -1109,13 +1040,10 @@ class RepositoryContext:
     def is_codex_only_plugin(self, plugin_dir: Path) -> bool:
         """Codex-claimed with no ``.claude-plugin`` marker.
 
-        The provenance line the Claude-format rules gate on: a
-        ``.claude-plugin`` marker or a ``.claude-plugin/marketplace.json``
-        listing is the author declaring Claude, so such a directory keeps
-        every Claude check. A Codex-only one is exempt from Claude
-        manifest, frontmatter, and naming requirements — the
-        ecosystem-neutral content and security rules still read its prose
-        either way.
+        The provenance line the Claude-format rules gate on: a Codex-only
+        directory is exempt from Claude manifest, frontmatter, and naming
+        requirements, while the ecosystem-neutral content and security
+        rules still read its prose either way.
         """
         return self.provenance(plugin_dir).codex_only
 
@@ -1124,13 +1052,11 @@ class RepositoryContext:
 
         The one gate behind ``Rule.provenance_scope``, read through
         ``Rule.scoped_find``: a node whose ``provenance_dir()`` is claimed
-        exclusively by other ecosystems is out of scope, so a Codex-only
-        plugin is exempt from Claude manifest, frontmatter, and naming
-        requirements. Unclaimed content (no ecosystem declared it) stays
-        in every scope, and a dual-manifest directory stays in scope for
-        each of its ecosystems — dual plugins keep their established
-        Claude results. Ownership itself comes from :meth:`provenance`,
-        per the doctrine: no fresh filesystem probes here.
+        exclusively by other ecosystems is out of scope. Unclaimed content
+        stays in every scope, and a dual-manifest directory stays in scope
+        for each of its ecosystems — dual plugins keep their established
+        Claude results. Ownership comes from :meth:`provenance`; no fresh
+        filesystem probes here.
         """
         owner_dir = node.provenance_dir()
         if owner_dir is None:
@@ -1141,12 +1067,10 @@ class RepositoryContext:
     def in_codex_only_plugin(self, path: Path) -> bool:
         """Whether *path* sits inside a Codex-ONLY plugin, nearest owner first.
 
-        The conditional-strictness gate shared by the ecosystem-tightened
+        The conditional-strictness gate for the ecosystem-tightened
         hooks/MCP shape checks: they apply only where the owning Codex
         plugin is Codex-exclusive, so a dual-manifest plugin keeps its
-        established Claude results — ``since`` gates rules rather than
-        checks, and a new hard error inside an old rule would break
-        previously green dual repositories.
+        established Claude results.
         """
         owner = self.codex_plugin_owning(path)
         return owner is not None and self.provenance(owner).codex_only
@@ -1161,9 +1085,8 @@ class RepositoryContext:
         resolved = safe_resolve(path)
         if resolved is None:
             return None
-        # Ancestor walk against a set — this runs per skill inside
-        # agentskill-evals and agentskill-rename-refs, where a scan over
-        # every root is O(skills x plugins) on a large catalog. Walking
+        # Ancestor walk against a set: runs per skill, where scanning every
+        # root would be O(skills x plugins) on a large catalog. Walking
         # upward finds the nearest root by construction.
         roots = set(self.codex_plugin_roots())
         for candidate in (resolved, *resolved.parents):
@@ -1174,10 +1097,10 @@ class RepositoryContext:
     def _codex_claim_boundary(self, parent: Path) -> Optional[Path]:
         """Resolved root of the Codex-only plugin owning *parent*, if any.
 
-        A lexical ancestor walk, nearest first, deliberately *not*
-        resolution-based like ``codex_plugin_owning`` — resolving first
-        would follow the very symlinks the boundary exists to reject.
-        Ownership itself comes from :meth:`provenance`, per the doctrine.
+        A lexical ancestor walk, nearest first — NOT resolution-based like
+        ``codex_plugin_owning``, because resolving first would follow the
+        very symlinks the boundary exists to reject. Ownership comes from
+        :meth:`provenance`.
         """
         for candidate in (parent, *parent.parents):
             if self.provenance(candidate).codex_only:
@@ -1195,20 +1118,19 @@ class RepositoryContext:
         business listing it, so registration checks must skip it.
         """
         if self._codex_install_root is _UNSET:
-            # Resolved once. This runs per SkillNode inside agentskill-name,
-            # so re-resolving it per call is a filesystem round-trip for
-            # every skill in the repository.
+            # Resolved once — this runs per SkillNode, so re-resolving per
+            # call costs a filesystem round-trip for every skill.
             self._codex_install_root = safe_resolve(
                 self.root_path.joinpath(*self.CODEX_INSTALL_DIR)
             )
         install_root = self._codex_install_root
         if install_root is None:
             return False
-        # Lexical first: ``.codex/plugins/foo`` symlinked to a plugin
-        # elsewhere in the checkout resolves *out* of the install root, so a
-        # resolved-only test would call it authored, then publish it and
-        # let autofixes rewrite it. How it was reached is what makes it an
-        # install, not where the bytes happen to live.
+        # Lexical first: ``.codex/plugins/foo`` symlinked elsewhere in the
+        # checkout resolves *out* of the install root, and a resolved-only
+        # test would call it authored, publish it, and let autofixes rewrite
+        # it. How it was reached makes it an install, not where the bytes
+        # live.
         lexical = self.root_path.joinpath(*self.CODEX_INSTALL_DIR)
         try:
             if plugin_dir != lexical and plugin_dir.is_relative_to(lexical):
@@ -1274,15 +1196,12 @@ class RepositoryContext:
             candidate = (self.root_path / source).resolve()
             plugin_root = self.marketplace_plugin_root()
             if plugin_root and not Path(source).is_absolute():
-                # metadata.pluginRoot is prepended to relative sources (both
-                # bare names and ./-prefixed paths). Real-world marketplaces
-                # (e.g. jeremylongshore/claude-code-plugins-plus-skills) set
-                # pluginRoot while their sources already include that prefix,
-                # so prefer the spec composition but fall back to the
-                # root-relative path when only the latter exists. The
-                # containment check below still rejects any candidate that
-                # escapes the repository, so a traversing pluginRoot cannot
-                # smuggle a source outside the root.
+                # metadata.pluginRoot is prepended to relative sources, but
+                # real-world marketplaces set pluginRoot while their sources
+                # already include that prefix — prefer the spec composition,
+                # fall back to the root-relative path when only it exists.
+                # The containment check below still rejects any candidate
+                # that escapes the repository.
                 composed = (self.root_path / plugin_root / source).resolve()
                 if safe_exists(composed) or not safe_exists(candidate):
                     candidate = composed
@@ -1396,12 +1315,10 @@ class RepositoryContext:
             or RepositoryType.CODEX_MARKETPLACE in self.repo_types
             or RepositoryType.CODEX_PLUGIN in self.repo_types
         ):
-            # Codex types too: a Codex-only catalog carries no
-            # MARKETPLACE type, and a Codex-claimed directory that ships
+            # Codex types too: a Codex-claimed directory that ships
             # commands/ needs its PluginNode so every content and security
             # rule reads its prose — Claude-format rules exempt Codex-only
             # directories themselves.
-            # Discover from plugins/ directory (backward compatibility)
             self._discover_from_plugins_dir(plugins, discovered_paths)
 
             # Discover from marketplace.json plugin entries
@@ -1419,11 +1336,10 @@ class RepositoryContext:
             if not item.is_dir() or item.name.startswith("."):
                 continue
 
-            # Marker semantics, Codex-claimed or not: a Codex plugin
-            # that ships commands/ gets a PluginNode so its prose reaches
-            # every content and security rule (secret scanning included) —
-            # the Claude-format rules exempt Codex-only directories
-            # themselves, via is_codex_only_plugin().
+            # Codex-claimed or not: a Codex plugin that ships commands/
+            # gets a PluginNode so its prose reaches every content and
+            # security rule; Claude-format rules exempt Codex-only
+            # directories themselves.
             if not ((item / ".claude-plugin").exists() or (item / "commands").exists()):
                 continue
 
@@ -1489,9 +1405,8 @@ class RepositoryContext:
         """
         resolved_path = plugin_path.resolve()
 
-        # Try plugin.json. Non-string names (invalid, flagged by validation
-        # rules) fall through to the directory-name fallback rather than
-        # propagating a TypeError into rules that expect a string.
+        # Non-string names (flagged by validation rules) fall through to
+        # the directory-name fallback rather than propagating a TypeError.
         plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
         if plugin_json.exists():
             try:
@@ -1606,10 +1521,9 @@ class RepositoryContext:
                     continue
                 self._discover_skills_in_dir(skills_path, skills, discovered)
 
-        # For plugin repos, also discover embedded skills. Codex plugins are
+        # For plugin repos, also discover embedded skills. Codex plugins
         # included: an installed plugin under .codex/plugins/ lives in a
-        # hidden directory the repository-wide scan never walks, so its
-        # skills would otherwise never enter the lint tree.
+        # hidden directory the repository-wide scan never walks.
         for plugin_path in self.plugins:
             skills_dir = plugin_path / "skills"
             if skills_dir.is_dir():
@@ -1619,9 +1533,8 @@ class RepositoryContext:
             plugin_root = safe_resolve(plugin_path)
             if plugin_root is None:
                 continue
-            # ``skills/`` is only the default. A manifest may point the field
-            # somewhere else entirely, and for a hidden install that path is
-            # the sole route into the tree.
+            # ``skills/`` is only the default — a manifest may point the
+            # field somewhere else entirely.
             for skills_dir in (
                 plugin_path / "skills",
                 *codex_declared_skill_dirs(plugin_path),
@@ -1630,7 +1543,7 @@ class RepositoryContext:
                     continue
                 if (skills_dir / "SKILL.md").exists():
                     # A manifest may name one skill directly rather than a
-                    # collection; descending would step straight past it.
+                    # collection — descending would step straight past it.
                     resolved = contained_resolve(skills_dir, plugin_root)
                     if resolved is None:
                         continue
@@ -1656,26 +1569,23 @@ class RepositoryContext:
     ) -> None:
         """Discover skill directories within a parent directory, recursively.
 
-        *contain_within* rejects children that resolve outside it. Passed
-        for Codex plugins, where ``skills/external`` can be a symlink out
-        of the repository and the SKILL.md behind it would otherwise be
-        read as if the plugin shipped it. ``None`` means no caller-imposed
-        boundary — the walk still derives one from provenance below, so
-        every route into a Codex-only directory (the AGENTSKILLS root
-        walk, the legacy plugin loop, a claimed repository root) honors
-        the same containment without each call site knowing to ask.
+        *contain_within* rejects children that resolve outside it — for
+        Codex plugins, ``skills/external`` can be a symlink out of the
+        repository, and the SKILL.md behind it would otherwise be read as
+        if the plugin shipped it. ``None`` means no caller-imposed boundary;
+        the walk still derives one from provenance below, so every route
+        into a Codex-only directory honors the same containment.
         """
         # ``discovered`` only records directories that held a SKILL.md, so
         # it cannot stop a cycle: ``skills/a/loop -> ../..`` stays inside
-        # the plugin, passes containment, and recurses until Python raises
-        # RecursionError during context construction. ``visited`` records
-        # every directory descended into, whether or not it held a skill.
+        # the plugin, passes containment, and recurses to RecursionError.
+        # ``visited`` records every directory descended into.
         if visited is None:
             visited = set()
             if contain_within is None:
-                # Top-level call: the scan may *start* inside a claimed
-                # directory (``plugin/skills``), where the descent check
-                # below never sees the claimed ancestor.
+                # The scan may *start* inside a claimed directory
+                # (``plugin/skills``), where the descent check below never
+                # sees the claimed ancestor.
                 contain_within = self._codex_claim_boundary(parent)
         try:
             for item in parent.iterdir():
@@ -1688,8 +1598,8 @@ class RepositoryContext:
                     continue
                 entrypoint = safe_resolve(item / "SKILL.md")
                 if entrypoint is not None and (item / "SKILL.md").exists():
-                    # The directory being contained is not enough: SKILL.md
-                    # can itself be a symlink out, and the tree follows it.
+                    # A contained directory is not enough: SKILL.md can
+                    # itself be a symlink out, and the tree follows it.
                     if contain_within is not None and not entrypoint.is_relative_to(contain_within):
                         continue
                     skills.append(item)
@@ -1698,9 +1608,8 @@ class RepositoryContext:
                     visited.add(resolved)
                     child_bound = contain_within
                     if child_bound is None and self.provenance(item).codex_only:
-                        # An unbounded walk is entering a Codex-only
-                        # directory: from here down, everything must
-                        # resolve inside it.
+                        # Entering a Codex-only directory: from here down,
+                        # everything must resolve inside it.
                         child_bound = resolved
                     self._discover_skills_in_dir(item, skills, discovered, child_bound, visited)
         except OSError:

--- a/src/skillsaw/docs/extractor.py
+++ b/src/skillsaw/docs/extractor.py
@@ -45,10 +45,9 @@ def extract_docs(
     title: Optional[str] = None,
 ) -> DocsOutput:
     """Extract documentation from a repository context."""
-    # A PluginNode with no Claude manifest but a Codex one is a Codex plugin
-    # that legacy discovery picked up for its commands/ or skills/ directory.
-    # _extract_codex_plugins handles it, and reading it through the Claude
-    # extractor as well would list it twice with empty metadata.
+    # A PluginNode with a Codex manifest but no Claude one belongs to
+    # _extract_codex_plugins; reading it through the Claude extractor as
+    # well would list it twice with empty metadata.
     codex_roots = _codex_roots(context)
     claude_plugins = [
         _extract_plugin(context, pn)
@@ -61,34 +60,29 @@ def extract_docs(
     marketplace = None
     if RepositoryType.MARKETPLACE in context.repo_types and context.marketplace_data:
         md = context.marketplace_data
-        # A mixed repository has two independent catalogs. Claude plugin
-        # docs remain governed by the Claude marketplace, while Codex-only
-        # docs must be filtered and enriched through the Codex catalog just
-        # as they are when no Claude marketplace is present. Otherwise an
+        # A mixed repository has two independent catalogs: Claude docs are
+        # governed by the Claude marketplace, Codex-only docs are filtered
+        # and enriched through the Codex catalog — otherwise an
         # unregistered Codex directory appears merely because discovery
-        # found it.
+        # found it. Remote-only Codex entries have no lint-tree node and
+        # must be added from the catalog.
         listed = claude_plugins + _codex_listed_docs(context, codex_plugins)
-        # Codex remote-only entries have no lint-tree node, so they are not
-        # in ``plugins`` and would be dropped entirely when a Claude
-        # marketplace supplies the catalog identity.
         marketplace = MarketplaceDoc(
             name=md.get("name", ""),
             owner=md.get("owner"),
             plugins=listed + _codex_remote_docs(context, {name_str(p.name) for p in listed}),
         )
     elif RepositoryType.CODEX_MARKETPLACE in context.repo_types:
-        # ``marketplace_data`` only ever loads .claude-plugin/marketplace.json,
-        # so a Codex catalog needs its own MarketplaceDoc to reach the
-        # multi-page renderer.
+        # ``marketplace_data`` only ever loads the Claude marketplace, so a
+        # Codex catalog needs its own MarketplaceDoc.
         marketplace = _codex_marketplace_doc(context, plugins)
 
     standalone_skills: List[SkillDoc] = []
     if RepositoryType.AGENTSKILLS in context.repo_types:
         plugin_skill_paths = {s.dir_path.resolve() for p in plugins for s in p.skills}
-        # Skipping an installed plugin above leaves its skills matched by no
-        # PluginDoc, so the standalone pass would publish someone else's
-        # skills as this repository's own top-level content — undoing the
-        # authorship line the skip was there to draw.
+        # An installed plugin's skills match no PluginDoc, and the
+        # standalone pass would publish someone else's skills as this
+        # repository's own top-level content.
         installed_roots = [
             r
             for p in context.codex_plugins
@@ -137,17 +131,13 @@ def _codex_roots(context: RepositoryContext) -> Set[Path]:
 def _is_codex_only(context: RepositoryContext, plugin_path: Path, codex_roots: Set[Path]) -> bool:
     """Whether *plugin_path* is a Codex plugin with no Claude identity.
 
-    Keyed on what discovery actually accepted, not a raw ``is_file()``: that
-    follows a symlink out of the plugin, so a rejected manifest would still
-    mark the directory Codex-only — filtering out the legacy node with no
-    Codex node to replace it, and dropping the plugin from the docs.
+    Keyed on what discovery actually accepted, not a raw ``is_file()``:
+    that follows a symlink out of the plugin, so a rejected manifest would
+    still mark the directory Codex-only and drop the plugin from the docs.
     """
     resolved = safe_resolve(plugin_path)
     if resolved is None:
         return False
-    # Claude identity (marker or marketplace listing) is the shared
-    # predicate's question; the codex_roots membership keeps the
-    # docstring's discovery-accepted requirement.
     return resolved in codex_roots and context.is_codex_only_plugin(plugin_path)
 
 
@@ -179,15 +169,12 @@ def _codex_listed_docs(context: RepositoryContext, plugins: List[PluginDoc]) -> 
     """The extracted docs the catalog actually lists, in catalog order.
 
     Membership is what the catalog's ``plugins`` array says, not what
-    discovery happened to find. A repository that is also ``dot-claude``
-    has a ``PluginNode`` for ``.claude/`` itself, and publishing every
-    discovered plugin listed that directory as a catalog entry.
+    discovery happened to find — publishing every discovered plugin listed
+    ``.claude/`` itself as a catalog entry on dot-claude repositories.
 
-    A listing's ``category`` is overlaid onto the matched doc: the field is
-    required on a catalog entry and frequently lives only there, so reading
-    it from the plugin manifest alone left locally-sourced plugins
-    uncategorised and missing from the rendered category filter — while
-    remote entries, which have no manifest to consult, showed theirs.
+    A listing's ``category`` is overlaid onto the matched doc: the field
+    frequently lives only in the catalog, and reading the manifest alone
+    left locally-sourced plugins missing from the rendered category filter.
     """
     by_path = {r: p for p in plugins if (r := safe_resolve(p.path)) is not None}
     codex_roots = _codex_roots(context)
@@ -208,12 +195,10 @@ def _codex_listed_docs(context: RepositoryContext, plugins: List[PluginDoc]) -> 
                 continue  # remote or malformed — _codex_remote_docs decides
             resolved = safe_resolve(context.root_path / source)
             if resolved is None or resolved not in codex_roots:
-                # A listed directory without a usable Codex manifest — a
-                # Claude-only plugin, say. Codex cannot install it, and
-                # codex-marketplace-registration reports the unusable
-                # source; publishing it in the Codex index would advertise
-                # what the catalog cannot deliver. Dual-host plugins are
-                # Codex roots and stay listed.
+                # A listed directory without a usable Codex manifest: Codex
+                # cannot install it, and publishing it would advertise what
+                # the catalog cannot deliver. Dual-host plugins are Codex
+                # roots and stay listed.
                 continue
             doc = by_path.get(resolved)
             if doc is None or id(doc) in seen:
@@ -246,10 +231,8 @@ def _remote_entry_docs(data: dict, local_names: set) -> List[PluginDoc]:
     """Metadata-only docs for catalog entries with no local directory.
 
     A ``url``, ``git-subdir`` or ``npm`` source is not checked out here, so
-    no CodexPluginConfigNode exists for it and it would be missing from the
-    rendered catalog entirely — leaving the index reporting fewer plugins
-    than the catalog lists. What the entry itself declares is enough to
-    list it.
+    no CodexPluginConfigNode exists for it; what the entry itself declares
+    is enough to list it.
     """
     entries = data.get("plugins")
     if not isinstance(entries, list):
@@ -265,10 +248,9 @@ def _remote_entry_docs(data: dict, local_names: set) -> List[PluginDoc]:
         if codex_local_source_path(source) is not None:
             continue  # local entry — the real plugin was extracted above
         if not is_remote_source(source):
-            # ``{"source": "local"}`` with no path, or an empty one, is a
-            # broken local entry rather than a remote one. Codex skips it
-            # and codex-marketplace-json-valid reports it; publishing a page
-            # for it would advertise a plugin that cannot be installed.
+            # ``{"source": "local"}`` with no path is a broken local entry,
+            # not a remote one — publishing a page for it would advertise a
+            # plugin that cannot be installed.
             continue
         local_names.add(name)
         docs.append(
@@ -287,15 +269,13 @@ def _extract_codex_plugins(context: RepositoryContext) -> List[PluginDoc]:
     """Plugin docs for Codex plugins that carry no Claude manifest.
 
     A dual-ecosystem plugin already has a ``PluginNode`` and is documented
-    through it, so it is skipped here to avoid a duplicate entry. A
-    Codex-only plugin has nothing but its ``CodexPluginConfigNode``; this
-    extractor emits its plugin metadata, hooks, and MCP servers.
+    through it; skipping it here avoids a duplicate entry. A Codex-only
+    plugin has nothing but its ``CodexPluginConfigNode``.
     """
-    # A PluginNode alone does not mean a Claude plugin: legacy discovery
-    # creates one for any directory with commands/ or skills/. Only a real
-    # Claude manifest, or a marketplace entry claiming it, means the Claude
-    # extractor can read its metadata — otherwise the docs fall back to the
-    # directory name and lose everything the Codex manifest declares.
+    # A PluginNode alone does not mean a Claude plugin — legacy discovery
+    # creates one for any directory with commands/ or skills/, and reading
+    # such a directory through the Claude extractor would lose everything
+    # the Codex manifest declares.
     codex_roots = _codex_roots(context)
     claude_dirs = {
         pn.path.resolve()
@@ -304,17 +284,15 @@ def _extract_codex_plugins(context: RepositoryContext) -> List[PluginDoc]:
     }
     docs: List[PluginDoc] = []
     for node in context.lint_tree.find(CodexPluginConfigNode):
-        # The build tagged the manifest node with its owning plugin root
-        # when it attached the Codex cluster — the tree's ownership
-        # decision, read back rather than re-derived from the path.
+        # The tree's ownership decision, read back rather than re-derived
+        # from the path.
         plugin_resolved = node.plugin_owner
         if not node.path.is_file() or plugin_resolved is None or plugin_resolved in claude_dirs:
             continue
         if context.is_codex_installed_plugin(node.plugin_dir):
-            # A personal install under .codex/plugins/. Publishing it as a
-            # member of the repository's catalog would misattribute someone
-            # else's plugin — the same authorship line the registration and
-            # manifest-quality rules already draw.
+            # A personal install under .codex/plugins/ — publishing it in
+            # the repository's catalog would misattribute someone else's
+            # plugin.
             continue
         docs.append(_extract_codex_plugin(context, node, plugin_resolved))
     return docs
@@ -328,11 +306,10 @@ def _owned_blocks(
 ) -> list:
     """Blocks the tree assigned to this plugin, the manifest subtree first.
 
-    Prose attaches to the plugin's container and config to the manifest
-    node, and a repo-root plugin's conventional ``.mcp.json`` was claimed
-    by the generic root attach before the plugin pass ran — all of them
-    carry the ``plugin_owner`` tag the build recorded, so one owner scan
-    finds every placement. The manifest subtree is listed first (and
+    Prose attaches to the plugin's container, config to the manifest node,
+    and a repo-root plugin's conventional ``.mcp.json`` to the tree root —
+    all carry the ``plugin_owner`` tag the build recorded, so one owner
+    scan finds every placement. The manifest subtree is listed first (and
     deduplicated by identity) to keep the established document order.
     """
     blocks = node.find(block_cls)
@@ -352,11 +329,9 @@ def _extract_codex_plugin(
 ) -> PluginDoc:
     """Build a PluginDoc from a Codex manifest and its subtree.
 
-    The Codex manifest carries the same descriptive fields as a Claude one,
-    so the shape of the output is unchanged. Commands, agents and rule
-    files attach when the plugin ships them — Codex reuses the Claude
-    directory conventions, and dropping them would publish empty pages
-    for plugins whose prose the lint tree already holds.
+    The Codex manifest carries the same descriptive fields as a Claude
+    one, so the shape of the output is unchanged; commands, agents and
+    rule files attach when the plugin ships them.
     """
     plugin_dir = node.plugin_dir
     meta = _read_json_dict(node)
@@ -382,8 +357,8 @@ def _extract_codex_plugin(
         skills=_extract_codex_skills(context, plugin_resolved),
         agents=_agent_docs(_owned_blocks(context, node, AgentBlock, plugin_resolved)),
         hooks=_extract_hooks(_owned_blocks(context, node, HooksBlock, plugin_resolved)),
-        # meta is passed empty: the manifest's own ``mcpServers`` map is
-        # already in the tree as a CodexInlineMcpBlock, and feeding it here
+        # meta is passed empty: the manifest's ``mcpServers`` map is
+        # already in the tree as a CodexInlineMcpBlock — feeding it here
         # too would list every inline server twice.
         mcp_servers=_extract_mcp_servers(
             _owned_blocks(context, node, McpBlock, plugin_resolved), {}
@@ -462,10 +437,8 @@ def _string_list(value) -> List[str]:
 def _extract_codex_skills(context: RepositoryContext, plugin_resolved: Path) -> List[SkillDoc]:
     """Skills the tree assigned to this plugin.
 
-    A nested plugin's skills nest under its container, while a repo-root
-    plugin's hang off the tree root; either way the build tagged each
-    ``SkillNode`` with its owning plugin root, so membership is a read,
-    not a path match.
+    The build tagged each ``SkillNode`` with its owning plugin root, so
+    membership is a read, not a path match.
     """
     docs = []
     for skill_node in context.lint_tree.find(SkillNode):

--- a/src/skillsaw/formats/codex.py
+++ b/src/skillsaw/formats/codex.py
@@ -1,12 +1,9 @@
 """OpenAI Codex plugin-format helpers.
 
-Functions over Codex manifest and marketplace values that need no
-repository state — only a plugin directory. ``context`` uses them while
-building the lint tree; rules and the docs extractor import them directly.
-
-Kept out of ``context.py`` deliberately: these are state-free readers
-of a ``plugin_dir``, and rules use them without holding a
-``RepositoryContext``.
+State-free readers over Codex manifest and marketplace values — they need
+only a plugin directory, never a ``RepositoryContext``. ``context`` uses
+them while building the lint tree; rules and the docs extractor import
+them directly.
 """
 
 from __future__ import annotations
@@ -65,11 +62,10 @@ def inline_documents(declared: Any, key: str) -> List[Dict[str, Any]]:
     like the file the field could have named instead — a nested *key* is
     used as-is, and a bare body is wrapped.
 
-    One document per object, never a merge. Merging read tidier but had to
-    discard occurrences when an array repeated an event or a server name,
-    and either loss hides a defect: the dropped occurrence is never
-    validated, and if the dropped one was the valid one its commands never
-    reach the security rules.
+    One document per object, NEVER a merge: merging must discard
+    occurrences when an array repeats an event or server name, and the
+    dropped occurrence is either never validated or never reaches the
+    security rules with its commands.
     """
     candidates = declared if isinstance(declared, list) else [declared]
     documents: List[Dict[str, Any]] = []
@@ -94,9 +90,8 @@ CODEX_PLUGIN_MANIFEST = (".codex-plugin", "plugin.json")
 def codex_manifest(plugin_dir: Path) -> Dict[str, Any]:
     """A Codex plugin's parsed manifest, or ``{}`` when absent or unparseable.
 
-    Goes through the shared cached reader so a UTF-8 BOM is stripped and
-    repeated reads cost nothing — discovery, the validity rule and the
-    registration rule all read these files.
+    Uses the shared cached reader: strips a UTF-8 BOM, and repeated reads
+    cost nothing.
     """
     data, error = read_json(plugin_dir.joinpath(*CODEX_PLUGIN_MANIFEST))
     return data if not error and isinstance(data, dict) else {}
@@ -175,19 +170,13 @@ def codex_inline_hooks(plugin_dir: Path) -> List[Dict[str, Any]]:
     """Hooks a Codex plugin manifest declares inline, in hooks.json shape.
 
     :func:`codex_declared_hook_files` covers the path forms; this covers
-    the object forms, which carry exactly the same executable commands and
-    so belong in front of the same hook rules. Without it a ``curl | sh``
-    SessionStart hook written inline is invisible to hooks-dangerous and
-    hooks-prohibited.
+    the object forms, which carry exactly the same executable commands —
+    without it a ``curl | sh`` SessionStart hook written inline is
+    invisible to hooks-dangerous and hooks-prohibited.
 
-    One document per declared object, never a merge. Merging looked tidier
-    but silently dropped occurrences: an array that repeats an event has to
-    lose one of the two values, and whichever rule loses is a defect
-    nothing else reports — ``codex-plugin-json-valid`` deliberately skips
-    hook objects, so a malformed ``SessionStart`` overwritten by a later
-    valid one goes unreported, and a valid one overwritten by a malformed
-    one loses its commands to hooks-dangerous. Separate blocks let every
-    occurrence be judged.
+    One document per declared object, never a merge (see
+    :func:`inline_documents`): separate blocks let every occurrence be
+    judged.
 
     Both ``{"hooks": {...}}`` (mirroring a hooks.json document) and a bare
     event map are accepted.
@@ -203,13 +192,9 @@ def codex_inline_mcp_servers(plugin_dir: Path) -> List[Dict[str, Any]]:
     commands the host will spawn, so they belong in front of the MCP rules
     whether they arrived by path or by value.
 
-    One document per declared object, for the reason spelled out in
-    :func:`codex_inline_hooks`: merging by server name would drop a second
-    ``same`` entry missing its ``command``, hiding exactly the structural
-    error mcp-valid-json exists to report.
-
-    Both ``{"mcpServers": {...}}`` and a bare server map are accepted,
-    matching what ``McpBlock.servers`` already reads.
+    One document per declared object, never a merge (see
+    :func:`inline_documents`). Both ``{"mcpServers": {...}}`` and a bare
+    server map are accepted, matching what ``McpBlock.servers`` reads.
     """
     return inline_documents(codex_manifest(plugin_dir).get("mcpServers"), "mcpServers")
 
@@ -218,11 +203,8 @@ def codex_manifest_is_contained(plugin_dir: Path) -> bool:
     """Whether *plugin_dir* carries a Codex manifest of its own.
 
     The authorship evidence the Claude rules stand down on, asked directly
-    of the filesystem rather than of discovery. Discovery is switched off
-    by an explicit ``--type`` override; reading the exemption from it would
-    make ``skillsaw lint --type marketplace`` restore exactly the false
-    positives this exemption removes — the same repository would get two
-    different answers from two invocations.
+    of the filesystem rather than of discovery — discovery is switched off
+    by a ``--type`` override, and the answer must be override-invariant.
 
     Containment is checked the way discovery checks it: a ``.codex-plugin``
     or a ``plugin.json`` symlinked out of the plugin is not this plugin's

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -126,10 +126,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         role = (resolved, block_cls)
         if role in seen_roles or not safe_is_file(p) or _is_excluded(p):
             return
-        # seen_roles only — never the path-only ``seen`` set. A manifest
-        # can declare ``hooks``/``mcpServers`` at any in-plugin markdown
-        # file; poisoning ``seen`` with that path would silently drop the
-        # file from every content and prose rule that attaches later.
+        # seen_roles only — never the path-only ``seen`` set: a manifest can
+        # declare ``hooks``/``mcpServers`` at any in-plugin markdown file,
+        # and poisoning ``seen`` would drop that file from every content
+        # rule that attaches later.
         seen_roles.add(role)
         block = block_cls(path=p)
         block.plugin_owner = owner
@@ -163,9 +163,8 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         ``commands/``, ``agents/``, ``rules/`` and README follow the same
         conventions in both ecosystems, so every claimed directory gets
         them here — the content and security rules must read this prose
-        whoever owns it. Containment mirrors ``_add_codex_block``: the
-        paths are found by convention, so a symlink would pull an
-        external file under an in-repo name.
+        whoever owns it. Containment as in ``_add_codex_block``: a symlink
+        would pull an external file under an in-repo name.
         """
         plugin_resolved = safe_resolve(plugin_dir)
         if plugin_resolved is None:
@@ -174,14 +173,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         def _contained(p: Path) -> bool:
             """Inside this plugin, and not inside a nested claimed plugin.
 
-            The recursive ``rules/`` scan of a repo-root plugin would
-            otherwise claim a catalog-sourced nested plugin's files —
-            tagging them with the outer owner and poisoning ``seen`` before
-            the nested plugin's own pass could attach them. Provenance owns
-            that boundary: any claimed plugin directory strictly between the
-            file and this plugin's root means the file is the nested
-            plugin's to attach. ``seen_plugin_dirs`` is fully populated
-            before the plugin loop makes the first call here.
+            Any claimed plugin directory strictly between the file and this
+            plugin's root means the file is the nested plugin's to attach —
+            otherwise a repo-root plugin's recursive ``rules/`` scan would
+            tag nested files with the outer owner and poison ``seen`` first.
+            ``seen_plugin_dirs`` is fully populated before the plugin loop
+            makes the first call here.
             """
             resolved = safe_resolve(p)
             if resolved is None:
@@ -304,16 +301,15 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
 
     # --- Plugins: one pass over every claimed directory ---
     # Exactly one container per directory, with prose and config attached
-    # here from its provenance. There are deliberately no per-ecosystem
-    # loops: two loops that must complement each other exactly are how a
-    # directory falls between attach paths and loses its content silently.
+    # from its provenance. Never add per-ecosystem loops: two loops that
+    # must complement each other exactly are how a directory falls between
+    # attach paths and loses its content silently.
     plugin_dirs: list[Path] = []
     seen_plugin_dirs: set[Path] = set()
-    # Catalog claims come last in the union: a local source with no
-    # manifest and no legacy marker is still a claimed directory whose
-    # hooks, prose, and skills the rules must see — the registration rule
-    # already reasons about it, and a container-less claim would skip all
-    # of that silently. The claim set is resolved and contained already.
+    # Catalog claims join the union: a local source with no manifest and no
+    # legacy marker is still a claimed directory whose hooks, prose, and
+    # skills the rules must see. The claim set is resolved and contained
+    # already.
     for candidate in (
         *context.plugins,
         *context.codex_plugins,
@@ -338,11 +334,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             continue
         resolved_plugin = plugin_path.resolve()
 
-        # Container type: a Claude identity (or no ecosystem claim at all
-        # — legacy discovery) keeps the PluginNode and the Claude-only
-        # PluginNode rules; a Codex-only directory gets the Codex
-        # container; a Codex-only plugin that IS the repository root hangs
-        # directly off the tree root.
+        # Container type: a Claude identity (or no ecosystem claim at all)
+        # keeps the PluginNode and its Claude-only rules; a Codex-only
+        # directory gets the Codex container; a Codex-only plugin that IS
+        # the repository root hangs directly off the tree root.
         container: LintTarget
         if prov.claude or not prov.codex:
             container = PluginNode(path=plugin_path)
@@ -356,11 +351,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         if container is not root:
             container.plugin_owner = resolved_plugin
         else:
-            # A repo-root Codex plugin shares conventional config paths
-            # with the repository itself, and the generic root attach ran
-            # first — so those blocks live on the tree root while the
-            # ownership is still this plugin's. Decided here, once, so
-            # readers like ``skillsaw docs`` never re-match the paths.
+            # A repo-root Codex plugin shares conventional config paths with
+            # the repository, and the generic root attach ran first — so
+            # those blocks live on the tree root but the ownership is this
+            # plugin's, decided here once.
             root_plugin_owner = resolved_plugin
             claimed = {
                 safe_resolve(plugin_path / ".mcp.json"),
@@ -373,28 +367,22 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 ):
                     child.plugin_owner = resolved_plugin
 
-        # Prose: the conventions are identical in both ecosystems, so one
-        # attach covers commands/, agents/, rules/ and README — with
-        # containment, because a symlinked command file is an external
-        # file under an in-repo name whichever ecosystem claims the
-        # directory.
         _add_plugin_prose(container, plugin_path, resolved_plugin)
 
-        # Conventional configs. Codex-claimed directories get hooks and
-        # MCP exclusively through the Codex cluster below — it attaches
-        # with the containment check for dual-manifest and manifest-less
-        # claims alike, so a symlinked hooks.json cannot parse an external
-        # file's commands into CI diagnostics. Pure-Claude plugins keep
-        # their established attach.
+        # Conventional configs. Codex-claimed directories get hooks and MCP
+        # exclusively through the Codex cluster below, whose containment
+        # check keeps a symlinked hooks.json from parsing an external
+        # file's commands into diagnostics. Pure-Claude plugins keep their
+        # established attach.
         if not prov.codex:
             _add_block(
                 container, plugin_path / "hooks" / "hooks.json", HooksBlock, owner=resolved_plugin
             )
             _add_block(container, plugin_path / ".mcp.json", McpBlock, owner=resolved_plugin)
         # settings.json is Claude-side configuration with no Codex
-        # counterpart: attached only for Claude-style directories, which
-        # also keeps _add_block's bare resolve() away from content a
-        # hostile Codex-only checkout controls.
+        # counterpart: attached only for Claude-style directories, keeping
+        # _add_block's bare resolve() away from content a hostile
+        # Codex-only checkout controls.
         if prov.claude or not prov.codex:
             _add_block(
                 container, plugin_path / "settings.json", SettingsBlock, owner=resolved_plugin
@@ -407,14 +395,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # directories hang it off their PluginNode).
         if prov.codex:
             manifest = plugin_path.joinpath(*context.CODEX_PLUGIN_MANIFEST)
-            # Not gated on the manifest existing: discovery keys off the
-            # reserved .codex-plugin/ directory (or a catalog claim), so a
-            # plugin whose manifest is missing still reaches
-            # codex-plugin-json-valid to be reported as such. No
-            # plugin-wide skip when the manifest is excluded, either — the
-            # plugin's hooks and MCP files have their own paths, exclusion
-            # checks, and executable commands; the linter filters
-            # violations filed against the excluded manifest itself.
+            # Not gated on the manifest existing: a plugin whose manifest is
+            # missing must still reach codex-plugin-json-valid to be
+            # reported. An excluded manifest is no plugin-wide skip either —
+            # hooks and MCP files carry executable commands and have their
+            # own exclusion checks; the linter filters violations filed
+            # against the excluded manifest itself.
             node = CodexPluginConfigNode(path=manifest)
             node.plugin_owner = resolved_plugin
             _add_openai_metadata(
@@ -425,17 +411,14 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             )
             # Codex "checks that default file automatically", so a plugin
             # can ship executable hooks without declaring them — the same
-            # supply-chain surface as a Claude plugin's hooks. Parser-role
-            # deduplication keeps the dual-ecosystem attach above from
-            # doubling findings; containment keeps a symlinked hooks.json
-            # from pulling an external file's commands into this plugin.
+            # supply-chain surface as a Claude plugin's hooks.
             _add_codex_block(
                 node, plugin_path / "hooks" / "hooks.json", HooksBlock, owner=resolved_plugin
             )
             # A manifest may point ``hooks`` at other files, or write them
             # inline; both carry the same executable commands. Inline
             # payloads have no file of their own, so they borrow the
-            # manifest path, which is already claimed — appended directly.
+            # manifest path.
             for declared_hooks in codex_declared_hook_files(plugin_path):
                 _add_parser_block(node, declared_hooks, HooksBlock, owner=resolved_plugin)
             for inline_hooks in codex_inline_hooks(plugin_path):
@@ -444,9 +427,6 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 node.children.append(inline_block)
             # Same treatment for MCP: the conventional .mcp.json, declared
             # files, and inline maps are all commands the host will spawn.
-            # One document can legitimately be declared as both ``hooks``
-            # and ``mcpServers``; one attach per parser role lets both
-            # rule families see it without doubling either.
             _add_codex_block(node, plugin_path / ".mcp.json", McpBlock, owner=resolved_plugin)
             for declared_mcp in codex_declared_mcp_files(plugin_path):
                 _add_parser_block(node, declared_mcp, McpBlock, owner=resolved_plugin)
@@ -470,10 +450,9 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             continue
         skill_node = SkillNode(path=skill_path)
         _add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
-        # Contained against the owning Codex plugin: agentskill-evals reads
-        # the eval document and agentskill-rename-refs can rewrite it, and
-        # the SAFE content fixes rewrite references in place — so a symlink
-        # here is a read *and* a write outside the checkout.
+        # Contained against the owning Codex plugin: rules both read and
+        # rewrite these files, so a symlink here is a read *and* a write
+        # outside the checkout.
         ref_root = _codex_owner(skill_path)
 
         _add_openai_metadata(
@@ -609,9 +588,8 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 claimed == extra_resolved for claimed, _ in seen_roles
             ):
                 # Already attached under a structured parser role (hooks,
-                # MCP): a broad content glob matching the same JSON must
-                # not re-attach it as prose — every content-quality rule
-                # would then lint structured config as instruction text.
+                # MCP): re-attaching it as prose would make every
+                # content-quality rule lint structured config as text.
                 continue
             _add_block(root, extra, ExtraBlock)
 

--- a/src/skillsaw/paths.py
+++ b/src/skillsaw/paths.py
@@ -4,10 +4,7 @@ The pure predicates answer questions about a path *string* — is it
 absolute, does it escape its root — without touching the filesystem.
 The ``safe_*`` wrappers are their filesystem-touching companions:
 ``pathlib`` calls that never raise, so discovery and rules can probe
-manifest-supplied paths without aborting the lint. They live here
-rather than in a format or rule module because independent packages
-need them, and none should have to import another's private helpers
-to get at an ecosystem-neutral utility.
+manifest-supplied paths without aborting the lint.
 """
 
 from __future__ import annotations
@@ -129,9 +126,8 @@ def escapes_root(value: str, root: Path) -> bool:
         resolved_root = root.resolve()
         candidate = (root / value).resolve()
     except (OSError, ValueError, RuntimeError):
-        # OSError: an unreadable parent, or a symlink loop on 3.13+.
-        # RuntimeError: a symlink loop before 3.13. ValueError: an embedded
-        # NUL. Containment cannot be proven in any of these cases, and
-        # failing closed is the safe direction for a containment check.
+        # Unreadable parent, symlink loop (OSError on 3.13+, RuntimeError
+        # before), or embedded NUL: containment cannot be proven, so fail
+        # closed.
         return True
     return candidate != resolved_root and not candidate.is_relative_to(resolved_root)

--- a/src/skillsaw/rules/builtin/codex/marketplace_json_valid.py
+++ b/src/skillsaw/rules/builtin/codex/marketplace_json_valid.py
@@ -37,10 +37,9 @@ _SOURCE_REQUIRED_FIELDS = {
 # intersection, and the set is configurable.
 DEFAULT_INSTALLATION_VALUES = ["AVAILABLE", "INSTALLED_BY_DEFAULT", "NOT_AVAILABLE"]
 
-# Same split for policy.authentication: prose describes the field ("whether
-# auth happens on install or first use"), plugin-json-spec.md publishes
-# exactly this pair as an enum. Unrecognized values warn for the same
-# reason as installation.
+# Same split for policy.authentication: the prose spec describes the field,
+# plugin-json-spec.md publishes exactly this pair as an enum. Unrecognized
+# values warn for the same reason as installation.
 DEFAULT_AUTHENTICATION_VALUES = ["ON_INSTALL", "ON_USE"]
 
 # The docs mandate these on every entry ("Always include policy.installation,
@@ -52,12 +51,10 @@ _RECOMMENDED_ENTRY_FIELDS = ("policy", "category")
 def _source_identity(source: Any) -> str:
     """A comparable identity for an entry's source.
 
-    Codex accepts a local source as a bare string or as an object, and
     ``./plugins/foo``, ``plugins/foo`` and ``{"source": "local", "path":
-    "./plugins/foo"}`` all install the same directory. Comparing raw JSON
-    would call those three different sources and report a duplicate name
-    that is not one, so local sources compare by their normalised path.
-    Remote sources have no such spellings and compare structurally.
+    "./plugins/foo"}`` all install the same directory, so local sources
+    compare by normalised path — raw JSON comparison would report a
+    duplicate name that is not one. Remote sources compare structurally.
     """
     local = codex_local_source_path(source)
     if local is not None:
@@ -113,10 +110,9 @@ class CodexMarketplaceJsonValidRule(Rule):
             marketplace_file = node.path
             data, error = read_json(marketplace_file)
             if error:
-                # An absent file is not a syntax error. The node exists
-                # because ``--type codex-marketplace`` said the format is
-                # Codex, so "Invalid JSON: Failed to read" would describe
-                # the wrong defect entirely.
+                # An absent file (a --type-seeded node) is not a syntax
+                # error — "Invalid JSON: Failed to read" would describe the
+                # wrong defect.
                 message = (
                     "Invalid JSON: {}".format(error)
                     if safe_exists(marketplace_file)
@@ -196,8 +192,7 @@ class CodexMarketplaceJsonValidRule(Rule):
 
             for field in _RECOMMENDED_ENTRY_FIELDS:
                 # ``None`` counts as absent throughout — an explicit null
-                # carries no more information than a missing key, and
-                # treating it as present would skip every check below it.
+                # carries no more information than a missing key.
                 if entry.get(field) is None:
                     violations.append(
                         self.violation(
@@ -221,8 +216,7 @@ class CodexMarketplaceJsonValidRule(Rule):
 
         The set of labels is open-ended, so their *values* stay
         unconstrained — but ``""``, a number, or an array carries less
-        information than an absent key, which already warns. Without this
-        the presence-only check above reports nothing at all for them.
+        information than an absent key, which already warns.
         """
         if category is None:
             return []  # absence already warned about above
@@ -259,30 +253,27 @@ class CodexMarketplaceJsonValidRule(Rule):
                 )
             ]
         if not name:
-            # Same reasoning as the plugin manifest: an empty identifier is a
-            # missing one, so it must not stop at the kebab-case warning.
+            # An empty identifier is a missing one — it must not stop at
+            # the kebab-case warning.
             return [
                 self.violation(
                     f"plugins[{idx}] required field 'name' is an empty string",
                     file_path=marketplace_file,
                 )
             ]
-        # A duplicate falls through to the casing check rather than returning:
-        # two entries named ``Bad_Name`` have both defects, and reporting only
-        # the duplicate would hide the second until the first was fixed.
+        # A duplicate falls through to the casing check rather than
+        # returning: two entries named ``Bad_Name`` have both defects.
         violations: List[RuleViolation] = []
         source_key = _source_identity(entry.get("source"))
         first = seen_names.get(name)
         # Across catalogs, one name pointing at one source is a curated
-        # second listing, not a defect — real catalogs split their index
-        # that way. It is only ambiguous when the two entries resolve
-        # somewhere different: that is when Codex's aggregation has to pick
-        # one and ``docs`` loses a page. Within a single file any repeat is
-        # a defect.
+        # second listing, not a defect. It is only ambiguous when the two
+        # entries resolve somewhere different — then Codex's aggregation
+        # has to pick one and ``docs`` loses a page. Within a single file
+        # any repeat is a defect.
         if first is not None and (first[0] == marketplace_file or first[2] != source_key):
             first_file, first_idx, _ = first
-            # Name the file only when it differs, so the single-catalog
-            # message reads exactly as it did before.
+            # Name the file only when it differs.
             where = (
                 f"plugins[{first_idx}]"
                 if first_file == marketplace_file
@@ -329,9 +320,9 @@ class CodexMarketplaceJsonValidRule(Rule):
             ]
 
         source_type = source.get("source")
-        # An empty discriminator is missing, not unknown: Codex cannot
-        # resolve the entry either way, so it must not fall through to the
-        # forward-compatibility warning and pass a default ``fail-on: error``.
+        # An empty discriminator is missing, not unknown: it must not fall
+        # through to the forward-compatibility warning and pass a default
+        # ``fail-on: error``.
         if not isinstance(source_type, str) or not source_type:
             return [
                 self.violation(
@@ -352,9 +343,7 @@ class CodexMarketplaceJsonValidRule(Rule):
 
         for required in _SOURCE_REQUIRED_FIELDS[source_type]:
             value = source.get(required)
-            # ``None`` counts as absent: an explicit null is no more usable
-            # than a missing key, and reporting it as present would let it
-            # through every check below.
+            # ``None`` counts as absent, as above.
             if value is None:
                 violations.append(
                     self.violation(
@@ -497,9 +486,9 @@ class CodexMarketplaceJsonValidRule(Rule):
                 continue
             known = self.config.get(f"{field}-values", default)
             if not isinstance(known, (list, tuple, set)):
-                # ``value not in known`` raises TypeError on a non-iterable,
-                # which the linter turns into a rule crash — every remaining
-                # entry in the catalog would then go unvalidated.
+                # ``value not in known`` raises TypeError on a non-iterable
+                # — a rule crash that leaves the rest of the catalog
+                # unvalidated.
                 known = default
             if value not in known:
                 violations.append(

--- a/src/skillsaw/rules/builtin/codex/marketplace_registration.py
+++ b/src/skillsaw/rules/builtin/codex/marketplace_registration.py
@@ -66,10 +66,8 @@ def _mutable_marketplace_data(original: str) -> Optional[dict]:
     except (json.JSONDecodeError, ValueError):
         return None
     except RecursionError:
-        # The shared reader turns this into an ordinary parse error, but
-        # this reparses the raw text to keep ruamel out of the fix path.
-        # Letting it escape makes the rule a rule-execution-error instead
-        # of standing down on a catalog that is already invalid.
+        # Letting this escape turns the rule into a rule-execution-error
+        # instead of standing down on an already-invalid catalog.
         return None
     if not isinstance(data, dict):
         return None
@@ -116,12 +114,10 @@ class CodexMarketplaceRegistrationRule(Rule):
         registerable = self._registerable(context, truly_unregistered, primary)
         for plugin_dir, name in unregistered:
             if name in local_names:
-                # The catalog lists the name but its local source path does
-                # not resolve to this directory. "Not registered" would be
-                # factually wrong — the name is right there — and fix()
-                # skips this by design (appending a second entry for a
-                # listed name would create a duplicate), so per the
-                # invariant it must not be a hard ERROR either.
+                # The catalog lists the name but its source path does not
+                # resolve to this directory — "not registered" would be
+                # factually wrong, and fix() skips it (a second entry for a
+                # listed name would be a duplicate).
                 violations.append(
                     self.violation(
                         f"Plugin '{safe_display(name)}' is listed in {primary.name} but the "
@@ -174,11 +170,9 @@ class CodexMarketplaceRegistrationRule(Rule):
         if _mutable_marketplace_data(_read_text(marketplace_file)) is None:
             return {}
 
-        # Every name the catalog spells, local entries included. This is a
-        # different question from ``_registered()``, which deliberately
-        # ignores local entries' names — here the point is that ``fix()``
-        # refuses to append a name already present, so advertising the fix
-        # would offer a no-op that leaves the violation standing.
+        # Every name the catalog spells, local entries included (unlike
+        # ``_registered()``): ``fix()`` refuses to append a name already
+        # present, so advertising that fix would offer a no-op.
         catalog_names = {
             entry.get("name")
             for node in context.lint_tree.find(CodexMarketplaceConfigNode)
@@ -223,10 +217,9 @@ class CodexMarketplaceRegistrationRule(Rule):
         name = manifest.get("name")
         if not isinstance(name, str) or not name:
             return False
-        # Writing a non-kebab name into the catalog trades one violation for
-        # another: codex-marketplace-json-valid rejects it on the next run,
-        # and the identifier hosts use as the component namespace is now
-        # published. The manifest name has to be corrected by hand first.
+        # A non-kebab name trades one violation for another:
+        # codex-marketplace-json-valid rejects it on the next run. The
+        # manifest name has to be corrected by hand first.
         return bool(KEBAB_CASE.match(name))
 
     def _unregistered(
@@ -249,20 +242,19 @@ class CodexMarketplaceRegistrationRule(Rule):
         for plugin_node in context.lint_tree.find(CodexPluginConfigNode):
             plugin_dir = plugin_node.plugin_dir
             if not plugin_node.path.is_file():
-                # A .codex-plugin/ directory with no manifest. There is
-                # nothing installable to register, and codex-plugin-json-valid
-                # already reports the missing entrypoint — stacking a second
-                # error on it would just say the same defect twice.
+                # No manifest: nothing installable to register, and
+                # codex-plugin-json-valid already reports the missing
+                # entrypoint.
                 continue
             if plugin_dir.resolve() in registered_dirs:
                 continue
             if context.is_codex_installed_plugin(plugin_dir):
                 continue
             if context.is_path_excluded(plugin_node.path):
-                # Registration files its violation against the catalog, not
-                # the excluded manifest, so the linter's path filter cannot
-                # enforce this boundary for us. Skipping here also keeps the
-                # fixer from publishing an excluded plugin.
+                # The violation is filed against the catalog, not the
+                # excluded manifest, so the linter's path filter cannot
+                # enforce this; skipping also keeps the fixer from
+                # publishing an excluded plugin.
                 continue
             name = codex_plugin_name(plugin_dir)
             if name in registered_names:
@@ -273,26 +265,20 @@ class CodexMarketplaceRegistrationRule(Rule):
     def _registered(self, context: RepositoryContext) -> Tuple[Set[str], Set[Path], Set[str]]:
         """Names and plugin directories the repository's catalogs already cover.
 
-        A plugin counts as registered when *any* catalog names it — openai/
-        plugins splits its catalog across two files — or when an entry's
-        local source resolves to its directory. The second half matters
-        because an entry whose ``name`` disagrees with the manifest still
-        installs that directory; without it the plugin would be reported
-        unregistered on top of the name-mismatch warning, and the autofix
-        would append a duplicate entry for a directory already listed.
+        A plugin counts as registered when *any* catalog names it (openai/
+        plugins splits its catalog across two files) or when an entry's
+        local source resolves to its directory — an entry whose ``name``
+        disagrees with the manifest still installs that directory.
 
-        A *local* entry contributes only its directory, never its name. The
-        two are one registration, and crediting them independently lets a
-        crossed pair — ``name: "b"`` against ``path: "./plugins/a"`` — cover
-        both directories: A matches the path, B matches the name, and the
-        fact that B is not installable at all goes unreported. Only remote
-        entries (url, git-subdir, npm) register by name, because they name
-        no directory in this repository for the path half to match.
+        A *local* entry contributes only its directory, never its name:
+        crediting both independently lets a crossed pair — ``name: "b"``
+        against ``path: "./plugins/a"`` — cover both directories while B is
+        not installable at all. Only remote entries (url, git-subdir, npm)
+        register by name, since they name no directory here to match.
 
-        A malformed entry registers nothing at all. ``{"source": "local"}``
-        with no ``path`` names no directory, and its ``name`` describes a
-        plugin the catalog cannot install; crediting it would silence the
-        unregistered-plugin report for a real directory of the same name.
+        A malformed entry registers nothing: ``{"source": "local"}`` with
+        no ``path`` names no directory, and crediting its ``name`` would
+        silence the unregistered report for a real directory of that name.
         """
         names: Set[str] = set()
         dirs: Set[Path] = set()
@@ -304,12 +290,9 @@ class CodexMarketplaceRegistrationRule(Rule):
                     resolved = safe_resolve(context.root_path / source)
                     if resolved is not None:
                         dirs.add(resolved)
-                    # The name is remembered without crediting the
-                    # directory: a directory whose name the catalog lists
-                    # under a non-matching path is a different defect from
-                    # one the catalog never mentions, and reporting the
-                    # second message for the first sends the author
-                    # grepping a catalog that already contains the name.
+                    # Remember the name without crediting the directory: a
+                    # name listed under a non-matching path is a different
+                    # defect from one the catalog never mentions.
                     name = entry.get("name")
                     if isinstance(name, str):
                         local_names.add(name)
@@ -406,11 +389,10 @@ class CodexMarketplaceRegistrationRule(Rule):
             return results
         marketplace_file = config_nodes[0].path
 
-        # Never write through a symlink: a catalog entry symlinked at an
-        # unrelated file — inside or outside the checkout — would receive
-        # this rule's appended JSON at whatever the link points to. The
-        # lexical path is what the repository ships; if resolution moves
-        # it, the write is declined and the violation stays manual.
+        # Never write through a symlink: the appended JSON would land at
+        # whatever the link points to. The lexical path is what the
+        # repository ships; if resolution moves it, the write is declined
+        # and the violation stays manual.
         lexical = Path(os.path.abspath(marketplace_file))
         resolved_target = safe_resolve(marketplace_file)
         if resolved_target is None or resolved_target != lexical:
@@ -419,8 +401,7 @@ class CodexMarketplaceRegistrationRule(Rule):
         original = _read_text(marketplace_file)
         data = _mutable_marketplace_data(original)
         if data is None:
-            # Malformed document — reported by codex-marketplace-json-valid
-            # and left for manual repair. check() marks these fixable=False.
+            # Malformed document — left for manual repair.
             return results
         data.setdefault("plugins", [])
 
@@ -431,9 +412,9 @@ class CodexMarketplaceRegistrationRule(Rule):
         unregistered = [
             (d, n)
             for d, n in self._unregistered(context, registered_names, registered_dirs)
-            # Name-listed entries get the WARNING path in check(), never a
-            # catalog write — appending a second entry for a listed name
-            # would create the duplicate the validity rule rejects.
+            # Name-listed entries never get a catalog write — a second
+            # entry for a listed name is the duplicate the validity rule
+            # rejects.
             if n not in local_names
         ]
         registerable = self._registerable(context, unregistered, marketplace_file)
@@ -464,10 +445,10 @@ class CodexMarketplaceRegistrationRule(Rule):
 
         if fixed:
             try:
-                # Python's encoder otherwise emits NaN and Infinity, which
-                # JavaScript accepts but the JSON standard and Codex manifests
-                # do not. Parsing is strict above; allow_nan=False is the final
-                # guard before returning content that the autofix will write.
+                # allow_nan=False: Python's encoder otherwise emits NaN and
+                # Infinity, which the JSON standard and Codex manifests
+                # reject. ensure_ascii=False preserves non-ASCII text in
+                # untouched entries.
                 fixed_content = (
                     json.dumps(data, indent=2, ensure_ascii=False, allow_nan=False) + "\n"
                 )
@@ -479,8 +460,6 @@ class CodexMarketplaceRegistrationRule(Rule):
                     file_path=marketplace_file,
                     confidence=AutofixConfidence.SUGGEST,
                     original_content=original,
-                    # ensure_ascii=False above preserves non-ASCII text in
-                    # untouched entries when the whole document is serialized.
                     fixed_content=fixed_content,
                     description=(f"Registered {len(fixed)} plugin(s) in {marketplace_file.name}"),
                     violations_fixed=fixed,

--- a/src/skillsaw/rules/builtin/codex/openai_metadata.py
+++ b/src/skillsaw/rules/builtin/codex/openai_metadata.py
@@ -52,17 +52,15 @@ class CodexOpenAIMetadataRule(Rule):
         violations: List[RuleViolation] = []
         for block in context.lint_tree.find(OpenAIMetadataBlock):
             if context.is_codex_installed_plugin(block.metadata_root):
-                # Vendor-installed under .codex/plugins/: authored-manifest
-                # quality is the vendor's to fix, the same stand-down every
-                # other manifest-quality rule applies there. Executable
-                # hooks/MCP checks are unaffected — this rule has none.
+                # Vendor-installed under .codex/plugins/: manifest quality
+                # is the vendor's to fix — the same stand-down every other
+                # manifest-quality rule applies there.
                 continue
             if block.parse_error:
                 violations.append(
                     self.violation(
-                        # Parser diagnostics quote source text, which a
-                        # malformed document controls — same redaction as
-                        # every other manifest-value echo.
+                        # Parser diagnostics quote source text a malformed
+                        # document controls — redact like any value echo.
                         f"Invalid YAML: {safe_display(block.parse_error)}",
                         file_path=block.path,
                         line=block.error_line,
@@ -72,8 +70,7 @@ class CodexOpenAIMetadataRule(Rule):
             data = block.raw_data
             if data is None:
                 # An empty document ("", a lone comment, a bare "---")
-                # declares nothing — there is no metadata to validate and
-                # nothing Codex would reject, so it is not an error.
+                # declares nothing to validate — not an error.
                 continue
             if not isinstance(data, dict):
                 violations.append(

--- a/src/skillsaw/rules/builtin/codex/plugin_json_valid.py
+++ b/src/skillsaw/rules/builtin/codex/plugin_json_valid.py
@@ -30,9 +30,8 @@ _INTERFACE_PATH_FIELDS = ("composerIcon", "logo", "logoDark")
 _INTERFACE_PATH_LIST_FIELDS = ("screenshots",)
 
 # What each field has to be on disk for the lint tree to follow it. Only
-# the fields the tree actually filters on are listed. ``apps`` and the
-# ``interface`` assets are documented as paths but nothing drops them
-# silently, so asserting a kind on them would add noise without cover.
+# fields the tree actually filters on are listed — nothing drops ``apps``
+# or the ``interface`` assets silently.
 _EXPECTED_KIND = {"hooks": "file", "mcpServers": "file", "skills": "dir"}
 
 
@@ -74,26 +73,22 @@ class CodexPluginJsonValidRule(Rule):
         violations: List[RuleViolation] = []
         recommended_fields = self.config.get("recommended-fields", self.DEFAULT_RECOMMENDED_FIELDS)
         if not isinstance(recommended_fields, (list, tuple, set)):
-            # Config loading does not enforce config_schema types, so a
-            # scalar here would fail at the loop below — before the
-            # per-entry string guard — and crash the rule for every manifest.
+            # Config loading does not enforce config_schema types; a scalar
+            # here would crash the rule for every manifest.
             recommended_fields = self.DEFAULT_RECOMMENDED_FIELDS
         check_paths_exist = self.config.get("check-paths-exist", True)
 
         for node in context.lint_tree.find(CodexPluginConfigNode):
             if context.is_codex_installed_plugin(node.plugin_dir):
-                # Third-party content a developer installed into their own
-                # checkout. Its hooks and MCP servers are still linted —
-                # they execute here, so they are this checkout's problem —
-                # but a kebab-case name or a missing description in a
-                # manifest the developer cannot edit is not. skillsaw does
-                # not walk .claude/plugins/* at all for the same reason.
+                # Third-party content a developer installed. Its hooks and
+                # MCP servers are still linted — they execute here — but a
+                # naming or description defect in a manifest the developer
+                # cannot edit is not this checkout's problem.
                 continue
             manifest = node.path
             if not safe_is_file(manifest):
-                # The node exists because .codex-plugin/ does. Codex reads
-                # the manifest from this exact path and loads nothing
-                # without it, so the entrypoint is simply missing.
+                # The node exists because .codex-plugin/ does; Codex loads
+                # nothing without the manifest at this exact path.
                 violations.append(
                     self.violation(
                         "Missing .codex-plugin/plugin.json — Codex reads the "
@@ -122,10 +117,8 @@ class CodexPluginJsonValidRule(Rule):
 
             for field in recommended_fields:
                 if not isinstance(field, str):
-                    # ``field not in data`` raises TypeError on an unhashable
-                    # value, which the linter turns into a rule crash — so a
-                    # malformed config entry would stop every manifest from
-                    # being validated at all.
+                    # ``field not in data`` raises TypeError on an
+                    # unhashable value — a rule crash for every manifest.
                     continue
                 if field not in data:
                     violations.append(
@@ -173,10 +166,9 @@ class CodexPluginJsonValidRule(Rule):
                 )
             ]
         if not name:
-            # An empty string is no more usable as the plugin identifier than
-            # a missing key, so it belongs with the required-field errors
-            # rather than falling through to the kebab-case warning — which
-            # a default ``fail-on: error`` would let pass.
+            # An empty identifier is a missing one: it belongs with the
+            # required-field errors, not the kebab-case warning a default
+            # ``fail-on: error`` would let pass.
             return [self.violation("Required field 'name' is an empty string", file_path=manifest)]
         if not KEBAB_CASE.match(name):
             return [
@@ -197,19 +189,15 @@ class CodexPluginJsonValidRule(Rule):
 
         for field, value in self._iter_path_values(data):
             if not isinstance(value, str):
-                # ``mcpServers`` is documented as "string or object", with a
-                # worked inline example, so an object there is conformant
-                # and warning on it is the false-positive class this rule
-                # set exists to remove. The block is already routed to the
-                # MCP rules either way. Base name, not exact label: an array
-                # element arrives as ``mcpServers[1]``, and a mixed
-                # ``["./servers.json", {...}]`` declaration is supported.
+                # ``mcpServers`` is documented as "string or object", so an
+                # inline object is conformant (and already routed to the MCP
+                # rules). Base name, not exact label: an array element
+                # arrives as ``mcpServers[1]``.
                 if field.split("[", 1)[0] == "mcpServers" and isinstance(value, dict):
                     continue
-                # Everything else: a warning, not an error. ``skills`` is
-                # typed as a string alone, but real plugins ship arrays and
-                # Codex mirrors Claude Code's plugin loader, so calling
-                # them invalid would overreach.
+                # A warning, not an error: ``skills`` is typed as a string
+                # alone, but real plugins ship arrays and Codex mirrors
+                # Claude Code's loader.
                 violations.append(
                     self.violation(
                         f"'{field}' is documented as a path string relative to "

--- a/src/skillsaw/rules/builtin/hooks/json_valid.py
+++ b/src/skillsaw/rules/builtin/hooks/json_valid.py
@@ -122,10 +122,9 @@ class HooksJsonValidRule(Rule):
         violations = []
 
         for block in context.lint_tree.find(HooksBlock):
-            # Conditional strictness, not a skip: the shared gate applies
-            # the Codex-tightened shape checks only inside Codex-ONLY
-            # plugins, so a dual-manifest plugin keeps its established
-            # Claude results (see in_codex_only_plugin's docstring).
+            # Conditional strictness, not a skip: Codex-tightened shape
+            # checks apply only inside Codex-ONLY plugins, so dual-manifest
+            # plugins keep their established Claude results.
             validate_codex_shapes = context.in_codex_only_plugin(block.path)
             if block.parse_error:
                 violations.append(
@@ -186,10 +185,9 @@ class HooksJsonValidRule(Rule):
                         and "matcher" in hook_config
                         and not isinstance(hook_config["matcher"], str)
                     ):
-                        # Annotated ``str`` everywhere downstream, and the
-                        # generated docs page lowercases it. Coerced at the
-                        # block boundary so nothing crashes; reported here
-                        # so coercing does not hide the defect.
+                        # The block boundary coerces a non-string matcher so
+                        # nothing crashes; reporting here keeps the coercion
+                        # from hiding the defect.
                         violations.append(
                             self.violation(
                                 f"Event '{event_type}[{idx}].matcher' must be a string",
@@ -238,17 +236,14 @@ class HooksJsonValidRule(Rule):
                         hook_type = hook["type"]
                         hook_path = f"{event_type}[{idx}].hooks[{hook_idx}]"
 
-                        # A JSON value is not necessarily hashable, and a
-                        # list- or dict-valued ``type`` reaches the set
-                        # membership test below as an unhashable key. The
-                        # resulting TypeError aborts the whole rule, so one
-                        # malformed hook silences hook validation for every
-                        # remaining block in the repository.
+                        # An unhashable ``type`` (list/dict) would raise
+                        # TypeError in the set membership test — a rule
+                        # crash that silences hook validation for every
+                        # remaining block.
                         if not isinstance(hook_type, str) or hook_type not in _VALID_HOOK_TYPES:
-                            # A non-string type is echoed as its repr, and a
-                            # dict value can carry a credentialed URL into
-                            # text/JSON/SARIF output — route it through the
-                            # diagnostic redactor like every manifest value.
+                            # A dict value can carry a credentialed URL into
+                            # text/JSON/SARIF output — redact like every
+                            # manifest value.
                             violations.append(
                                 self.violation(
                                     f"Event '{hook_path}' has invalid type "

--- a/src/skillsaw/rules/builtin/mcp/valid_json.py
+++ b/src/skillsaw/rules/builtin/mcp/valid_json.py
@@ -70,10 +70,9 @@ class McpValidJsonRule(Rule):
                 )
                 continue
 
-            # Conditional strictness, not a skip: the shared gate applies
-            # the tightened non-empty-string checks only inside Codex-ONLY
-            # plugins, so a dual-manifest plugin keeps its established
-            # Claude results (see in_codex_only_plugin's docstring).
+            # Conditional strictness, not a skip: the tightened
+            # non-empty-string checks apply only inside Codex-ONLY plugins,
+            # so dual-manifest plugins keep their established Claude results.
             require_usable = context.in_codex_only_plugin(block.path)
             if "mcpServers" in data:
                 violations.extend(
@@ -193,14 +192,11 @@ class McpValidJsonRule(Rule):
                             file_path=file_path,
                         )
                     )
-                # Present is not the same as usable. ``"command": []`` and
+                # Present is not the same as usable: ``"command": []`` and
                 # ``"command": ""`` satisfy a key-existence check while
-                # naming nothing the host can spawn, so the server failed
-                # silently at run time with nothing reported here — the
-                # same gap the 'url' and 'cwd' type checks below close.
-                #
-                # A non-string ``url`` is left to the dedicated check
-                # below, so one defect still yields one violation.
+                # naming nothing the host can spawn. A non-string ``url``
+                # is left to the dedicated check below, so one defect
+                # still yields one violation.
                 elif (
                     require_usable
                     and not _is_usable(server_config[required_field])

--- a/src/skillsaw/utils.py
+++ b/src/skillsaw/utils.py
@@ -41,12 +41,10 @@ class FileCache:
             try:
                 resolved = file_path.resolve() if isinstance(file_path, Path) else None
             except (OSError, RuntimeError, ValueError):
-                # A symlink loop (OSError on 3.13+, RuntimeError before),
-                # an embedded NUL. The wrapped reader has its own error
-                # handling and returns a diagnostic for unreadable input —
-                # raising here instead aborts the whole lint from a cache
-                # key lookup. Key on the unresolved path; correctness only
-                # loses alias deduplication for a path that cannot resolve.
+                # Symlink loop or embedded NUL: raising here aborts the
+                # whole lint from a cache key lookup, while the wrapped
+                # reader already diagnoses unreadable input. Key on the
+                # unresolved path — that only loses alias deduplication.
                 resolved = file_path
             sub_key = (args[1:], tuple(sorted(kwargs.items())))
             with self._lock:
@@ -222,13 +220,10 @@ def read_json(file_path: Path) -> Tuple[Optional[object], Optional[str]]:
         # still being constructed — letting it escape aborts the CLI.
         return None, str(e)
     except RecursionError:
-        # ``json`` parses nested containers recursively, so a document
-        # nested past the interpreter's stack limit raises here rather
-        # than returning a decode error. Discovery reads manifests while
-        # RepositoryContext is still being constructed, outside the
+        # ``json`` parses nested containers recursively. Discovery reads
+        # manifests during RepositoryContext construction, outside the
         # rule-execution-error guard, so letting this propagate aborts the
-        # whole lint with a traceback and reports nothing at all. Every
-        # caller already handles the error string.
+        # whole lint with a traceback.
         return None, _TOO_DEEP
 
 
@@ -243,10 +238,7 @@ def read_yaml(file_path: Path) -> Tuple[Optional[object], Optional[str]]:
     except yaml.YAMLError as e:
         return None, str(e)
     except RecursionError:
-        # Same hazard as read_json: nested collections are parsed
-        # recursively, and the reader is called from discovery, where an
-        # escaping exception aborts the run instead of producing a
-        # violation. See the note there.
+        # Same hazard as read_json — see the note there.
         return None, _TOO_DEEP
 
 


### PR DESCRIPTION
## Summary

Final cleanup pass for the `codex-plugin-rules` branch: comments and docstrings only, zero code change. After ~20 adversarial review rounds, many functions carried docstrings litigating decisions against past objections. This PR prunes that sediment while keeping every load-bearing invariant:

**Kept (tightened where wordy):**
- Invariants — lexical-vs-resolved walks, fail-closed containment, `--type`-invariance of the provenance path, ordering constraints, cache-validity rules, benchmark-backed performance constraints.
- Non-obvious domain facts — Codex spec quirks, upstream spec disagreements, stdlib version differences.
- Security rationale — redaction, symlink containment, autofix write refusal (`diagnostics.py` is untouched: it is entirely redaction rationale).

**Deleted or compressed:**
- Rebuttals to hypothetical objections and alternatives-considered narration ("Merging read tidier but...").
- Justifications whose only audience was a past reviewer ("deliberately NOT x", defensive hedging).
- Restatements of the adjacent line and branch-development history.

## Verification

- **Machine-verified comments-only**: a throwaway script parses every touched file at `origin/codex-plugin-rules` and at HEAD with `ast.parse`, strips docstring nodes, and compares `ast.dump()` — identical for all 17 files (`AST-IDENTITY: PASS`).
- `make test` green, `make lint` clean, `make update` clean.
- Net delta: comment-line counts below; no code lines touched.

| File | Comment lines before | After | Delta |
|---|---|---|---|
| src/skillsaw/context.py | 655 | 564 | -91 |
| src/skillsaw/lint_tree.py | 176 | 154 | -22 |
| src/skillsaw/docs/extractor.py | 174 | 147 | -27 |
| src/skillsaw/formats/codex.py | 135 | 117 | -18 |
| src/skillsaw/paths.py | 75 | 71 | -4 |
| src/skillsaw/diagnostics.py | 47 | 47 | 0 |
| src/skillsaw/cli/_helpers.py | 76 | 75 | -1 |
| src/skillsaw/utils.py | 285 | 277 | -8 |
| rules/builtin/codex/marketplace_json_valid.py | 95 | 84 | -11 |
| rules/builtin/codex/marketplace_registration.py | 173 | 152 | -21 |
| rules/builtin/codex/plugin_json_valid.py | 68 | 56 | -12 |
| rules/builtin/codex/openai_metadata.py | 21 | 18 | -3 |
| rules/builtin/codex/plugin_structure.py | 7 | 7 | 0 |
| rules/builtin/codex/_helpers.py | 43 | 43 | 0 |
| rules/builtin/hooks/json_valid.py | 29 | 24 | -5 |
| rules/builtin/mcp/valid_json.py | 26 | 22 | -4 |

## Calibration examples

**Kept (invariant, wording tightened):** `context.py` `_codex_claim_boundary` — "A lexical ancestor walk, nearest first — NOT resolution-based like `codex_plugin_owning`, because resolving first would follow the very symlinks the boundary exists to reject."

**Deleted (alternatives-considered narration):** `formats/codex.py` `codex_inline_hooks` — the 9-line "Merging looked tidier but silently dropped occurrences: an array that repeats an event has to lose one of the two values, and whichever rule loses..." paragraph is now one sentence stating the invariant ("One document per declared object, never a merge") with a pointer to the single canonical explanation on `inline_documents`.

**Deleted (reviewer-audience justification):** `marketplace_json_valid.py` — "Name the file only when it differs, so the single-catalog message reads exactly as it did before" became "Name the file only when it differs." The backward-compat history served only a past review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
