### PR TITLE
Rename the action for Marketplace listing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'skillsaw'
+name: 'Skillsaw Agent Context Linter'
 description: 'Lint agent skills, plugins, and AI coding assistant context'
 branding:
-  icon: 'check-circle'
-  color: 'green'
+  icon: 'settings'
+  color: 'orange'
 
 inputs:
   path:


### PR DESCRIPTION
## Summary

Renames the GitHub Action's Marketplace listing name from `skillsaw` to **Skillsaw Agent Context Linter**, unblocking the 0.20 Marketplace publish: the Marketplace refuses a listing whose name matches an existing GitHub user, and a user named `skillsaw` exists.

- **Zero impact on existing workflows** — `uses: stbenjam/skillsaw@<ref>` resolves by repository path, never by the listing name; every documented `uses:` reference stays valid verbatim.
- The action has never been listed, so there is no existing marketplace slug to break — this is the last free moment to pick the name.
- Branding moves from the generic `check-circle`/green to the `settings` gear in orange — the closest Feather icon to a circular saw blade, in power-tool livery.

## Test plan

- [x] `make test` — 4656 passed
- [x] `make lint` clean; `make update` clean (only action.yml changed)
- [x] `openshift-eng/ai-helpers` exits 0
- [x] `test_release_metadata` still green (it pins the `version` input default, not the name)

Assisted-by: Claude:claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Qt3WNQCWATbFrjxLQZPL