### PR TITLE
Skip user-only skills in description routing

### DIFF
--- a/.skillsaw.yaml.example
+++ b/.skillsaw.yaml.example
@@ -313,6 +313,7 @@ rules:
     severity: warning
     # require-trigger-phrasing: true
     # flag-name-restatement: true
+    # check-user-only-skills: false
 
   # Flags hook commands that execute scripts from dotfile directories, download-and-execute chains (curl|sh), obfuscation (eval/base64), or perform network requests
   hooks-dangerous:

--- a/docs/rules/description-routing.md
+++ b/docs/rules/description-routing.md
@@ -17,17 +17,27 @@ Checks that skill and agent descriptions work as routing signals, while command 
 
 ## What it checks
 
-- Descriptions are present, non-empty strings. This basic check is always on.
+- Descriptions are present, non-empty strings. This basic check stays on when the routing heuristics are disabled.
 - Skill and agent descriptions say when the model should use them. Commands are excluded because users select them directly.
 - Descriptions do more than restate the building block name or category, such as a `deploy-staging` skill described only as "Deploy staging" or a command described only as "A command."
 
-The two routing heuristics after the always-on empty check can be configured independently:
+Skills with `disable-model-invocation: true` are user-only: the model cannot route
+to them, so this rule skips them by default. Set `check-user-only-skills: true`
+to check their descriptions normally. Only the YAML boolean `true` opts a skill
+out; an absent field, `false`, strings, and numbers remain checked.
+
+Natural selection clauses count as trigger phrasing, including "Use this skill
+for ...", "Invoke this skill whenever ...", "This skill should be used before
+...", and "Use only when ...".
+
+The routing heuristics and user-only-skill behavior can be configured independently:
 
 ```yaml
 rules:
   description-routing:
     require-trigger-phrasing: true
     flag-name-restatement: true
+    check-user-only-skills: false
 ```
 
 ## Why this matters
@@ -53,6 +63,7 @@ rules:
 |-----------|-------------|---------|
 | `require-trigger-phrasing` | Require skill and agent descriptions to say when they should be used | `true` |
 | `flag-name-restatement` | Flag descriptions that only restate the name or generic category | `true` |
+| `check-user-only-skills` | Check skills whose frontmatter sets disable-model-invocation to true | `false` |
 
 
 *Run `skillsaw explain description-routing` to see this documentation and the rule's effective configuration in your terminal.*

--- a/src/skillsaw/rules/builtin/description_routing.py
+++ b/src/skillsaw/rules/builtin/description_routing.py
@@ -9,13 +9,21 @@ from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.rules.builtin.content_analysis import AgentBlock, CommandBlock, SkillBlock
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
-_USE_THIS_TRIGGER_RE = re.compile(r"\buse this(?: (?:skill|agent))? (?:when|if)\b")
+_USE_THIS_TRIGGER_RE = re.compile(
+    r"\b(?:use|invoke) this(?: (?:skill|agent))?(?: proactively)? "
+    r"(?:when(?:ever)?|if|before|for|to)\b"
+)
+_PASSIVE_USE_TRIGGER_RE = re.compile(
+    r"(?:^|[.!?]\s+)(?:this (?:skill|agent) )?(?:must|should) be used "
+    r"(?:when(?:ever)?|if|before)\b"
+)
 _FOR_TRIGGER_RE = re.compile(r"(?:^|[.!?]\s+)for (?:requests|tasks)\b")
 _EXPLANATORY_USER_TRIGGER_RE = re.compile(
     r"\b(?:what happens|what to expect) (?:when (?:the user|users)|if the user)\b"
 )
 _TRIGGER_MARKERS = (
     "use when",
+    "use only when",
     "when the user",
     "when users",
     "when you need",
@@ -51,6 +59,11 @@ class DescriptionRoutingRule(Rule):
             "default": True,
             "description": "Flag descriptions that only restate the name or generic category",
         },
+        "check-user-only-skills": {
+            "type": "bool",
+            "default": False,
+            "description": ("Check skills whose frontmatter sets disable-model-invocation to true"),
+        },
     }
 
     @property
