### PR TITLE
Parallelize the test suite with pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,11 @@ on:
 permissions:
   contents: read
 
-# A newer push to the same PR supersedes any in-flight run; pushes to main
-# always run to completion.
+# A newer push to the same PR supersedes any in-flight run. Pushes to main
+# get a per-commit group so every one runs to completion — a shared group
+# would let GitHub cancel the queued middle run of three rapid pushes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: read
 
+# A newer push to the same PR supersedes any in-flight run; pushes to main
+# always run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,7 +41,7 @@ jobs:
         run: make venv VENV_EXTRAS=test
 
       - name: Run compatibility tests without coverage
-        run: .venv/bin/pytest tests/ -v
+        run: .venv/bin/pytest tests/ -v -n auto
 
   coverage:
     name: test (3.11)
@@ -216,7 +222,7 @@ jobs:
 
       - name: Test openshift-eng/ai-helpers
         run: |
-          git clone https://github.com/openshift-eng/ai-helpers.git /tmp/ai-helpers
+          git clone --depth 1 https://github.com/openshift-eng/ai-helpers.git /tmp/ai-helpers
 
           # --no-custom-rules: never execute repo-provided Python from
           # third-party clones in CI (THREAT_MODEL.md T1). This also makes
@@ -260,7 +266,7 @@ jobs:
 
       - name: Test auth0/agent-skills
         run: |
-          git clone https://github.com/auth0/agent-skills.git /tmp/agent-skills
+          git clone --depth 1 https://github.com/auth0/agent-skills.git /tmp/agent-skills
 
           skillsaw --format json --no-custom-rules /tmp/agent-skills | python3 -c "
           import sys, json
@@ -277,7 +283,7 @@ jobs:
 
       - name: Test opendatahub-io/agent-eval-harness
         run: |
-          git clone https://github.com/opendatahub-io/agent-eval-harness.git /tmp/agent-eval-harness
+          git clone --depth 1 https://github.com/opendatahub-io/agent-eval-harness.git /tmp/agent-eval-harness
 
           skillsaw --format json --no-custom-rules /tmp/agent-eval-harness | python3 -c "
           import sys, json
@@ -294,7 +300,7 @@ jobs:
 
       - name: Test kubernetes-sigs/maintainer-tools
         run: |
-          git clone https://github.com/kubernetes-sigs/maintainer-tools.git /tmp/maintainer-tools
+          git clone --depth 1 https://github.com/kubernetes-sigs/maintainer-tools.git /tmp/maintainer-tools
 
           skillsaw --format json --no-custom-rules /tmp/maintainer-tools | python3 -c "
           import sys, json
@@ -311,7 +317,7 @@ jobs:
 
       - name: Test RedHatProductSecurity/prodsec-skills
         run: |
-          git clone https://github.com/RedHatProductSecurity/prodsec-skills.git /tmp/prodsec-skills
+          git clone --depth 1 https://github.com/RedHatProductSecurity/prodsec-skills.git /tmp/prodsec-skills
 
           skillsaw --format json --no-custom-rules /tmp/prodsec-skills | python3 -c "
           import sys, json
@@ -330,8 +336,10 @@ jobs:
         run: |
           # Pinned: an unrelated upstream commit must not turn main red
           # with a message blaming a rule change. Bump deliberately.
-          git clone --filter=blob:none https://github.com/openai/plugins.git /tmp/openai-plugins
-          git -C /tmp/openai-plugins checkout --quiet 11c74d6ba24d3a6d48f54a194cd00ef3beea18f9
+          git init --quiet /tmp/openai-plugins
+          git -C /tmp/openai-plugins remote add origin https://github.com/openai/plugins.git
+          git -C /tmp/openai-plugins fetch --quiet --depth 1 origin 11c74d6ba24d3a6d48f54a194cd00ef3beea18f9
+          git -C /tmp/openai-plugins checkout --quiet FETCH_HEAD
 
           # The flagship Codex catalog (~180 plugins, ~580 skills). The five
           # codex-* rules are clean on it and must stay that way — a finding
@@ -402,8 +410,7 @@ jobs:
 
       - name: Test --output flag with multiple formats
         run: |
-          git clone https://github.com/openshift-eng/ai-helpers.git /tmp/ai-helpers-output 2>/dev/null || true
-
+          # Reuses the /tmp/ai-helpers clone from the earlier step.
           skillsaw --no-custom-rules --output /tmp/report.json --output /tmp/report.sarif --output /tmp/report.html /tmp/ai-helpers
 
           python3 -c "

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         run: make venv VENV_EXTRAS=test
 
       - name: Run tests with coverage
