### PR TITLE
Reduce unlinked internal-reference false positives

### DIFF
--- a/docs/designs/content-rules-research.md
+++ b/docs/designs/content-rules-research.md
@@ -523,19 +523,21 @@ false positives in a linter train users to stop reading its output.
 (e.g., `src/config.yaml` mentioned in prose but not linked as
 `[src/config.yaml](src/config.yaml)`).
 
-Bare path references are a maintenance hazard. When a path is mentioned in
-prose without link syntax, there is no tooling (including
-`content-broken-internal-reference`) that can verify the referenced file still
-exists. The path silently rots as the repository evolves.
+Bare path references to existing local targets are a maintenance hazard. When
+a real repository path is mentioned in prose without link syntax, there is no
+tooling (including `content-broken-internal-reference`) that can verify it after
+the target is renamed or deleted. The path silently rots as the repository
+evolves.
 
 Wrapping paths in link syntax provides two benefits: (1) link checkers and
 linters can detect when the target is renamed or deleted, and (2) in rendered
 markdown environments (GitHub, IDEs), the reference becomes navigable. Both
 benefits improve the reliability of instruction files as executable context.
 
-The rule is configurable via `patterns` — a list of glob patterns that control
-which path-like strings are flagged. This avoids false positives on paths that
-are illustrative examples rather than real file references.
+The rule requires a resolvable in-repository target and is configurable via
+`patterns` — a list of glob patterns that further controls which path-like
+strings are flagged. The existence check avoids false positives on technology
+names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -463,19 +463,21 @@ false positives in a linter train users to stop reading its output.
 (e.g., `src/config.yaml` mentioned in prose but not linked as
 `[src/config.yaml](src/config.yaml)`).
 
-Bare path references are a maintenance hazard. When a path is mentioned in
-prose without link syntax, there is no tooling (including
-`content-broken-internal-reference`) that can verify the referenced file still
-exists. The path silently rots as the repository evolves.
+Bare path references to existing local targets are a maintenance hazard. When
+a real repository path is mentioned in prose without link syntax, there is no
+tooling (including `content-broken-internal-reference`) that can verify it after
+the target is renamed or deleted. The path silently rots as the repository
+evolves.
 
 Wrapping paths in link syntax provides two benefits: (1) link checkers and
 linters can detect when the target is renamed or deleted, and (2) in rendered
 markdown environments (GitHub, IDEs), the reference becomes navigable. Both
 benefits improve the reliability of instruction files as executable context.
 
-The rule is configurable via `patterns` — a list of glob patterns that control
-which path-like strings are flagged. This avoids false positives on paths that
-are illustrative examples rather than real file references.
+The rule requires a resolvable in-repository target and is configurable via
+`patterns` — a list of glob patterns that further controls which path-like
+strings are flagged. The existence check avoids false positives on technology
+names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 

--- a/docs/rules/content-unlinked-internal-reference.md
+++ b/docs/rules/content-unlinked-internal-reference.md
@@ -17,7 +17,9 @@ Detect bare path-like strings not wrapped in markdown link syntax
 A bare path like `src/config.ts` in prose is not clickable and not
 machine-navigable. Wrapping it in markdown link syntax
 (`[src/config.ts](src/config.ts)`) makes it a navigable reference
-that tools and agents can follow to read the file's contents.
+that tools and agents can follow to read the file's contents. The rule only
+reports paths that resolve to an existing target inside the repository, so
+technology names and illustrative paths do not create unactionable findings.
 
 ## Examples
 
@@ -37,8 +39,7 @@ See [src/config.ts](src/config.ts) for the shared configuration.
 
 Wrap the bare path in markdown link syntax: `[path](path)`. When the
 violation message says "file exists, autofixable", `skillsaw fix` can
-wrap it automatically. For paths that do not exist, verify the path
-is correct before linking.
+wrap it automatically. Paths without a resolvable local target are ignored.
 
 ## Configuration
 
@@ -59,19 +60,21 @@ rules:
 (e.g., `src/config.yaml` mentioned in prose but not linked as
 `[src/config.yaml](src/config.yaml)`).
 
