### PR TITLE
Add LeakTK pre-commit secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# Local contributor hooks. Install once with: .venv/bin/pre-commit install
+repos:
+  - repo: https://github.com/leaktk/leaktk.git
+    # Pin the exact revision so each contributor uses the same scanner source.
+    rev: d46703286f99f3cabe3a592d0eba047477d12a07
+    hooks:
+      - id: leaktk.git.pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "black>=26,<27",
     "flake8>=6.0",
     "mypy>=1.0",
+    "pre-commit>=4,<5",
     "skillsaw-runbooks==0.1.0",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,8 +11,8 @@ coverage[toml]>=7.10  # needed for [tool.coverage.run] patch = ["subprocess"] in
 black>=26,<27
 flake8>=6.0
 mypy>=1.0
+pre-commit>=4,<5
 
 # Build
 build>=1.5.0
 twine>=7.0.0
-

--- a/tests/agent_plugins/test_mcp_rule.py
+++ b/tests/agent_plugins/test_mcp_rule.py
@@ -219,9 +219,9 @@ class TestMcpServerEntries:
 
     def test_env_and_headers_reject_credentials_without_echoing_values(self, tmp_path):
         schema_base = "https://agent-plugins.org/schemas/1.0.0"
-        env_secret = "r4Nd0m-V4lu3-Q8z2-W7k9"
+        env_secret = "r4Nd0m-V4lu3-Q8z2-W7k9"  # notsecret
         authorization_secret = "Bearer q7K9m2V4w8R3n6D1"