-        run: make test VENV_EXTRAS=test
+        run: make test-coverage VENV_EXTRAS=test
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.12", "3.13", "3.14"]
+        # PRs cover only the oldest and newest supported versions — src/ has
+        # no version-conditional code paths, so the middle versions exercise
+        # identical code. Pushes to main run the full matrix. 3.11 is covered
+        # by the coverage job on every run.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.9", "3.14"]') || fromJSON('["3.9", "3.10", "3.12", "3.13", "3.14"]') }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,10 @@ jobs:
       contents: read
     strategy:
       matrix:
-        # PRs cover only the oldest and newest supported versions — src/ has
-        # no version-conditional code paths, so the middle versions exercise
-        # identical code. Pushes to main run the full matrix. 3.11 is covered
-        # by the coverage job on every run.
-        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.9", "3.14"]') || fromJSON('["3.9", "3.10", "3.12", "3.13", "3.14"]') }}
+        # PRs run only the oldest supported version here — src/ has no
+        # version-conditional code paths, and the newest (3.14) is exercised
+        # by the coverage job on every run. Pushes to main run the rest.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.9"]') || fromJSON('["3.9", "3.10", "3.11", "3.12", "3.13"]') }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,7 +47,7 @@ jobs:
         run: .venv/bin/pytest tests/ -v -n auto
 
   coverage:
-    name: test (3.11)
+    name: test (3.14)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,10 +58,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.11"
+          python-version: "3.14"
 
       - name: Install package and dependencies
         run: make venv VENV_EXTRAS=test

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,9 +18,11 @@ This creates a `.venv/` virtualenv and installs skillsaw in editable mode with a
 
 ```bash
 make test         # full suite with coverage
+make test-fast    # full suite without coverage — fastest local loop
 ```
 
-Tests run against Python 3.9–3.14 in CI. Locally, your active Python version is used.
+Both targets run in parallel via pytest-xdist (`-n auto`). Tests run
+against Python 3.9–3.14 in CI. Locally, your active Python version is used.
 
 Most of `tests/test_integration.py` drives the CLI out-of-process via
 `subprocess.run([sys.executable, "-m", "skillsaw", ...])`. pytest-cov 7

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,8 +17,8 @@ This creates a `.venv/` virtualenv and installs skillsaw in editable mode with a
 ## Running tests
 
 ```bash
-make test         # full suite with coverage
-make test-fast    # full suite without coverage — fastest local loop
+make test           # full suite, parallel, no coverage
+make test-coverage  # what CI's coverage job runs
 ```
 
 Both targets run in parallel via pytest-xdist (`-n auto`). Tests run
@@ -31,8 +31,9 @@ dropped automatic subprocess instrumentation, so without help
 exercised. `pyproject.toml` sets `[tool.coverage.run] patch =
 ["subprocess"]` (requires coverage>=7.10) to have coverage.py patch the
 `subprocess` module so child interpreters get instrumented automatically —
-no `COVERAGE_PROCESS_START`/`sitecustomize.py` setup needed. This adds
-roughly 25 seconds to `make test`.
+no `COVERAGE_PROCESS_START`/`sitecustomize.py` setup needed. The
+instrumentation roughly doubles the runtime, which is why coverage is
+confined to `make test-coverage`.
 
 ## Formatting and linting
 

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@ VENV_EXTRAS_STAMP := $(VENV)/.skillsaw-extras-$(subst $(comma),-,$(VENV_EXTRAS))
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 
-.PHONY: help venv format lint test test-fast clean update update-contributors apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile badge self-lint
+.PHONY: help venv format lint test test-coverage clean update update-contributors apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile badge self-lint
 
 help:
 	@echo "Available targets:"
 	@echo "  venv          - Create virtualenv and install dev dependencies"
 	@echo "  format        - Fix code formatting with black"
 	@echo "  lint          - Check code formatting with black"
-	@echo "  test          - Run pytest tests (parallel, with coverage)"
-	@echo "  test-fast     - Run pytest tests in parallel without coverage"
+	@echo "  test          - Run pytest tests in parallel"
+	@echo "  test-coverage - Run pytest tests with coverage (CI)"
 	@echo "  clean         - Remove Python cache files and virtualenv"
 	@echo "  generate-example - Regenerate .skillsaw.yaml.example from builtin rules"
 	@echo "  generate-docs - Regenerate README docs sections when present"
@@ -41,10 +41,12 @@ lint: $(VENV_EXTRAS_STAMP)
 	$(VENV)/bin/black --check src/ tests/
 
 test: $(VENV_EXTRAS_STAMP)