-Bare path references are a maintenance hazard. When a path is mentioned in
-prose without link syntax, there is no tooling (including
-`content-broken-internal-reference`) that can verify the referenced file still
-exists. The path silently rots as the repository evolves.
+Bare path references to existing local targets are a maintenance hazard. When
+a real repository path is mentioned in prose without link syntax, there is no
+tooling (including `content-broken-internal-reference`) that can verify it after
+the target is renamed or deleted. The path silently rots as the repository
+evolves.
 
 Wrapping paths in link syntax provides two benefits: (1) link checkers and
 linters can detect when the target is renamed or deleted, and (2) in rendered
 markdown environments (GitHub, IDEs), the reference becomes navigable. Both
 benefits improve the reliability of instruction files as executable context.
 
-The rule is configurable via `patterns` — a list of glob patterns that control
-which path-like strings are flagged. This avoids false positives on paths that
-are illustrative examples rather than real file references.
+The rule requires a resolvable in-repository target and is configurable via
+`patterns` — a list of glob patterns that further controls which path-like
+strings are flagged. The existence check avoids false positives on technology
+names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 

--- a/src/skillsaw/rules/builtin/content/unlinked_internal_reference.py
+++ b/src/skillsaw/rules/builtin/content/unlinked_internal_reference.py
@@ -138,10 +138,18 @@ class ContentUnlinkedInternalReferenceRule(Rule):
                         file_exists = safe_exists(resolved)
                     except ValueError:
                         pass
+                # A path-shaped phrase that cannot resolve locally is not an
+                # actionable linking opportunity.  Requiring an existing
+                # in-repository target keeps examples such as
+                # ``JavaScript/Node.js`` and ``examples/app/config.yaml`` from
+                # dominating first-run results while preserving every real
+                # local reference this rule can make navigable.
+                if not file_exists:
+                    continue
                 # fix() only wraps references whose target exists on disk,
                 # and never rewrites a body extracted from another format —
                 # there is no span in the enclosing file to splice into.
-                fixable = file_exists and not cf.diagnostic_only
+                fixable = not cf.diagnostic_only
                 msg = f"Unlinked path reference: '{path_str}' — consider wrapping in link syntax [{path_str}]({path_str})"
                 if fixable:
                     msg += " (file exists, autofixable)"

--- a/src/skillsaw/rules/docs/content-unlinked-internal-reference.md
+++ b/src/skillsaw/rules/docs/content-unlinked-internal-reference.md
@@ -3,7 +3,9 @@
 A bare path like `src/config.ts` in prose is not clickable and not
 machine-navigable. Wrapping it in markdown link syntax
 (`[src/config.ts](src/config.ts)`) makes it a navigable reference
-that tools and agents can follow to read the file's contents.
+that tools and agents can follow to read the file's contents. The rule only
+reports paths that resolve to an existing target inside the repository, so
+technology names and illustrative paths do not create unactionable findings.
 
 ## Examples
 
@@ -23,5 +25,4 @@ See [src/config.ts](src/config.ts) for the shared configuration.
 
 Wrap the bare path in markdown link syntax: `[path](path)`. When the
 violation message says "file exists, autofixable", `skillsaw fix` can
-wrap it automatically. For paths that do not exist, verify the path
-is correct before linking.
+wrap it automatically. Paths without a resolvable local target are ignored.

--- a/tests/fixtures/content/unlinked-reference-signal/CLAUDE.md
+++ b/tests/fixtures/content/unlinked-reference-signal/CLAUDE.md
@@ -1,0 +1,7 @@
+# Release workflow
+
+<!-- skillsaw-assert content-unlinked-internal-reference -->
+Review docs/release-checklist.md before publishing a release.
+
+The web tooling supports JavaScript/Node.js projects.
+Examples may use examples/service/config.yaml as an illustrative path.

--- a/tests/fixtures/content/unlinked-reference-signal/docs/release-checklist.md
+++ b/tests/fixtures/content/unlinked-reference-signal/docs/release-checklist.md
@@ -1,0 +1,3 @@
+# Release checklist
+
+Run the full test suite and verify the built artifacts before publishing.

--- a/tests/fixtures/single-plugin/content-violations/docs/architecture-overview.md
+++ b/tests/fixtures/single-plugin/content-violations/docs/architecture-overview.md
@@ -1,0 +1,4 @@
+# Architecture overview
+
+The service separates request handling, domain logic, and persistence into
+independent layers.

