### PR TITLE
Simplify report cards to grade only

### DIFF
--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -4,7 +4,6 @@
   <style>
     .title { font: 600 16px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .subtitle { font: 400 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
-    .grade-label { font: 600 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; letter-spacing: 1.4px; }
     .grade-letter { font: 800 48px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #44cc11; }
   </style>
   <rect x="0.5" y="0.5" width="494" height="194" rx="4.5" fill="#0d1117" stroke="#30363d"/>
@@ -12,9 +11,8 @@
     <path fill-rule="evenodd" fill="#44cc11" d="M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z"/>
   </g>
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
-  <text x="56" y="46" class="subtitle">skillsaw grade</text>
+  <text x="56" y="46" class="subtitle">Agent Context Linter</text>
   <path d="M24 63.5H471" stroke="#30363d"/>
-  <text x="247.5" y="81" text-anchor="middle" class="grade-label">OVERALL GRADE</text>
   <g transform="translate(247.5, 127)">
     <circle r="42" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>
     <circle r="42" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="263.89 263.89"/>

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -4,14 +4,18 @@
   <style>
     .title { font: 600 16px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .subtitle { font: 400 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
+    .repo-label { font: 600 9px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; letter-spacing: 1px; }
+    .repo-name { font: 600 13px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .grade-letter { font: 800 48px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #44cc11; }
   </style>
   <rect x="0.5" y="0.5" width="494" height="194" rx="4.5" fill="#0d1117" stroke="#30363d"/>
   <g transform="translate(24, 17)">
     <path fill-rule="evenodd" fill="#44cc11" d="M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z"/>
   </g>
-  <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
+  <text x="56" y="30" class="title" data-testid="product-name">skillsaw</text>
   <text x="56" y="46" class="subtitle">Agent Context Linter</text>
+  <text x="471" y="27" text-anchor="end" class="repo-label">REPOSITORY</text>
+  <text x="471" y="46" text-anchor="end" class="repo-name" data-testid="repo-name">skillsaw</text>
   <path d="M24 63.5H471" stroke="#30363d"/>
   <g transform="translate(247.5, 127)">
     <circle r="42" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -4,7 +4,8 @@
   <style>
     .title { font: 600 16px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .subtitle { font: 400 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
-    .grade-letter { font: 800 44px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #44cc11; }
+    .grade-label { font: 600 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; letter-spacing: 1.4px; }
+    .grade-letter { font: 800 48px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #44cc11; }
   </style>
   <rect x="0.5" y="0.5" width="494" height="194" rx="4.5" fill="#0d1117" stroke="#30363d"/>
   <g transform="translate(24, 17)">
@@ -12,9 +13,11 @@
   </g>
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
   <text x="56" y="46" class="subtitle">skillsaw grade</text>
-  <g transform="translate(415.5, 97.5)">
-    <circle r="46" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>
-    <circle r="46" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="289.03 289.03"/>
+  <path d="M24 63.5H471" stroke="#30363d"/>
+  <text x="247.5" y="81" text-anchor="middle" class="grade-label">OVERALL GRADE</text>
+  <g transform="translate(247.5, 127)">
+    <circle r="42" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>
+    <circle r="42" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="263.89 263.89"/>
     <text y="16" text-anchor="middle" class="grade-letter" data-testid="grade-letter">A+</text>
   </g>
 </svg>

--- a/.skillsaw-card.svg
+++ b/.skillsaw-card.svg
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="495" height="195" viewBox="0 0 495 195" fill="none" role="img" aria-labelledby="card-title">
-  <title id="card-title">skillsaw report card for skillsaw: grade A+</title>
+  <title id="card-title">skillsaw grade for skillsaw: A+</title>
   <style>
     .title { font: 600 16px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #e6edf3; }
     .subtitle { font: 400 11px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
-    .label { font: 600 13px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #c9d1d9; }
-    .value { font: 400 13px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #c9d1d9; }
-    .rule { font: 400 11.5px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #8b949e; }
     .grade-letter { font: 800 44px 'Segoe UI', Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif; fill: #44cc11; }
   </style>
   <rect x="0.5" y="0.5" width="494" height="194" rx="4.5" fill="#0d1117" stroke="#30363d"/>
@@ -14,16 +11,7 @@
     <path fill-rule="evenodd" fill="#44cc11" d="M20.0 12.0L22.3 15.8L19.3 15.3L17.7 17.7L16.6 22.0L14.8 19.5L12.0 20.0L8.2 22.3L8.7 19.3L6.3 17.7L2.0 16.6L4.5 14.8L4.0 12.0L1.7 8.2L4.7 8.7L6.3 6.3L7.4 2.0L9.2 4.5L12.0 4.0L15.8 1.7L15.3 4.7L17.7 6.3L22.0 7.4L19.5 9.2ZM15.0 12.0A3.0 3.0 0 1 0 9.0 12.0A3.0 3.0 0 1 0 15.0 12.0Z"/>
   </g>
   <text x="56" y="30" class="title" data-testid="repo-name">skillsaw</text>
-  <text x="56" y="46" class="subtitle">skillsaw report card</text>
-  <g data-testid="stats">
-    <text x="24" y="76"><tspan class="label">Violation density</tspan><tspan x="180" class="value"><tspan data-testid="density">0.27</tspan> per 10k tokens</tspan></text>
-    <text x="24" y="97"><tspan class="label">Content tokens</tspan><tspan x="180" class="value">~<tspan data-testid="tokens">37,264</tspan></tspan></text>
-    <text x="24" y="118"><tspan class="label">Building blocks</tspan><tspan x="180" class="value"><tspan data-testid="plugins">1</tspan> plugin &#183; <tspan data-testid="skills">11</tspan> skills</tspan></text>
-    <text x="24" y="139" class="label">Top rules</text>
-    <text x="24" y="154" class="rule" data-testid="rule-0">1. content-inconsistent-terminology (5)</text>
-    <text x="24" y="168" class="rule" data-testid="rule-1">2. content-unlinked-internal-reference (3)</text>
-    <text x="24" y="182" class="rule" data-testid="rule-2">3. content-section-length (2)</text>
-  </g>
+  <text x="56" y="46" class="subtitle">skillsaw grade</text>
   <g transform="translate(415.5, 97.5)">
     <circle r="46" fill="none" stroke="#44cc11" stroke-opacity="0.25" stroke-width="7"/>
     <circle r="46" fill="none" stroke="#44cc11" stroke-width="7" stroke-linecap="round" transform="rotate(-90)" stroke-dasharray="289.03 289.03"/>

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -156,10 +156,8 @@ the inline comments it handled, leaving thread resolution to a collaborator.
 
 `skillsaw badge` writes `.skillsaw-badge.json` (a shields.io endpoint
 payload) and prints ready-to-paste README markdown. Add `--large` to also
-render `.skillsaw-card.svg` — a self-contained SVG card showing the repository
-name and letter grade. It omits volatile density, token, building-block, and
-rule counts, so a generated card changes only when the grade changes (`--theme
-light|dark`, default dark):
+render `.skillsaw-card.svg` — a self-contained SVG card with the repository
+name and letter grade (`--theme light|dark`, default dark):
 
 ![skillsaw's own report card, dark theme (the default)](https://raw.githubusercontent.com/stbenjam/skillsaw/main/.skillsaw-card.svg)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -156,10 +156,10 @@ the inline comments it handled, leaving thread resolution to a collaborator.
 
 `skillsaw badge` writes `.skillsaw-badge.json` (a shields.io endpoint
 payload) and prints ready-to-paste README markdown. Add `--large` to also
-render `.skillsaw-card.svg` — a self-contained SVG report card showing
-the letter grade, weighted violation density, content-token count,
-plugin/skill counts, and the top offending rules (`--theme light|dark`,
-default dark):
+render `.skillsaw-card.svg` — a self-contained SVG card showing the repository
+name and letter grade. It omits volatile density, token, building-block, and
+rule counts, so a generated card changes only when the grade changes (`--theme
+light|dark`, default dark):
 
 ![skillsaw's own report card, dark theme (the default)](https://raw.githubusercontent.com/stbenjam/skillsaw/main/.skillsaw-card.svg)
 

--- a/src/skillsaw/card.py
+++ b/src/skillsaw/card.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import math
 import unicodedata
-from typing import Sequence, Tuple
 from xml.sax.saxutils import escape
 
 from .grade import LETTER_NOTCHES, LOGO_PATH, Grade
@@ -102,17 +101,11 @@ def _truncate(text: str, max_width: int) -> str:
 def render_card(
     grade: Grade,
     repo_name: str,
-    plugin_count: int,
-    skill_count: int,
-    top_rules: Sequence[Tuple[str, int]],
     theme: str = "dark",
 ) -> str:
     """Render a grade-focused SVG card.
 
-    The non-grade parameters are retained for source compatibility with
-    callers from versions that displayed repository statistics. The
-    repository name remains visible; the counts and rule list are deliberately
-    ignored so only a grade change alters the SVG during normal operation.
+    The card contains the repository name and grade.
     """
     if theme not in THEMES:
         raise ValueError(f"unknown theme {theme!r} (choose from {', '.join(sorted(THEMES))})")

--- a/src/skillsaw/card.py
+++ b/src/skillsaw/card.py
@@ -159,7 +159,6 @@ def render_card(
         "  <style>",
         f"    .title {{ font: 600 16px {_FONTS}; fill: {colors['title']}; }}",
         f"    .subtitle {{ font: 400 11px {_FONTS}; fill: {colors['muted']}; }}",
-        f"    .grade-label {{ font: 600 11px {_FONTS}; fill: {colors['muted']}; letter-spacing: 1.4px; }}",
         f"    .grade-letter {{ font: 800 48px {_FONTS}; fill: {accent}; }}",
         "  </style>",
         (
@@ -170,9 +169,8 @@ def render_card(
         f'    <path fill-rule="evenodd" fill="{accent}" d="{LOGO_PATH}"/>',
         "  </g>",
         f'  <text x="56" y="30" class="title" data-testid="repo-name">{name}</text>',
-        '  <text x="56" y="46" class="subtitle">skillsaw grade</text>',
+        '  <text x="56" y="46" class="subtitle">Agent Context Linter</text>',
         f'  <path d="M24 63.5H471" stroke="{colors["border"]}"/>',
-        '  <text x="247.5" y="81" text-anchor="middle" class="grade-label">OVERALL GRADE</text>',
         '  <g transform="translate(247.5, 127)">',
         (
             f'    <circle r="{_RING_RADIUS}" fill="none" stroke="{accent}"'

--- a/src/skillsaw/card.py
+++ b/src/skillsaw/card.py
@@ -114,7 +114,7 @@ def render_card(
     # and an on-scale letter, but a public function shouldn't crash on
     # unexpected inputs.
     accent = SHIELDS_COLOR_HEX.get(grade.color, "#888888")
-    name = escape(_truncate(repo_name or "repository", 30))
+    name = escape(_truncate(repo_name or "repository", 20))
     letter = escape(grade.letter)
 
     # Ring fill reflects the grade's position on the fixed notch scale
@@ -152,6 +152,8 @@ def render_card(
         "  <style>",
         f"    .title {{ font: 600 16px {_FONTS}; fill: {colors['title']}; }}",
         f"    .subtitle {{ font: 400 11px {_FONTS}; fill: {colors['muted']}; }}",
+        f"    .repo-label {{ font: 600 9px {_FONTS}; fill: {colors['muted']}; letter-spacing: 1px; }}",
+        f"    .repo-name {{ font: 600 13px {_FONTS}; fill: {colors['title']}; }}",
         f"    .grade-letter {{ font: 800 48px {_FONTS}; fill: {accent}; }}",
         "  </style>",
         (
@@ -161,8 +163,10 @@ def render_card(
         '  <g transform="translate(24, 17)">',
         f'    <path fill-rule="evenodd" fill="{accent}" d="{LOGO_PATH}"/>',
         "  </g>",
-        f'  <text x="56" y="30" class="title" data-testid="repo-name">{name}</text>',
+        '  <text x="56" y="30" class="title" data-testid="product-name">skillsaw</text>',
         '  <text x="56" y="46" class="subtitle">Agent Context Linter</text>',
+        f'  <text x="471" y="27" text-anchor="end" class="repo-label">REPOSITORY</text>',
+        f'  <text x="471" y="46" text-anchor="end" class="repo-name" data-testid="repo-name">{name}</text>',
         f'  <path d="M24 63.5H471" stroke="{colors["border"]}"/>',
         '  <g transform="translate(247.5, 127)">',
         (

--- a/src/skillsaw/card.py
+++ b/src/skillsaw/card.py
@@ -1,8 +1,8 @@
-"""Self-contained SVG report card for ``skillsaw badge --large``.
+"""Self-contained SVG grade card for ``skillsaw badge --large``.
 
-Renders a fixed-size (495x195 viewBox) github-readme-stats style card
-showing the letter grade, weighted violation density, content-token
-count, plugin/skill counts, and the top offending rules.
+Renders a fixed-size (495x195 viewBox) card showing the repository name and
+letter grade. The SVG must not churn when a repository's context size or
+individual rule counts change without changing its grade.
 
 Invariants:
 
@@ -72,9 +72,7 @@ def _char_width(ch: str) -> int:
 
     East-Asian Wide and Fullwidth glyphs (CJK, most emoji) render at
     roughly twice the advance width of an ASCII character in the card's
-    proportional font stack, so they count double toward the layout
-    budget. Everything else — including ambiguous-width characters,
-    which render narrow outside East Asian contexts — counts one.
+    proportional font stack, so they count double toward the layout budget.
     """
     return 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
 
@@ -87,10 +85,7 @@ def _truncate(text: str, max_width: int) -> str:
     """Truncate *text* to an estimated display width, appending "…".
 
     ``max_width`` is a budget in ASCII-character columns (see
-    :func:`_char_width`), not a character count — a checkout directory
-    named in CJK would otherwise keep enough double-width glyphs to run
-    past the card's fixed 495px viewBox. For pure-ASCII input this is
-    identical to a plain character-count limit.
+    :func:`_char_width`), not a character count.
     """
     if _display_width(text) <= max_width:
         return text
@@ -104,13 +99,6 @@ def _truncate(text: str, max_width: int) -> str:
     return text  # pragma: no cover — the early return above always fires
 
 
-def _stat_row(y: int, label: str, value_markup: str) -> str:
-    return (
-        f'    <text x="24" y="{y}"><tspan class="label">{label}</tspan>'
-        f'<tspan x="180" class="value">{value_markup}</tspan></text>'
-    )
-
-
 def render_card(
     grade: Grade,
     repo_name: str,
@@ -119,11 +107,12 @@ def render_card(
     top_rules: Sequence[Tuple[str, int]],
     theme: str = "dark",
 ) -> str:
-    """Render the report card as an SVG string.
+    """Render a grade-focused SVG card.
 
-    ``top_rules`` is a list of ``(rule_id, violation_count)`` pairs,
-    most frequent first (``Counter.most_common(3)``); at most three are
-    shown.
+    The non-grade parameters are retained for source compatibility with
+    callers from versions that displayed repository statistics. The
+    repository name remains visible; the counts and rule list are deliberately
+    ignored so only a grade change alters the SVG during normal operation.
     """
     if theme not in THEMES:
         raise ValueError(f"unknown theme {theme!r} (choose from {', '.join(sorted(THEMES))})")
@@ -159,29 +148,6 @@ def render_card(
             )
         ]
 
-    if top_rules:
-        rules_block = ['    <text x="24" y="139" class="label">Top rules</text>']
-        for i, (rule_id, count) in enumerate(list(top_rules)[:3]):
-            label = escape(f"{i + 1}. {_truncate(rule_id, 40)} ({count})")
-            rules_block.append(
-                f'    <text x="24" y="{154 + 14 * i}" class="rule"'
-                f' data-testid="rule-{i}">{label}</text>'
-            )
-    else:
-        # A violation-free run gets a positive line instead of a "Top
-        # rules" header with nothing to list under it.
-        rules_block = [
-            '    <text x="24" y="139" class="label" data-testid="rule-none">'
-            "No violations — clean run</text>"
-        ]
-
-    plugin_word = "plugin" if plugin_count == 1 else "plugins"
-    skill_word = "skill" if skill_count == 1 else "skills"
-    plugins_value = (
-        f'<tspan data-testid="plugins">{plugin_count}</tspan> {plugin_word}'
-        f' &#183; <tspan data-testid="skills">{skill_count}</tspan> {skill_word}'
-    )
-
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         (
@@ -189,13 +155,10 @@ def render_card(
             f' height="{CARD_HEIGHT}" viewBox="0 0 {CARD_WIDTH} {CARD_HEIGHT}"'
             ' fill="none" role="img" aria-labelledby="card-title">'
         ),
-        f'  <title id="card-title">skillsaw report card for {name}: grade {letter}</title>',
+        f'  <title id="card-title">skillsaw grade for {name}: {letter}</title>',
         "  <style>",
         f"    .title {{ font: 600 16px {_FONTS}; fill: {colors['title']}; }}",
         f"    .subtitle {{ font: 400 11px {_FONTS}; fill: {colors['muted']}; }}",
-        f"    .label {{ font: 600 13px {_FONTS}; fill: {colors['text']}; }}",
-        f"    .value {{ font: 400 13px {_FONTS}; fill: {colors['text']}; }}",
-        f"    .rule {{ font: 400 11.5px {_FONTS}; fill: {colors['muted']}; }}",
         f"    .grade-letter {{ font: 800 44px {_FONTS}; fill: {accent}; }}",
         "  </style>",
         (
@@ -206,21 +169,7 @@ def render_card(
         f'    <path fill-rule="evenodd" fill="{accent}" d="{LOGO_PATH}"/>',
         "  </g>",
         f'  <text x="56" y="30" class="title" data-testid="repo-name">{name}</text>',
-        '  <text x="56" y="46" class="subtitle">skillsaw report card</text>',
-        '  <g data-testid="stats">',
-        _stat_row(
-            76,
-            "Violation density",
-            f'<tspan data-testid="density">{grade.density:.2f}</tspan> per 10k tokens',
-        ),
-        _stat_row(
-            97,
-            "Content tokens",
-            f'~<tspan data-testid="tokens">{grade.content_tokens:,}</tspan>',
-        ),
-        _stat_row(118, "Building blocks", plugins_value),
-        *rules_block,
-        "  </g>",
+        '  <text x="56" y="46" class="subtitle">skillsaw grade</text>',
         '  <g transform="translate(415.5, 97.5)">',
         (
             f'    <circle r="{_RING_RADIUS}" fill="none" stroke="{accent}"'

--- a/src/skillsaw/card.py
+++ b/src/skillsaw/card.py
@@ -63,7 +63,7 @@ THEMES = {
 
 # Grade-ring geometry. The circumference is derived from the radius so
 # the two can never drift apart; both are rendered rounded to 2 decimals.
-_RING_RADIUS = 46
+_RING_RADIUS = 42
 _RING_CIRCUMFERENCE = 2 * math.pi * _RING_RADIUS
 
 
@@ -159,7 +159,8 @@ def render_card(
         "  <style>",
         f"    .title {{ font: 600 16px {_FONTS}; fill: {colors['title']}; }}",
         f"    .subtitle {{ font: 400 11px {_FONTS}; fill: {colors['muted']}; }}",
-        f"    .grade-letter {{ font: 800 44px {_FONTS}; fill: {accent}; }}",
+        f"    .grade-label {{ font: 600 11px {_FONTS}; fill: {colors['muted']}; letter-spacing: 1.4px; }}",
+        f"    .grade-letter {{ font: 800 48px {_FONTS}; fill: {accent}; }}",
         "  </style>",
         (
             f'  <rect x="0.5" y="0.5" width="{CARD_WIDTH - 1}" height="{CARD_HEIGHT - 1}"'
@@ -170,7 +171,9 @@ def render_card(
         "  </g>",
         f'  <text x="56" y="30" class="title" data-testid="repo-name">{name}</text>',
         '  <text x="56" y="46" class="subtitle">skillsaw grade</text>',
-        '  <g transform="translate(415.5, 97.5)">',
+        f'  <path d="M24 63.5H471" stroke="{colors["border"]}"/>',
+        '  <text x="247.5" y="81" text-anchor="middle" class="grade-label">OVERALL GRADE</text>',
+        '  <g transform="translate(247.5, 127)">',
         (
             f'    <circle r="{_RING_RADIUS}" fill="none" stroke="{accent}"'
             ' stroke-opacity="0.25" stroke-width="7"/>'

--- a/src/skillsaw/cli/_badge.py
+++ b/src/skillsaw/cli/_badge.py
@@ -145,9 +145,6 @@ def _run_badge(args):
                 render_card(
                     grade,
                     repo_name=_repo_display_name(context.root_path),
-                    plugin_count=0,
-                    skill_count=0,
-                    top_rules=[],
                     theme=getattr(args, "theme", "dark"),
                 ).encode("utf-8"),
                 root=context.root_path if args.output is None else badge_path.parent,

--- a/src/skillsaw/cli/_badge.py
+++ b/src/skillsaw/cli/_badge.py
@@ -32,12 +32,7 @@ def _git(root_path: Path, *argv):
 
 
 def _repo_display_name(root_path: Path) -> str:
-    """Repository name shown on the report card.
-
-    Prefers the origin remote's repository basename — checkout directory
-    names vary (forks, CI workspaces, worktrees) while the remote does
-    not — and falls back to the directory name.
-    """
+    """Repository name shown on the grade card."""
     remote = _git(root_path, "remote", "get-url", "origin")
     if remote:
         name = remote.rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
@@ -141,10 +136,7 @@ def _run_badge(args):
 
     card_path = None
     if getattr(args, "large", False):
-        from collections import Counter
-
         from ..card import render_card
-        from ..lint_target import SkillNode
 
         card_path = badge_path.parent / _CARD_FILENAME
         try:
@@ -153,11 +145,9 @@ def _run_badge(args):
                 render_card(
                     grade,
                     repo_name=_repo_display_name(context.root_path),
-                    # The deduplicated Claude∪Codex count every formatter
-                    # reports; PluginNode covers only Claude-style directories.
-                    plugin_count=len(context.distinct_plugin_dirs()),
-                    skill_count=len(context.lint_tree.find(SkillNode)),
-                    top_rules=Counter(v.rule_id for v in violations).most_common(3),
+                    plugin_count=0,
+                    skill_count=0,
+                    top_rules=[],
                     theme=getattr(args, "theme", "dark"),
                 ).encode("utf-8"),
                 root=context.root_path if args.output is None else badge_path.parent,

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -70,18 +70,34 @@ def test_card_is_valid_xml_with_fixed_viewbox():
     assert root.get("height") == str(CARD_HEIGHT)
 
 
-def test_card_shows_grade_and_stats():
+def test_card_shows_grade_without_volatile_stats():
     grade = compute_grade(_violations(warnings=5, info=3), content_tokens=12_345)
     svg = _render(grade=grade)
     fields = _texts_by_testid(svg)
     assert fields["grade-letter"] == grade.letter
-    assert fields["repo-name"] == "example/repo"
-    assert fields["density"] == f"{grade.density:.2f}"
-    assert fields["tokens"] == "12,345"
-    assert fields["plugins"] == "3"
-    assert fields["skills"] == "12"
-    assert fields["rule-0"] == "1. content-vague (5)"
-    assert fields["rule-1"] == "2. skill-frontmatter (3)"
+    assert fields == {"repo-name": "example/repo", "grade-letter": grade.letter}
+    assert "Violation density" not in svg
+    assert "Content tokens" not in svg
+    assert "Top rules" not in svg
+
+
+def test_card_is_unchanged_when_non_grade_inputs_change():
+    grade = compute_grade(_violations(warnings=5), content_tokens=10_000)
+    first = _render(
+        grade=grade,
+        repo_name="first/repo",
+        plugin_count=1,
+        skill_count=2,
+        top_rules=[("content-vague", 5)],
+    )
+    second = _render(
+        grade=grade,
+        repo_name="first/repo",
+        plugin_count=99,
+        skill_count=1_000,
+        top_rules=[("different-rule", 1_000)],
+    )
+    assert first == second
 
 
 def test_card_letter_is_color_graded():
@@ -153,34 +169,25 @@ def test_card_escapes_repo_name():
 
 
 def test_card_truncates_long_names():
-    svg = _render(repo_name="x" * 100, top_rules=[("y" * 100, 1)])
+    svg = _render(repo_name="x" * 100)
     fields = _texts_by_testid(svg)
     assert len(fields["repo-name"]) <= 30
     assert fields["repo-name"].endswith("…")
-    assert len(fields["rule-0"]) < 50
 
 
 def test_card_ascii_truncation_behavior_unchanged():
-    # For pure-ASCII names the width-aware truncation must be identical
-    # to the old 30-character limit.
     assert _texts_by_testid(_render(repo_name="x" * 100))["repo-name"] == "x" * 29 + "…"
     exactly_thirty = "a" * 30
     assert _texts_by_testid(_render(repo_name=exactly_thirty))["repo-name"] == exactly_thirty
 
 
 def test_card_truncates_wide_glyph_names_by_display_width():
-    # Regression: a 31-glyph CJK checkout-directory name (the fallback
-    # when there is no origin remote). CJK glyphs render ~2 ASCII columns
-    # wide at the title's 16px, so the old character-count limit kept
-    # ~480px of text starting at x=56 and overflowed the 495px viewBox.
     from skillsaw.card import _display_width
 
     name = "日本語プロジェクト管理支援用大規模開発環境設定集約リポジトリ超"
-    assert len(name) == 31
     shown = _texts_by_testid(_render(repo_name=name))["repo-name"]
     assert shown.endswith("…")
     assert _display_width(shown) <= 30
-    # 14 double-width glyphs plus a single-column ellipsis = 29 columns.
     assert shown == name[:14] + "…"
 
 
@@ -190,28 +197,6 @@ def test_card_mixed_width_names_share_the_budget():
     shown = _texts_by_testid(_render(repo_name="skill-日本語-" + "z" * 40))["repo-name"]
     assert shown.endswith("…")
     assert _display_width(shown) <= 30
-
-
-def test_card_without_violations_shows_clean_run():
-    svg = _render(grade=compute_grade([], content_tokens=10_000), top_rules=[])
-    fields = _texts_by_testid(svg)
-    assert "rule-0" not in fields
-    # No dangling "Top rules" header over an empty list — a single
-    # positive line takes its place.
-    assert fields["rule-none"] == "No violations — clean run"
-    assert "Top rules" not in svg
-
-
-def test_card_shows_at_most_three_rules():
-    svg = _render(top_rules=[(f"rule-{i}", 9 - i) for i in range(6)])
-    fields = _texts_by_testid(svg)
-    assert "rule-2" in fields
-    assert "rule-3" not in fields
-
-
-def test_card_empty_repo_name_falls_back():
-    fields = _texts_by_testid(_render(repo_name=""))
-    assert fields["repo-name"] == "repository"
 
 
 def test_f_grade_draws_empty_ring_without_stray_dot():
@@ -275,11 +260,8 @@ def test_badge_card_writes_svg(tmp_path):
     assert card_file.exists()
     svg = card_file.read_text(encoding="utf-8")
     fields = _texts_by_testid(svg)
-    # marketplace/clean has 3 plugins and 2 skills.
-    assert fields["plugins"] == "3"
-    assert fields["skills"] == "2"
     assert fields["grade-letter"]
-    assert fields["repo-name"] == repo.name
+    assert fields == {"repo-name": repo.name, "grade-letter": fields["grade-letter"]}
 
     # Dark theme is the default.
     assert THEMES["dark"]["bg"] in svg
@@ -410,7 +392,6 @@ def test_run_badge_in_process_with_remote(tmp_path, capsys):
     assert "raw.githubusercontent.com/acme/mkt/main/.skillsaw-card.svg" in out
     svg = (repo / ".skillsaw-card.svg").read_text(encoding="utf-8")
     assert THEMES["light"]["bg"] in svg
-    # The card shows the remote's repo basename, not the checkout dirname.
     assert _texts_by_testid(svg)["repo-name"] == "mkt"
 
 
@@ -419,7 +400,6 @@ def test_repo_display_name(tmp_path):
 
     repo = tmp_path / "checkout-dir"
     repo.mkdir()
-    # Not a git repo, then a repo without a remote: directory name.
     assert _repo_display_name(repo) == "checkout-dir"
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
     assert _repo_display_name(repo) == "checkout-dir"

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -72,7 +72,11 @@ def test_card_shows_grade_without_volatile_stats():
     svg = _render(grade=grade)
     fields = _texts_by_testid(svg)
     assert fields["grade-letter"] == grade.letter
-    assert fields == {"repo-name": "example/repo", "grade-letter": grade.letter}
+    assert fields == {
+        "product-name": "skillsaw",
+        "repo-name": "example/repo",
+        "grade-letter": grade.letter,
+    }
     assert "Violation density" not in svg
     assert "Content tokens" not in svg
     assert "Top rules" not in svg
@@ -146,14 +150,14 @@ def test_card_escapes_repo_name():
 def test_card_truncates_long_names():
     svg = _render(repo_name="x" * 100)
     fields = _texts_by_testid(svg)
-    assert len(fields["repo-name"]) <= 30
+    assert len(fields["repo-name"]) <= 20
     assert fields["repo-name"].endswith("…")
 
 
 def test_card_ascii_truncation_behavior_unchanged():
-    assert _texts_by_testid(_render(repo_name="x" * 100))["repo-name"] == "x" * 29 + "…"
-    exactly_thirty = "a" * 30
-    assert _texts_by_testid(_render(repo_name=exactly_thirty))["repo-name"] == exactly_thirty
+    assert _texts_by_testid(_render(repo_name="x" * 100))["repo-name"] == "x" * 19 + "…"
+    exactly_twenty = "a" * 20
+    assert _texts_by_testid(_render(repo_name=exactly_twenty))["repo-name"] == exactly_twenty
 
 
 def test_card_truncates_wide_glyph_names_by_display_width():
@@ -162,8 +166,8 @@ def test_card_truncates_wide_glyph_names_by_display_width():
     name = "日本語プロジェクト管理支援用大規模開発環境設定集約リポジトリ超"
     shown = _texts_by_testid(_render(repo_name=name))["repo-name"]
     assert shown.endswith("…")
-    assert _display_width(shown) <= 30
-    assert shown == name[:14] + "…"
+    assert _display_width(shown) <= 20
+    assert shown == name[:9] + "…"
 
 
 def test_card_mixed_width_names_share_the_budget():
@@ -171,7 +175,7 @@ def test_card_mixed_width_names_share_the_budget():
 
     shown = _texts_by_testid(_render(repo_name="skill-日本語-" + "z" * 40))["repo-name"]
     assert shown.endswith("…")
-    assert _display_width(shown) <= 30
+    assert _display_width(shown) <= 20
 
 
 def test_f_grade_draws_empty_ring_without_stray_dot():
@@ -236,7 +240,11 @@ def test_badge_card_writes_svg(tmp_path):
     svg = card_file.read_text(encoding="utf-8")
     fields = _texts_by_testid(svg)
     assert fields["grade-letter"]
-    assert fields == {"repo-name": repo.name, "grade-letter": fields["grade-letter"]}
+    assert fields == {
+        "product-name": "skillsaw",
+        "repo-name": repo.name,
+        "grade-letter": fields["grade-letter"],
+    }
 
     # Dark theme is the default.
     assert THEMES["dark"]["bg"] in svg

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -35,9 +35,6 @@ def _render(**overrides):
     kwargs = dict(
         grade=compute_grade(_violations(warnings=5, info=3), content_tokens=12_345),
         repo_name="example/repo",
-        plugin_count=3,
-        skill_count=12,
-        top_rules=[("content-vague", 5), ("skill-frontmatter", 3)],
         theme="light",
     )
     kwargs.update(overrides)
@@ -79,25 +76,6 @@ def test_card_shows_grade_without_volatile_stats():
     assert "Violation density" not in svg
     assert "Content tokens" not in svg
     assert "Top rules" not in svg
-
-
-def test_card_is_unchanged_when_non_grade_inputs_change():
-    grade = compute_grade(_violations(warnings=5), content_tokens=10_000)
-    first = _render(
-        grade=grade,
-        repo_name="first/repo",
-        plugin_count=1,
-        skill_count=2,
-        top_rules=[("content-vague", 5)],
-    )
-    second = _render(
-        grade=grade,
-        repo_name="first/repo",
-        plugin_count=99,
-        skill_count=1_000,
-        top_rules=[("different-rule", 1_000)],
-    )
-    assert first == second
 
 
 def test_card_letter_is_color_graded():
@@ -149,9 +127,6 @@ def test_default_theme_is_dark():
     kwargs = dict(
         grade=compute_grade(_violations(warnings=5, info=3), content_tokens=12_345),
         repo_name="example/repo",
-        plugin_count=3,
-        skill_count=12,
-        top_rules=[("content-vague", 5)],
     )
     assert THEMES["dark"]["bg"] in render_card(**kwargs)
 


### PR DESCRIPTION
## What changed

Report cards retain the repository name and letter grade, but no longer render violation density, content-token totals, building-block counts, or top rule counts.

This prevents generated `.skillsaw-card.svg` conflicts when those values change without a grade change, as in #518.

## Testing

- `pytest tests/ -q` — 4,698 passed
- `pytest tests/test_card.py -q` — 30 passed
- `black --check src/ tests/`
- `make update` (including self-lint)
