### PR TITLE
Use fable model for labeled review panels

### DIFF
--- a/.github/workflows/skillsaw-review-panel.yml
+++ b/.github/workflows/skillsaw-review-panel.yml
@@ -41,7 +41,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools Agent,Edit,Write,Read,Bash,WebFetch,WebSearch,Skill,Glob,Grep,TaskCreate,TaskUpdate,TaskList,TaskGet
-            --model claude-opus-5
+            --model ${{ contains(github.event.pull_request.labels.*.name, 'fable-5') && 'claude-fable-5' || 'claude-opus-5' }}
 
       - name: Upload execution log
         if: always()


### PR DESCRIPTION
## Summary

- Select `claude-fable-5` for review-panel runs when the pull request has the `fable-5` label.
- Keep `claude-opus-5` as the default model.

## Why

The review-panel workflow previously hardcoded `claude-opus-5`, unlike the PR follow-up workflow, which already honors the `fable-5` label.

## Validation

- `make test` — 3,902 passed
- `make lint`
- `make update`
- `skillsaw lint` against `openshift-eng/ai-helpers` — exit 0 with one existing deprecation warning