--- a/tests/test_content_rules.py
+++ b/tests/test_content_rules.py
@@ -1813,6 +1813,8 @@ class TestContentUnlinkedInternalReferenceRule:
         assert rule.default_severity() == Severity.INFO
 
     def test_bare_path_violation(self, temp_dir):
+        (temp_dir / "src" / "config").mkdir(parents=True)
+        (temp_dir / "src" / "config" / "settings.yaml").write_text("theme: dark\n")
         (temp_dir / "CLAUDE.md").write_text(
             "Check the file at src/config/settings.yaml for defaults.\n"
         )
@@ -1830,14 +1832,16 @@ class TestContentUnlinkedInternalReferenceRule:
         assert len(violations) == 0
 
     def test_dot_slash_path(self, temp_dir):
+        (temp_dir / "scripts").mkdir()
+        (temp_dir / "scripts" / "build.sh").write_text("#!/bin/sh\n")
         (temp_dir / "CLAUDE.md").write_text("Run ./scripts/build.sh to build.\n")
         context = RepositoryContext(temp_dir)
         violations = ContentUnlinkedInternalReferenceRule().check(context)
         assert len(violations) == 1
         assert "./scripts/build.sh" in violations[0].message
 
-    def test_resolution_failure_is_not_autofixable(self, temp_dir, monkeypatch):
-        """An unresolvable bare path must not be statted or offered for autofix."""
+    def test_resolution_failure_is_not_reported(self, temp_dir, monkeypatch):
+        """An unresolvable bare path must not be statted or reported."""
         from skillsaw.rules.builtin.content import unlinked_internal_reference as rule_module
 
         (temp_dir / "CLAUDE.md").write_text("See docs/hostile.md for details.\n")
@@ -1862,8 +1866,18 @@ class TestContentUnlinkedInternalReferenceRule:
         monkeypatch.setattr(Path, "exists", hostile_exists)
 
         violations = ContentUnlinkedInternalReferenceRule().check(context)
