### PR TITLE
Recognize direct description routing phrases

### DIFF
--- a/docs/rules/content-description-routing.md
+++ b/docs/rules/content-description-routing.md
@@ -26,9 +26,9 @@ to them, so this rule skips them by default. Set `check-user-only-skills: true`
 to check their descriptions normally. Only the YAML boolean `true` opts a skill
 out; an absent field, `false`, strings, and numbers remain checked.
 
-Natural selection clauses count as trigger phrasing, including "Use this skill
-for ...", "Invoke this skill whenever ...", "This skill should be used before
-...", and "Use only when ...".
+Natural selection clauses count as trigger phrasing, including "Use for ...",
+"Use it when ...", "Use this skill for ...", "Invoke this skill whenever ...",
+"This skill should be used before ...", and "Use only when ...".
 
 The routing heuristics and user-only-skill behavior can be configured independently:
 

--- a/src/skillsaw/rules/builtin/description_routing.py
+++ b/src/skillsaw/rules/builtin/description_routing.py
@@ -15,9 +15,10 @@ from skillsaw.rules.builtin.content_analysis import (
 )
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
-_USE_THIS_TRIGGER_RE = re.compile(
+_ACTIVE_USE_TRIGGER_RE = re.compile(
     r"(?:^|[.!?—]\s+)(?:(?:you )?(?:must|should) )?"
-    r"(?:use|invoke) this(?: (?:skill|agent))?(?: proactively)? "
+    r"(?:use(?: this(?: (?:skill|agent))?| it)?|invoke this(?: (?:skill|agent))?)"
+    r"(?: proactively)? "
     r"(?:when(?:ever)?|if|before|for|to)\b"
 )
 _PASSIVE_USE_TRIGGER_RE = re.compile(
@@ -230,7 +231,7 @@ class DescriptionRoutingRule(Rule):
         without_explanatory_clauses = _EXPLANATORY_USER_TRIGGER_RE.sub("", normalized)
         return (
             any(marker in without_explanatory_clauses for marker in _TRIGGER_MARKERS)
-            or bool(_USE_THIS_TRIGGER_RE.search(without_explanatory_clauses))
+            or bool(_ACTIVE_USE_TRIGGER_RE.search(without_explanatory_clauses))
             or bool(_PASSIVE_USE_TRIGGER_RE.search(without_explanatory_clauses))
             or bool(_FOR_TRIGGER_RE.search(without_explanatory_clauses))
         )

--- a/src/skillsaw/rules/docs/content-description-routing.md
+++ b/src/skillsaw/rules/docs/content-description-routing.md
@@ -11,9 +11,9 @@ to them, so this rule skips them by default. Set `check-user-only-skills: true`
 to check their descriptions normally. Only the YAML boolean `true` opts a skill
 out; an absent field, `false`, strings, and numbers remain checked.
 
-Natural selection clauses count as trigger phrasing, including "Use this skill
-for ...", "Invoke this skill whenever ...", "This skill should be used before
-...", and "Use only when ...".
+Natural selection clauses count as trigger phrasing, including "Use for ...",
+"Use it when ...", "Use this skill for ...", "Invoke this skill whenever ...",
+"This skill should be used before ...", and "Use only when ...".
 
 The routing heuristics and user-only-skill behavior can be configured independently:
 

--- a/tests/fixtures/content-description-routing/.claude/skills/active-use-for-direct/SKILL.md
+++ b/tests/fixtures/content-description-routing/.claude/skills/active-use-for-direct/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: active-use-for-direct
+description: Build stateful web artifacts. Use for complex applications requiring routing or component libraries.
+---
+
+# Active use for direct
+
+Build complex, stateful web artifacts.

--- a/tests/fixtures/content-description-routing/.claude/skills/active-use-it-when/SKILL.md
+++ b/tests/fixtures/content-description-routing/.claude/skills/active-use-it-when/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: active-use-it-when
+description: Apply the official brand system to an artifact. Use it when colors, typography, or visual standards apply.
+---
+
+# Active use it when
+
+Apply the official brand system to an artifact.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4429,7 +4429,9 @@ class TestDescriptionRouting:
         routing_violations = self._routing_violations(result)
         expected_clean = {
             "active-invoke-whenever",
+            "active-use-for-direct",
             "active-use-for",
+            "active-use-it-when",
             "active-use-to",
             "modal-after-em-dash",
             "passive-must-whenever",


### PR DESCRIPTION
## Summary

- recognize clear sentence-level routing clauses beginning with Use for and Use it when
- preserve sentence-boundary guards against explanatory prose false positives
- keep missing, empty, and name-restatement diagnostics unchanged
- add realistic regression fixtures and update rule documentation

This implements the focused signal recommendation from #532. Findings on the sampled corpora drop from 8 to 6 for anthropics/skills and 242 to 226 for github/awesome-copilot.

## Validation

- make test: 5,130 passed
- make lint
- make update and self-lint
- focused routing and marketplace tests: 101 passed
- medium benchmark: no regression
- latest openshift-eng/ai-helpers: exit 0