### PR TITLE
Clarify proportional review guidance

### DIFF
--- a/.agents/skills/skillsaw-review-panel/SKILL.md
+++ b/.agents/skills/skillsaw-review-panel/SKILL.md
@@ -60,6 +60,10 @@ Follow these steps in order. Do not skip ahead.
 Parse the argument string. `--serial` sets serial mode. A bare
 integer is the PR number.
 
+Read the repository's `REVIEW.md` before assessing the change. It defines the
+project-specific review priorities and severity calibration that every panel
+member and the arbiter must follow.
+
 Check what the changes are being compared against:
 
 - In the automated workflow, read `/tmp/skillsaw-panel-pr.json` for PR

--- a/.apm/skills/skillsaw-review-panel/SKILL.md
+++ b/.apm/skills/skillsaw-review-panel/SKILL.md
@@ -60,6 +60,10 @@ Follow these steps in order. Do not skip ahead.
 Parse the argument string. `--serial` sets serial mode. A bare
 integer is the PR number.
 
+Read the repository's `REVIEW.md` before assessing the change. It defines the
+project-specific review priorities and severity calibration that every panel
+member and the arbiter must follow.
+
 Check what the changes are being compared against:
 
 - In the automated workflow, read `/tmp/skillsaw-panel-pr.json` for PR

--- a/.claude/skills/skillsaw-review-panel/SKILL.md
+++ b/.claude/skills/skillsaw-review-panel/SKILL.md
@@ -60,6 +60,10 @@ Follow these steps in order. Do not skip ahead.
 Parse the argument string. `--serial` sets serial mode. A bare
 integer is the PR number.
 
+Read the repository's `REVIEW.md` before assessing the change. It defines the
+project-specific review priorities and severity calibration that every panel
+member and the arbiter must follow.
+
 Check what the changes are being compared against:
 
 - In the automated workflow, read `/tmp/skillsaw-panel-pr.json` for PR

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -12,6 +12,15 @@ Read the canonical conventions in `.apm/instructions/`, `CONTRIBUTING.md`, and
 `DEVELOPMENT.md`; read the security posture in [THREAT_MODEL.md](THREAT_MODEL.md).
 Review each change against the checklist below and always flag deviations.
 
+## Proportional review
+
+Do not harp on extremely rare false-positive edge cases when addressing them
+would substantially increase a rule's complexity. Skillsaw supports narrowly
+scoped, per-rule suppressions around the affected block, so users can opt out
+where a rare false positive occurs. Flag a case only when its likelihood or
+impact justifies the added maintenance and complexity; otherwise, accept the
+rule's practical behavior and the available suppression mechanism.
+
 ## Repo coherence
 
 ### Lint rules


### PR DESCRIPTION
## Summary
- direct reviewers not to focus on extremely rare false-positive edge cases when a scoped suppression is available
- require the skillsaw review panel to read the repository's REVIEW.md before reviewing a change

## Validation
- make test (4,703 passed)
- make lint
- make update
- .venv/bin/skillsaw lint .
- linted openshift-eng/ai-helpers successfully