### PR TITLE
Remove duplicated Agent Plugins rule text

### DIFF
--- a/docs/rules/agent-plugin-required.md
+++ b/docs/rules/agent-plugin-required.md
@@ -14,12 +14,6 @@ Plugins must also be available as vendor-neutral Agent Plugins v1 packages, with
 
 ## Why
 
-Agent Plugins v1 is the vendor-neutral plugin format: a root
-`plugin.json`, skills at `skills/*/SKILL.md`, and an optional portable
-`mcp.json`. It coexists with Claude Code and Codex formats in the same
-directory, so publishing it costs two generated files per plugin — and
-buys installation by any conforming client.
-
 Agent Plugins coexists with Claude Code and Codex formats in the same
 directory, so publishing it costs at most two generated files per
 plugin (`mcp.json` only when the plugin has MCP configuration) — and

--- a/docs/rules/agent-plugin-required.md
+++ b/docs/rules/agent-plugin-required.md
@@ -14,9 +14,10 @@ Plugins must also be available as vendor-neutral Agent Plugins v1 packages, with
 
 ## Why
 
-Agent Plugins coexists with Claude Code and Codex formats in the same
-directory, so publishing it costs at most two generated files per
-plugin (`mcp.json` only when the plugin has MCP configuration) — and
+Agent Plugins v1 is the vendor-neutral plugin format: a root
+`plugin.json`, skills at `skills/*/SKILL.md`, and an optional portable
+`mcp.json`. It coexists with Claude Code and Codex formats in the same
+directory, so publishing it costs two generated files per plugin — and
 buys installation by any conforming client.
 
 This opt-in rule turns that from a one-time conversion into a standing

--- a/src/skillsaw/rules/docs/agent-plugin-required.md
+++ b/src/skillsaw/rules/docs/agent-plugin-required.md
@@ -1,11 +1,5 @@
 ## Why
 
-Agent Plugins v1 is the vendor-neutral plugin format: a root
-`plugin.json`, skills at `skills/*/SKILL.md`, and an optional portable
-`mcp.json`. It coexists with Claude Code and Codex formats in the same
-directory, so publishing it costs two generated files per plugin — and
-buys installation by any conforming client.
-
 Agent Plugins coexists with Claude Code and Codex formats in the same
 directory, so publishing it costs at most two generated files per
 plugin (`mcp.json` only when the plugin has MCP configuration) — and

--- a/src/skillsaw/rules/docs/agent-plugin-required.md
+++ b/src/skillsaw/rules/docs/agent-plugin-required.md
@@ -1,8 +1,9 @@
 ## Why
 
-Agent Plugins coexists with Claude Code and Codex formats in the same
-directory, so publishing it costs at most two generated files per
-plugin (`mcp.json` only when the plugin has MCP configuration) — and
+Agent Plugins v1 is the vendor-neutral plugin format: a root
+`plugin.json`, skills at `skills/*/SKILL.md`, and an optional portable
+`mcp.json`. It coexists with Claude Code and Codex formats in the same
+directory, so publishing it costs two generated files per plugin — and
 buys installation by any conforming client.
 
 This opt-in rule turns that from a one-time conversion into a standing


### PR DESCRIPTION
## Summary

- Remove the duplicated explanation from the Agent Plugins rule documentation.
- Regenerate the tracked site page from its canonical source.

## Root cause

The source documentation contained both the original and refined versions of
the same explanation, so the generated public page displayed the passage twice.

## Validation

- `make lint` passed.
- Site content generation passed.
- `skillsaw lint --no-plugins --no-progress .` passed.
- `make test` was interrupted at 60% after reporting 2,857 passes and 117
  failures; the failures are dominated by the installed
  `skillsaw-runbooks` entry point failing to import `skillsaw_runbooks`.
- `make update` generated the site content but its self-lint reached the same
  missing-plugin import error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Agent Plugins v1 publishing requirements and generated file counts.
  * Updated rationale text to better explain when the optional MCP configuration file is included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->