-	$(VENV)/bin/pytest tests/ -v -n auto --cov=src/skillsaw --cov-report=xml --cov-report=term
-
-test-fast: $(VENV_EXTRAS_STAMP)
 	$(VENV)/bin/pytest tests/ -q -n auto
+
+# Coverage instrumentation (including the subprocess patch for the CLI
+# integration tests) roughly doubles the runtime, so it runs only in CI.
+test-coverage: $(VENV_EXTRAS_STAMP)
+	$(VENV)/bin/pytest tests/ -q -n auto --cov=src/skillsaw --cov-report=xml --cov-report=term
 
 # Generate example config in a temp dir to avoid clobbering .skillsaw.yaml
 generate-example: $(VENV_EXTRAS_STAMP)

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,15 @@ VENV_EXTRAS_STAMP := $(VENV)/.skillsaw-extras-$(subst $(comma),-,$(VENV_EXTRAS))
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 
-.PHONY: help venv format lint test clean update update-contributors apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile badge self-lint
+.PHONY: help venv format lint test test-fast clean update update-contributors apm verify-apm generate-example generate-docs generate-site-content serve-site build-site benchmark benchmark-save benchmark-compare profile badge self-lint
 
 help:
 	@echo "Available targets:"
 	@echo "  venv          - Create virtualenv and install dev dependencies"
 	@echo "  format        - Fix code formatting with black"
 	@echo "  lint          - Check code formatting with black"
-	@echo "  test          - Run pytest tests"
+	@echo "  test          - Run pytest tests (parallel, with coverage)"
+	@echo "  test-fast     - Run pytest tests in parallel without coverage"
 	@echo "  clean         - Remove Python cache files and virtualenv"
 	@echo "  generate-example - Regenerate .skillsaw.yaml.example from builtin rules"
 	@echo "  generate-docs - Regenerate README docs sections when present"
@@ -40,7 +41,10 @@ lint: $(VENV_EXTRAS_STAMP)
 	$(VENV)/bin/black --check src/ tests/
 
 test: $(VENV_EXTRAS_STAMP)
