### PR TITLE
Fix targeted OpenCode parse validation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,7 +20,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo, codex-plugin, codex-marketplace, agent-plugin. |  |
-| `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |
+| `--rule` | Only run these rules and their validation dependencies (repeatable). Config still comes from .skillsaw.yaml. |  |
 | `--skip-rule` | Skip these rules (repeatable). Cannot be combined with --rule. |  |
 | `--no-baseline` | Ignore baseline file even if .skillsaw-baseline.json exists |  |
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
@@ -48,7 +48,7 @@ Automatically fix lint violations
 | `-c`, `--config` | Path to .skillsaw.yaml config file (default: auto-discover from the first path) |  |
 | `--dry-run` | Preview fixes without writing changes |  |
 | `--suggest` | Also apply suggested fixes (not just safe ones) |  |
-| `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |
+| `--rule` | Only run these rules and their validation dependencies (repeatable). Config still comes from .skillsaw.yaml. |  |
 | `--skip-rule` | Skip these rules (repeatable). Cannot be combined with --rule. |  |
 | `--no-custom-rules` | Skip custom rules defined in .skillsaw.yaml (recommended for CI on untrusted PRs) |  |
 | `--no-network` | Skip every rule that makes outbound network requests, whatever the linted repository's .skillsaw.yaml enables (env: SKILLSAW_NO_NETWORK=1). Accepted on fix for argv compatibility only: fix never runs network rules, so this has no effect there |  |

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -171,7 +171,8 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         action="append",
         default=[],
         metavar="RULE",
-        help="Only run these rules (repeatable). Config still comes from .skillsaw.yaml.",
+        help="Only run these rules and their validation dependencies (repeatable). "
+        "Config still comes from .skillsaw.yaml.",
     )
     lint_parser.add_argument(
         "--skip-rule",
@@ -245,7 +246,8 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         action="append",
         default=[],
         metavar="RULE",
-        help="Only run these rules (repeatable). Config still comes from .skillsaw.yaml.",
+        help="Only run these rules and their validation dependencies (repeatable). "
+        "Config still comes from .skillsaw.yaml.",
     )
     fix_parser.add_argument(
         "--skip-rule",

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -354,7 +354,24 @@ class Linter:
 
     def _load_builtin_rules(self):
         """Load builtin rules from skillsaw.rules.builtin"""
-        from .rules.builtin import BUILTIN_RULES
+        from .rules.builtin import BUILTIN_RULE_REGISTRY, BUILTIN_RULES, canonical_rule_id
+
+        # ``--rule`` bypasses normal enablement so one validator can be run in
+        # isolation. Some validators intentionally leave a prerequisite
+        # diagnostic to another builtin rule, though; expand those declared
+        # dependencies before filtering or a targeted run can falsely pass.
+        if self._rule_ids:
+            pending = list(self._rule_ids)
+            while pending:
+                selected = pending.pop()
+                rule_class = BUILTIN_RULE_REGISTRY.get(selected)
+                if rule_class is None:
+                    continue
+                for dependency in rule_class.target_dependencies:
+                    dependency = canonical_rule_id(dependency)
+                    if dependency not in self._rule_ids:
+                        self._rule_ids.add(dependency)
+                        pending.append(dependency)
 
         for rule_class in BUILTIN_RULES:
             rule_instance = rule_class()

--- a/src/skillsaw/rule.py
+++ b/src/skillsaw/rule.py
@@ -135,6 +135,11 @@ class Rule(ABC):
     # One-sentence rationale rendered on the documentation site's
     # Deprecated page and each deprecated rule's own page.
     deprecated_reason: Optional[str] = None
+    # Builtin rule IDs that must accompany this rule when an operator names
+    # it explicitly with ``--rule``. This is for validation prerequisites
+    # whose diagnostics are deliberately owned by another rule; ordinary
+    # config-driven enablement remains independent.
+    target_dependencies: tuple[str, ...] = ()
     # Default activation when the user config doesn't mention the rule:
     # True (always on), False (opt-in), or "auto" (on when repo_types /
     # formats match the repository). ``LinterConfig.default()`` is generated

--- a/src/skillsaw/rules/builtin/opencode/config_valid.py
+++ b/src/skillsaw/rules/builtin/opencode/config_valid.py
@@ -21,6 +21,7 @@ class OpenCodeConfigValidRule(Rule):
     """Check that an OpenCode project config parses and is shaped the way OpenCode reads it"""
 
     since = "0.20.0"
+    target_dependencies = ("mcp-valid-json",)
 
     formats = frozenset({HAS_OPENCODE})
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2502,6 +2502,20 @@ class TestOpenCode:
         assert found[0]["message"].startswith("Invalid JSON:")
         assert by_rule(r).get("opencode-config-valid", []) == []
 
+    def test_targeting_config_validation_also_runs_its_parse_validation(self, tmp_path):
+        """A focused config check must not pass a file OpenCode cannot read."""
+        repo = copy_fixture("opencode/unparseable", tmp_path)
+        r = run_lint(repo, "--rule", "opencode-config-valid")
+
+        assert r["rc"] == 1
+        found = by_rule(r)
+        assert [v["file_path"] for v in found["mcp-valid-json"]] == ["opencode.jsonc"]
+        assert found.get("opencode-config-valid", []) == []
+        assert set(r["out"]["stats"]["rules_run"]) == {
+            "mcp-valid-json",
+            "opencode-config-valid",
+        }
+
     def test_a_version_pinned_project_still_learns_the_config_is_unreadable(self, tmp_path):
         """The `since` gate, exercised as itself rather than as `enabled: false`.
 

--- a/tests/test_rule_registry.py
+++ b/tests/test_rule_registry.py
@@ -44,6 +44,16 @@ def test_default_enabled_values_are_valid():
         )
 
 
+def test_target_dependencies_are_known_builtins():
+    problems = []
+    known = set(BUILTIN_RULE_REGISTRY)
+    for rule_id, cls in BUILTIN_RULE_REGISTRY.items():
+        unknown = set(cls.target_dependencies) - known
+        if unknown:
+            problems.append(f"{rule_id}: {', '.join(sorted(unknown))}")
+    assert problems == [], f"unknown target dependencies: {problems}"
+
+
 def test_default_config_generated_from_registry():
     """default() must cover every builtin rule with the class-level defaults.
 


### PR DESCRIPTION
## Summary

- declare builtin validation dependencies for focused --rule runs
- make opencode-config-valid include mcp-valid-json when targeted
- prevent malformed OpenCode JSON/JSONC from producing a false-success focused run
- document dependency-aware --rule behavior

## Validation

- make test: 5,130 passed
- make lint
- make update and self-lint
- direct malformed OpenCode CLI regression
- latest openshift-eng/ai-helpers: exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Targeting a lint rule now automatically runs its validation dependencies.
  - Added support for declaring prerequisite validation rules.

- **Bug Fixes**
  - Targeted checks now report parsing and validation issues required by the selected rule.

- **Documentation**
  - Updated CLI help and documentation to explain dependency execution for `lint` and `fix`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->