-        structured_token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"
+        structured_token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"  # notsecret
         structured_secret = f"{structured_token}:${{PLUGIN_ROOT}}"
         manifest = {
             "$schema": f"{schema_base}/plugin.schema.json",
@@ -516,7 +516,7 @@ class TestRemoteUrlPolicy:
 
 
 class TestPlaceholderConfiguration:
-    HEADERS = {"X-Api-Key": "corp-vault-9f2b41d7c6"}
+    HEADERS = {"X-Api-Key": "corp-vault-9f2b41d7c6"}  # notsecret
 
     def test_project_placeholder_convention_errors_by_default(self, tmp_path):
         _write_plugin(tmp_path, _remote("https://example.com/mcp", headers=self.HEADERS))
@@ -537,7 +537,7 @@ class TestPlaceholderConfiguration:
         assert findings == []
 
     def test_structured_tokens_survive_a_placeholder_allowlist(self, tmp_path):
-        token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"
+        token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"  # notsecret
         _write_plugin(
             tmp_path,
             _remote("https://example.com/mcp", headers={"X-Api-Key": f"corp-vault-{token}"}),

--- a/tests/fixtures/security/malicious-skill/SKILL.md
+++ b/tests/fixtures/security/malicious-skill/SKILL.md
@@ -34,4 +34,4 @@ bootstrap a new environment for the service.
 
 Before deploying, inspect the current changes with !`git diff HEAD`.
 
-Verification token: C9dAQAoseEUamRL1QhVyXiErf9l9F/nMkOlgY56MoJ8PloDb6jHGX2Al7cpDg8z+DqAX/bYdje1GroeqOVcf/wy75uxQ2+Vkhjt7DiK/PYtXkc667M2eXNLcHleaJAKC
+Verification token: C9dAQAoseEUamRL1QhVyXiErf9l9F/nMkOlgY56MoJ8PloDb6jHGX2Al7cpDg8z+DqAX/bYdje1GroeqOVcf/wy75uxQ2+Vkhjt7DiK/PYtXkc667M2eXNLcHleaJAKC <!-- notsecret -->

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -695,7 +695,7 @@ class TestContentEmbeddedSecretsRule:
             ("npm_abcdefghijklmnopqrstuvwxyz1234567890", "npm access token"),  # notsecret
             ("pypi-abcdefghijklmnopqrstuvwxyz", "PyPI API token"),
             (
-                "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456",
+                "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456",  # notsecret
                 "JSON Web Token",
             ),
             ("-----BEGIN RSA PRIVATE KEY-----", "Private key"),
@@ -5324,7 +5324,7 @@ class TestContentMcpToolNameAutofix:
         assert set(by_name) == {"CLAUDE.md", ".coderabbit.yaml"}
 
         yaml_fix = by_name[".coderabbit.yaml"]
-        token = "mcp__plugin_jira_atlassian__getJiraIssue"
+        token = "mcp__plugin_jira_atlassian__getJiraIssue"  # notsecret
         before = yaml_fix.original_content.split("\n")
         after = yaml_fix.fixed_content.split("\n")
         assert len(after) == len(before)

--- a/tests/test_mcp_rules.py
+++ b/tests/test_mcp_rules.py
@@ -650,7 +650,7 @@ def test_valid_headers_on_http_server(temp_dir):
 
 
 def test_editor_mcp_credentials_are_reported_without_echoing_values(temp_dir):
-    cursor_secret = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+    cursor_secret = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"  # notsecret
     vscode_secret = "AKIAQRSTUVWXYZABCDEF"
     cursor = temp_dir / ".cursor"
     vscode = temp_dir / ".vscode"
@@ -766,7 +766,7 @@ def test_additional_placeholders_suppress_structured_credential(temp_dir):
 
 
 def test_additional_placeholders_do_not_mask_real_tokens(temp_dir):
-    token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"
+    token = "ghp_aB3cD4eF5gH6iJ7kL8mN9pQ0rS1uV2wX3yZ4"  # notsecret
     mcp_config = {
         "mcpServers": {"local": {"command": "srv", "env": {"API_KEY": f"corp-vault-{token}"}}}
     }

--- a/tests/test_pre_commit_hooks.py
+++ b/tests/test_pre_commit_hooks.py
@@ -1,4 +1,4 @@
-"""Tests for the .pre-commit-hooks.yaml manifest.
+"""Tests for the shipped and local pre-commit configurations.
 
 Validates the hook definition offline: structure, consistency with the
 console scripts declared in pyproject.toml, and the repo-level invocation
@@ -11,15 +11,26 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from skillsaw.utils import read_yaml_commented
 
 REPO_ROOT = Path(__file__).parent.parent
 MANIFEST = REPO_ROOT / ".pre-commit-hooks.yaml"
+CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 
 
 @pytest.fixture(scope="module")
 def hooks():
-    return yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    parsed, error, _error_line = read_yaml_commented(MANIFEST)
+    assert error is None
+    return parsed
+
+
+@pytest.fixture(scope="module")
+def config():
+    parsed, error, _error_line = read_yaml_commented(CONFIG)
+    assert error is None
+    return parsed
 
 
 @pytest.fixture(scope="module")
@@ -52,3 +63,14 @@ def test_skillsaw_hook_contract(skillsaw_hook):
     assert re.search(
         rf"^{re.escape(entry_cmd)}\s*=", pyproject, re.MULTILINE
     ), f"entry {entry_cmd!r} is not a [project.scripts] console script"
+
+
+def test_leaktk_hook_is_enabled_at_a_pinned_revision(config):
+    """Keep local secret scanning reproducible and installed by make venv."""
+    repositories = config["repos"]
+    leaktk = next(
+        repo for repo in repositories if repo["repo"] == "https://github.com/leaktk/leaktk.git"
+    )
+
+    assert re.fullmatch(r"[0-9a-f]{40}", leaktk["rev"])
+    assert {hook["id"] for hook in leaktk["hooks"]} == {"leaktk.git.pre-commit"}


### PR DESCRIPTION
Summary:
- Add a pinned LeakTK pre-commit hook for local secret detection.
- Annotate fake-secret fixtures reported by LeakTK with # notsecret.
- Document setup and test that the hook stays pinned.

Validation:
- make update
- make test
- make lint
- pre-commit run leaktk.git.pre-commit --all-files
- skillsaw lint against openshift-eng/ai-helpers