-	$(VENV)/bin/pytest tests/ -v --cov=src/skillsaw --cov-report=xml --cov-report=term
+	$(VENV)/bin/pytest tests/ -v -n auto --cov=src/skillsaw --cov-report=xml --cov-report=term
+
+test-fast: $(VENV_EXTRAS_STAMP)
+	$(VENV)/bin/pytest tests/ -q -n auto
 
 # Generate example config in a temp dir to avoid clobbering .skillsaw.yaml
 generate-example: $(VENV_EXTRAS_STAMP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,13 @@ docs = [
 test = [
     "pytest>=7.0",
     "pytest-cov>=7.0",
+    "pytest-xdist>=3",
     "coverage[toml]>=7.10",  # needed for [tool.coverage.run] patch = ["subprocess"]
 ]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=7.0",
+    "pytest-xdist>=3",
     "coverage[toml]>=7.10",  # needed for [tool.coverage.run] patch = ["subprocess"]
     "black>=26,<27",
     "flake8>=6.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@
 # Testing
 pytest>=7.0
 pytest-cov>=7.0
+pytest-xdist>=3
 coverage[toml]>=7.10  # needed for [tool.coverage.run] patch = ["subprocess"] in pyproject.toml
 
 # Code quality

--- a/tests/test_markdown_doc.py
+++ b/tests/test_markdown_doc.py
@@ -506,13 +506,16 @@ class TestContentMapLocate:
         def elapsed(n):
             body = "\n".join(f"path src/file_{i}.py" for i in range(n))
             cmap = _ContentMap(body.split("\n"), 0, body)
-            t = time.perf_counter()
+            t = time.process_time()
             for start, _line, _col in cmap.entries:
                 cmap.locate(start)
-            return time.perf_counter() - t
+            return time.process_time() - t
 
-        small = elapsed(2000)
-        large = elapsed(8000)
+        # CPU time, best of three: wall clock flakes when parallel test
+        # workers contend for cores, while a quadratic regression still
+        # blows the ratio by an order of magnitude.
+        small = min(elapsed(2000) for _ in range(3))
+        large = min(elapsed(8000) for _ in range(3))
         # 4x the lines under quadratic scaling would be ~16x the time; require
         # well under that so a reintroduced linear scan fails loudly.
         assert large < (small + 1e-4) * 8

--- a/tests/test_workflow_hardening.py
+++ b/tests/test_workflow_hardening.py
@@ -215,13 +215,13 @@ def test_codecov_uses_oidc_without_a_repository_secret():
     assert "use_oidc: true" in workflow
     assert "CODECOV_TOKEN" not in workflow
     assert test_job["permissions"] == {"contents": "read"}
-    assert "3.11" not in test_job["strategy"]["matrix"]["python-version"]
+    assert "3.14" not in test_job["strategy"]["matrix"]["python-version"]
     matrix_test_step = next(
         step for step in test_job["steps"] if step.get("name", "").startswith("Run ")
     )
     assert matrix_test_step["run"] == ".venv/bin/pytest tests/ -v -n auto"
     assert "--cov" not in matrix_test_step["run"]
-    assert coverage_job["name"] == "test (3.11)"
+    assert coverage_job["name"] == "test (3.14)"
     assert coverage_job["permissions"] == {
         "contents": "read",
         "id-token": "write",

--- a/tests/test_workflow_hardening.py
+++ b/tests/test_workflow_hardening.py
@@ -219,7 +219,7 @@ def test_codecov_uses_oidc_without_a_repository_secret():
     matrix_test_step = next(
         step for step in test_job["steps"] if step.get("name", "").startswith("Run ")
     )
-    assert matrix_test_step["run"] == ".venv/bin/pytest tests/ -v"
+    assert matrix_test_step["run"] == ".venv/bin/pytest tests/ -v -n auto"
     assert "--cov" not in matrix_test_step["run"]
     assert coverage_job["name"] == "test (3.11)"
     assert coverage_job["permissions"] == {


### PR DESCRIPTION
## What

The suite's cost is death by a thousand subprocesses, not a few slow tests: ~520 `subprocess.run([python, "-m", "skillsaw", ...])` invocations (~440 in `tests/test_integration.py` alone) each pay full interpreter + import startup, and subprocess-patched coverage triples that — the coverage job's pytest step was averaging ~438s and was the critical path of every CI run.

The tests are already parallel-clean (zero `os.chdir` in src or tests, everything `tmp_path`-scoped, no network, no sleeps, no shared paths), so `pytest-xdist -n auto` gives a near-linear speedup with no refactor.

**Measured locally (8 cores):**

| Run | Before | After |
|---|---|---|
| Suite, no coverage | 133s | 28s |
| `make test` (coverage) | 214s | 51s |

Coverage total is identical (94%) — `patch = ["subprocess"]` combines correctly across xdist workers.

## Changes

- `pytest-xdist>=3` in the `test`/`dev` extras and `requirements-dev.txt`; `-n auto` on `make test`, the CI matrix jobs, and the coverage job
- `make test` no longer collects coverage (nobody reads the local report and it doubles the runtime; `-q` still prints failures in full) — the CI coverage job uses the new `make test-coverage` target
- `test_scales_sub_quadratically` measured wall clock and flaked under worker CPU contention; it now measures CPU time (`process_time`), best-of-three — a quadratic regression still blows the 8× ceiling by an order of magnitude
- Updated the pinned matrix pytest command in `test_workflow_hardening.py`
- The coverage job moved from 3.11 to 3.14 and PRs run two suites instead of six: 3.9 plain (matrix) + 3.14 with coverage. Pushes to main run 3.9-3.13 in the matrix plus the 3.14 coverage job, so every supported version is still exercised on main. `src/` has no version-conditional code paths, so the trimmed PR matrix exercises identical code
- CI hygiene: `concurrency` cancel-in-progress for superseded PR pushes, keyed per-commit on push so rapid main pushes never cancel each other; `--depth 1` on the integration-repo clones; blobless depth-1 fetch of the pinned openai/plugins SHA; removed a dead clone in the `--output` step

## Not included (possible follow-ups)

- Converting the ~450 convertible CLI spawns to an in-process `run_cli()` (root-cause fix; would also obsolete `patch = ["subprocess"]`)
- Lazy rule discovery in `rules/builtin/__init__.py` (~130ms of every CLI startup, users included)
- Coverage on main/nightly only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kKjvHWor42Wftk4YSgHfA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Tests now run in parallel for faster feedback.
  * Pull requests use a focused Python compatibility check, while main-branch pushes validate the supported version range.
  * Coverage testing is handled separately through a dedicated test command.
  * Integration checks use more efficient repository retrieval and improved benchmark consistency.

* **Documentation**
  * Updated development guidance to explain standard and coverage test commands, parallel execution, and expected runtime.

* **Chores**
  * Added the tooling required for parallel test execution.
  * Improved CI run management by canceling redundant in-progress pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->