@@ -76,6 +89,12 @@ class DescriptionRoutingRule(Rule):
         for block_type in (SkillBlock, AgentBlock, CommandBlock):
             for block in context.lint_tree.find(block_type):
                 if block.frontmatter_error:
+                    continue
+                if (
+                    block_type is SkillBlock
+                    and not self.config.get("check-user-only-skills", False)
+                    and block.field_value("disable-model-invocation") is True
+                ):
                     continue
                 if not block.has_frontmatter:
                     violations.append(
@@ -151,6 +170,7 @@ class DescriptionRoutingRule(Rule):
         return (
             any(marker in without_explanatory_clauses for marker in _TRIGGER_MARKERS)
             or bool(_USE_THIS_TRIGGER_RE.search(without_explanatory_clauses))
+            or bool(_PASSIVE_USE_TRIGGER_RE.search(without_explanatory_clauses))
             or bool(_FOR_TRIGGER_RE.search(without_explanatory_clauses))
         )
 

--- a/src/skillsaw/rules/builtin/description_routing.py
+++ b/src/skillsaw/rules/builtin/description_routing.py
@@ -10,14 +10,15 @@ from skillsaw.rules.builtin.content_analysis import AgentBlock, CommandBlock, Sk
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 _USE_THIS_TRIGGER_RE = re.compile(
-    r"\b(?:use|invoke) this(?: (?:skill|agent))?(?: proactively)? "
+    r"(?:^|[.!?—]\s+)(?:(?:you )?(?:must|should) )?"
+    r"(?:use|invoke) this(?: (?:skill|agent))?(?: proactively)? "
     r"(?:when(?:ever)?|if|before|for|to)\b"
 )
 _PASSIVE_USE_TRIGGER_RE = re.compile(
-    r"(?:^|[.!?]\s+)(?:this (?:skill|agent) )?(?:must|should) be used "
+    r"(?:^|[.!?—]\s+)(?:this (?:skill|agent) )?(?:must|should) be used "
     r"(?:when(?:ever)?|if|before)\b"
 )
-_FOR_TRIGGER_RE = re.compile(r"(?:^|[.!?]\s+)for (?:requests|tasks)\b")
+_FOR_TRIGGER_RE = re.compile(r"(?:^|[.!?—]\s+)for (?:requests|tasks)\b")
 _EXPLANATORY_USER_TRIGGER_RE = re.compile(
     r"\b(?:what happens|what to expect) (?:when (?:the user|users)|if the user)\b"
 )
@@ -92,7 +93,7 @@ class DescriptionRoutingRule(Rule):
                     continue
                 if (
                     block_type is SkillBlock
-                    and not self.config.get("check-user-only-skills", False)
+                    and self.config.get("check-user-only-skills", False) is not True
                     and block.field_value("disable-model-invocation") is True
                 ):
                     continue

--- a/src/skillsaw/rules/docs/description-routing.md
+++ b/src/skillsaw/rules/docs/description-routing.md
@@ -2,17 +2,27 @@ Checks that skill and agent descriptions work as routing signals, while command 
 
 ## What it checks
 
-- Descriptions are present, non-empty strings. This basic check is always on.
+- Descriptions are present, non-empty strings. This basic check stays on when the routing heuristics are disabled.
 - Skill and agent descriptions say when the model should use them. Commands are excluded because users select them directly.
 - Descriptions do more than restate the building block name or category, such as a `deploy-staging` skill described only as "Deploy staging" or a command described only as "A command."
 
-The two routing heuristics after the always-on empty check can be configured independently:
+Skills with `disable-model-invocation: true` are user-only: the model cannot route
+to them, so this rule skips them by default. Set `check-user-only-skills: true`
+to check their descriptions normally. Only the YAML boolean `true` opts a skill
+out; an absent field, `false`, strings, and numbers remain checked.
+
+Natural selection clauses count as trigger phrasing, including "Use this skill
+for ...", "Invoke this skill whenever ...", "This skill should be used before
+...", and "Use only when ...".
+
+The routing heuristics and user-only-skill behavior can be configured independently:
 
 ```yaml
 rules:
   description-routing:
     require-trigger-phrasing: true
     flag-name-restatement: true
+    check-user-only-skills: false
 ```
 
 ## Why this matters

--- a/tests/fixtures/description-routing-user-only/.claude/agents/field-true.md
+++ b/tests/fixtures/description-routing-user-only/.claude/agents/field-true.md
@@ -1,0 +1,9 @@
+---
+name: field-true
+description: Runs an internal workflow.
+disable-model-invocation: true
+---
+
+# Field true agent
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/commands/field-true.md
+++ b/tests/fixtures/description-routing-user-only/.claude/commands/field-true.md
@@ -1,0 +1,8 @@
+---
+description:
+disable-model-invocation: true
+---
+
+# Field true command
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-absent/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-absent/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: field-absent
+description: Runs an internal workflow.
+---
+
+# Field absent
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-false/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-false/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: field-false
+description: Runs an internal workflow.
+disable-model-invocation: false
+---
+
+# Field false
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-numeric-one/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-numeric-one/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: field-numeric-one
+description: Runs an internal workflow.
+disable-model-invocation: 1
+---
+
+# Field numeric one
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-string-true/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-string-true/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: field-string-true
+description: Runs an internal workflow.
+disable-model-invocation: "true"
+---
+
+# Field string true
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-true-empty/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-true-empty/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: field-true-empty
+description:
+disable-model-invocation: true
+---
+
+# Field true empty
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing-user-only/.claude/skills/field-true/SKILL.md
+++ b/tests/fixtures/description-routing-user-only/.claude/skills/field-true/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: field-true
+description: Runs an internal workflow.
+disable-model-invocation: true
+---
+
+# Field true
+
+Run the internal workflow.

--- a/tests/fixtures/description-routing/.claude/agents/oauth-explainer.md
+++ b/tests/fixtures/description-routing/.claude/agents/oauth-explainer.md
@@ -1,0 +1,8 @@
+---
+name: oauth-explainer
+description: Explains how to use this skill to configure OAuth.
+---
+
+# OAuth explainer
+
+Explain OAuth configuration without acting as a routing directive.

--- a/tests/fixtures/description-routing/.claude/skills/active-invoke-whenever/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/active-invoke-whenever/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: active-invoke-whenever
+description: Invoke this skill proactively whenever a command needs Snowflake data access.
+---
+
+# Active invoke whenever
+
+Verify Snowflake data access before running a command.

--- a/tests/fixtures/description-routing/.claude/skills/active-use-for/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/active-use-for/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: active-use-for
+description: Use this skill for Component Readiness triage duty.
+---
+
+# Active use for
+
+Triage Component Readiness regressions.

--- a/tests/fixtures/description-routing/.claude/skills/active-use-to/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/active-use-to/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: active-use-to
+description: Use this skill to implement TLS security profiles for OpenShift workloads.
+---
+
+# Active use to
+
+Implement TLS security profiles.

--- a/tests/fixtures/description-routing/.claude/skills/modal-after-em-dash/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/modal-after-em-dash/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: modal-after-em-dash
+description: Manage payload results — you must use this skill whenever reading or writing the results file.
+---
+
+# Modal after em dash
+
+Manage the payload results file safely.

--- a/tests/fixtures/description-routing/.claude/skills/passive-must-whenever/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/passive-must-whenever/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: passive-must-whenever
+description: MUST be used whenever triggering payload testing on a pull request.
+---
+
+# Passive must whenever
+
+Trigger payload testing with the required command syntax.

--- a/tests/fixtures/description-routing/.claude/skills/passive-should-before/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/passive-should-before/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: passive-should-before
+description: This skill should be used before any Snowflake command.
+---
+
+# Passive should before
+
+Verify Snowflake connectivity and session context.

--- a/tests/fixtures/description-routing/.claude/skills/use-only-when/SKILL.md
+++ b/tests/fixtures/description-routing/.claude/skills/use-only-when/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: use-only-when
+description: Run the lint fixer. Use only when explicitly asked to fix lint issues.
+---
+
+# Use only when
+
+Run the lint fixer and resolve reported issues.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2160,6 +2160,31 @@ class TestDescriptionRouting:
         rerun = run_lint(repo, "--rule", "description-routing")
         assert self._routing_violations(rerun) == vs
 
+    def test_accepts_explicit_trigger_phrase_variants(self, tmp_path):
+        """Accept active, passive, and restrictive selection clauses."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        result = run_lint(repo, "--rule", "description-routing")
+        routing_violations = self._routing_violations(result)
+        expected_clean = {
+            "active-invoke-whenever",
+            "active-use-for",
+            "active-use-to",
+            "passive-must-whenever",
+            "passive-should-before",
+            "use-only-when",
+        }
+        discovered = {Path(path).name for path in result["out"]["stats"]["skills"]}
+        flagged = {
+            path.parent.name if path.name == "SKILL.md" else path.stem
+            for violation in routing_violations
+            for path in [Path(violation["file_path"])]
+        }
+
+        assert expected_clean <= discovered
+        assert expected_clean.isdisjoint(flagged)
+        # Subject-matter wording remains distinct from a selection clause.
+        assert {"explainer", "sdk-guide", "user-event-explainer"} <= flagged
+
     def test_codex_only_command_without_description_is_reported(self, tmp_path):
         """Keep the always-on presence check active without Claude provenance."""
         repo = copy_fixture("codex/clean", tmp_path)
@@ -2216,6 +2241,57 @@ class TestDescriptionRouting:
         routing_violations = self._routing_violations(r)
         assert len(routing_violations) == expected_count
         assert not any(message in v["message"] for v in routing_violations)
+
+    def test_user_only_skills_are_skipped_only_for_exact_boolean_true(self, tmp_path):
+        """Default skipping is limited to the actual YAML boolean true."""
+        repo = copy_fixture("description-routing-user-only", tmp_path)
+
+        result = run_lint(repo, "--rule", "description-routing")
+        routing_violations = self._routing_violations(result)
+        skill_violations = [v for v in routing_violations if "skills" in Path(v["file_path"]).parts]
+        checked_skills = {Path(v["file_path"]).parent.name for v in skill_violations}
+
+        assert checked_skills == {
+            "field-absent",
+            "field-false",
+            "field-numeric-one",
+            "field-string-true",
+        }
+        assert all("when to use" in v["message"] for v in skill_violations)
+        assert any("agents/field-true.md" in v["file_path"] for v in routing_violations)
+        assert any("commands/field-true.md" in v["file_path"] for v in routing_violations)
+
+    def test_user_only_skills_can_be_checked_by_configuration(self, tmp_path):
+        """The opt-in checks a boolean-true user-only skill normally."""
+        repo = copy_fixture("description-routing-user-only", tmp_path)
+        config = repo / ".skillsaw.yaml"
+        config.write_text(
+            "rules:\n  description-routing:\n    check-user-only-skills: true\n",
+            encoding="utf-8",
+        )
+
+        result = run_lint(repo, config=config)
+        routing_violations = self._routing_violations(result)
+        skill_violations = [v for v in routing_violations if "skills" in Path(v["file_path"]).parts]
+        checked_skills = {Path(v["file_path"]).parent.name for v in skill_violations}
+
+        assert checked_skills == {
+            "field-absent",
+            "field-false",
+            "field-numeric-one",
+            "field-string-true",
+            "field-true",
+            "field-true-empty",
+        }
+        assert all(
+            "when to use" in v["message"]
+            for v in skill_violations
+            if "field-true-empty" not in v["file_path"]
+        )
+        assert any(
+            "field-true-empty" in v["file_path"] and "Description is empty" in v["message"]
+            for v in skill_violations
+        )
 
 
 class TestUnlinkedInternalReferenceAutofix:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2142,12 +2142,13 @@ class TestDescriptionRouting:
         r = run_lint(repo, "--rule", "description-routing")
         vs = self._routing_violations(r)
 
-        assert len(vs) == 11
+        assert len(vs) == 12
         assert all(v["severity"] == "warning" and v["line"] in {2, 3} for v in vs)
-        assert sum("when to use" in v["message"] for v in vs) == 6
+        assert sum("when to use" in v["message"] for v in vs) == 7
         assert sum("restates the name" in v["message"] for v in vs) == 3
         assert sum("Description is empty" in v["message"] for v in vs) == 2
         assert any("sdk-guide" in v["file_path"] for v in vs)
+        assert any("oauth-explainer" in v["file_path"] for v in vs)
         assert any("user-event-explainer" in v["file_path"] for v in vs)
         assert any("header-builder" in v["file_path"] for v in vs)
         assert any("generic-command" in v["file_path"] for v in vs)
@@ -2169,6 +2170,7 @@ class TestDescriptionRouting:
             "active-invoke-whenever",
             "active-use-for",
             "active-use-to",
+            "modal-after-em-dash",
             "passive-must-whenever",
             "passive-should-before",
             "use-only-when",
@@ -2183,7 +2185,7 @@ class TestDescriptionRouting:
         assert expected_clean <= discovered
         assert expected_clean.isdisjoint(flagged)
         # Subject-matter wording remains distinct from a selection clause.
-        assert {"explainer", "sdk-guide", "user-event-explainer"} <= flagged
+        assert {"explainer", "oauth-explainer", "sdk-guide", "user-event-explainer"} <= flagged
 
     def test_codex_only_command_without_description_is_reported(self, tmp_path):
         """Keep the always-on presence check active without Claude provenance."""
@@ -2221,7 +2223,7 @@ class TestDescriptionRouting:
         ("option", "message", "expected_count"),
         [
             ("require-trigger-phrasing", "when to use", 5),
-            ("flag-name-restatement", "restates the name", 8),
+            ("flag-name-restatement", "restates the name", 9),
         ],
     )
     def test_subchecks_can_be_disabled_independently(
@@ -2292,6 +2294,27 @@ class TestDescriptionRouting:
             "field-true-empty" in v["file_path"] and "Description is empty" in v["message"]
             for v in skill_violations
         )
+
+    def test_quoted_false_config_does_not_check_user_only_skills(self, tmp_path):
+        """A truthy string does not accidentally enable the boolean opt-in."""
+        repo = copy_fixture("description-routing-user-only", tmp_path)
+        config = repo / ".skillsaw.yaml"
+        config.write_text(
+            'rules:\n  description-routing:\n    check-user-only-skills: "false"\n',
+            encoding="utf-8",
+        )
+
+        result = run_lint(repo, config=config)
+        routing_violations = self._routing_violations(result)
+        skill_violations = [v for v in routing_violations if "skills" in Path(v["file_path"]).parts]
+        checked_skills = {Path(v["file_path"]).parent.name for v in skill_violations}
+
+        assert checked_skills == {
+            "field-absent",
+            "field-false",
+            "field-numeric-one",
+            "field-string-true",
+        }
 
 
 class TestUnlinkedInternalReferenceAutofix:


### PR DESCRIPTION
Follow-up to #412.

## Summary
- Skip skills with `disable-model-invocation: true` by default because they are user-invoked and unavailable to model routing.
- Add `check-user-only-skills: true` to opt those skills back into description checks.
- Recognize natural trigger clauses found during a fresh ai-helpers audit.
- Keep agents, commands, absent/false fields, and non-boolean lookalikes in scope.

## Corpus audit
Fresh `openshift-eng/ai-helpers` comparison: upstream produced 87 description-routing findings; this branch produced 79. The eight removed findings are the one user-only skill and seven verified trigger-phrase false positives. No findings were added, and manual inspection found no false positives among the remaining 79.

## Validation
- `make test` (3,636 passed)
- `make lint`
- `pytest -q tests/test_integration.py::TestDescriptionRouting` (8 passed)
- `make update` and self-lint
- medium benchmark showed no material regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved description routing checks to recognize more natural phrases, including active, passive, and restrictive wording.
  - Added an option to include user-only skills in validation checks.
- **Bug Fixes**
  - Refined routing validation for empty descriptions and commands.
  - Reduced false positives for valid trigger phrasing while continuing to flag unclear subject-matter descriptions.
- **Documentation**
  - Updated configuration examples and guidance for the enhanced routing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->