-        assert len(violations) == 1
-        assert violations[0].fixable is False
+        assert violations == []
+
+    def test_nonexistent_path_shaped_prose_not_reported(self, temp_dir):
+        """Technology names and illustrative paths are not actionable local links."""
+        (temp_dir / "CLAUDE.md").write_text(
+            "Use JavaScript/Node.js for the worker.\n"
+            "Examples may refer to examples/service/config.yaml.\n"
+        )
+
+        violations = ContentUnlinkedInternalReferenceRule().check(RepositoryContext(temp_dir))
+
+        assert violations == []
 
     def test_path_abutting_close_paren_not_flagged(self, temp_dir):
         """Regression for #321: `scripts/test.pyc)` must not backtrack to a
@@ -1888,6 +1902,8 @@ class TestContentUnlinkedInternalReferenceRule:
     def test_dot_slash_path_does_not_swallow_sentence_period(self, temp_dir):
         """Regression for #321: `./docs/guide.md.` at the end of a sentence
         must match `./docs/guide.md`, not include the period."""
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "guide.md").write_text("# Guide\n")
         (temp_dir / "CLAUDE.md").write_text("See ./docs/guide.md. Then continue.\n")
         context = RepositoryContext(temp_dir)
         violations = ContentUnlinkedInternalReferenceRule().check(context)
@@ -1911,6 +1927,10 @@ class TestContentUnlinkedInternalReferenceRule:
 
     def test_custom_patterns_config(self, temp_dir):
         """Test that custom patterns config filters which paths are flagged."""
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "guide.md").write_text("# Guide\n")
+        (temp_dir / "src" / "config").mkdir(parents=True)
+        (temp_dir / "src" / "config" / "settings.yaml").write_text("theme: dark\n")
         (temp_dir / "CLAUDE.md").write_text(
             "See docs/guide.md for info.\nAlso check src/config/settings.yaml.\n"
         )
@@ -1937,6 +1957,8 @@ class TestContentUnlinkedInternalReferenceRule:
         assert len(violations) == 0
 
     def test_reports_line_number(self, temp_dir):
+        (temp_dir / "docs").mkdir()
+        (temp_dir / "docs" / "guide.md").write_text("# Guide\n")
         content = "Line 1\nLine 2\nSee docs/guide.md for info.\nLine 4\n"
         (temp_dir / "CLAUDE.md").write_text(content)
         context = RepositoryContext(temp_dir)
@@ -1962,6 +1984,8 @@ class TestContentUnlinkedInternalReferenceRule:
 
     def test_double_backtick_exact_path_flagged(self, temp_dir):
         """A path that is the entire content of a double-backtick span should still be flagged."""
+        (temp_dir / "prompts").mkdir()
+        (temp_dir / "prompts" / "analyze-skill.md").write_text("# Analysis prompt\n")
         (temp_dir / "CLAUDE.md").write_text(
             "You can also reference ``prompts/analyze-skill.md`` with double backticks.\n"
         )
@@ -2169,16 +2193,15 @@ class TestContentUnlinkedInternalReferenceAutofix:
         assert "run [scripts/test.py](scripts/test.py) to validate" in fixed
         assert len(fixed.splitlines()) == 2
 
-    def test_no_autofix_for_nonexistent_path(self, temp_dir):
-        """Bare paths to nonexistent files should not be autofixed."""
+    def test_no_violation_or_autofix_for_nonexistent_path(self, temp_dir):
+        """Bare paths to nonexistent files are neither reported nor autofixed."""
         (temp_dir / "CLAUDE.md").write_text("See docs/guide.md for info.\n")
         context = RepositoryContext(temp_dir)
         rule = ContentUnlinkedInternalReferenceRule()
         violations = rule.check(context)
-        assert len(violations) == 1
-        assert "autofixable" not in violations[0].message
+        assert violations == []
         fixes = rule.fix(context, violations)
-        assert len(fixes) == 0
+        assert fixes == []
 
     def test_autofix_duplicate_paths_no_double_wrap(self, temp_dir):
         """When the same path appears multiple times, each should be wrapped independently."""
@@ -2244,7 +2267,7 @@ class TestContentUnlinkedInternalReferenceAutofix:
         assert fixed.count("[[") == 0
 
     def test_autofix_mixed_autofixable_and_nonexistent(self, temp_dir):
-        """Only existing paths should be fixed; nonexistent paths left alone."""
+        """Only existing paths should be reported and fixed."""
         (temp_dir / "src").mkdir()
         (temp_dir / "src" / "real.py").write_text("# real\n")
         (temp_dir / "CLAUDE.md").write_text(
@@ -2253,9 +2276,9 @@ class TestContentUnlinkedInternalReferenceAutofix:
         context = RepositoryContext(temp_dir)
         rule = ContentUnlinkedInternalReferenceRule()
         violations = rule.check(context)
-        assert len(violations) == 2
-        autofixable = [v for v in violations if "autofixable" in v.message]
-        assert len(autofixable) == 1
+        assert len(violations) == 1
+        assert "src/real.py" in violations[0].message
+        assert "autofixable" in violations[0].message
         fixes = rule.fix(context, violations)
         assert len(fixes) == 1
         fixed = fixes[0].fixed_content

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4611,6 +4611,22 @@ class TestDescriptionRouting:
         }
 
 
+class TestUnlinkedInternalReferenceSignal:
+    """Only actionable local targets should reach first-run output."""
+
+    def test_reports_existing_target_and_ignores_path_shaped_prose(self, tmp_path):
+        repo = copy_fixture("content/unlinked-reference-signal", tmp_path)
+
+        found = by_rule(run_lint(repo, "--rule", "content-unlinked-internal-reference"))[
+            "content-unlinked-internal-reference"
+        ]
+
+        assert len(found) == 1
+        assert "docs/release-checklist.md" in found[0]["message"]
+        assert found[0]["line"] == 4
+        assert found[0]["fixable"] is True
+
+
 class TestUnlinkedInternalReferenceAutofix:
     """Integration tests for content-unlinked-internal-reference autofix via CLI."""
 


### PR DESCRIPTION
## Summary

- report bare internal references only when they resolve to an existing in-repository target
- ignore technology names and illustrative path-shaped prose that cannot become working local links
- preserve safe autofix for ordinary Markdown and diagnostics for embedded read-only content
- update tests and documentation for the narrower contract

This implements the focused signal recommendation from #532. On its six pinned repositories, findings fall from 1,747 to 650 (62.8%). Linked stale targets remain covered by content-broken-internal-reference.

## Validation

- make test: 5,134 passed
- make lint and git diff --check
- make update and self-lint
- focused rule/autofix tests: 45 passed on final staged code
- medium benchmark: no rule regression
- latest openshift-eng/ai-helpers: exit 0