### PR TITLE
Fix macOS-only test failures ahead of 0.18.0 release

### DIFF
--- a/tests/test_instruction_file_rules.py
+++ b/tests/test_instruction_file_rules.py
@@ -15,8 +15,10 @@ from skillsaw.rules.builtin.instructions import (
 
 @pytest.fixture
 def temp_dir():
+    # Resolve symlinks (macOS /var -> /private/var) so path assertions match
+    # the resolved paths the imports rule reports for nested files.
     tmp = tempfile.mkdtemp()
-    yield Path(tmp)
+    yield Path(tmp).resolve()
     shutil.rmtree(tmp)
 
 


### PR DESCRIPTION
Pre-release cleanup for v0.18.0. The version files were already bumped to 0.18.0 in #484, so this PR carries only a test fix found during release pre-flight:

`make test` fails on macOS with 4 failures in `TestInstructionImportsValidRule`. `tempfile.mkdtemp()` returns `/var/folders/...` on macOS — a symlink to `/private/var/...` — and the `instruction-imports-valid` rule reports nested-import violations against `safe_resolve()`d paths (#480), so `file_path` equality assertions fail locally while passing on Linux CI, whose tempdir is not a symlink. Resolving the fixture's tempdir makes the assertions platform-independent.

Release validation against `openshift-eng/ai-helpers` passed: no new builtin findings vs 0.17.0, grade improves 0.93 → 0.47 weighted violations per 10k tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary-directory path handling for more reliable path assertions across environments with symlinked temporary directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->