### PR TITLE
Collapse noisy repeated findings in text output

### DIFF
--- a/.agents/skills/skillsaw-fix/SKILL.md
+++ b/.agents/skills/skillsaw-fix/SKILL.md
@@ -28,8 +28,9 @@ unavailable).
 
 Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
 `--no-collapse` keeps repetitive findings individually visible to the agent.
-Each violation line includes the severity, file path, line number, message,
-and rule ID — read them all.
+Each violation line includes the severity, file path, message, and rule ID;
+line-specific violations also include a line number. Inventory file-level
+violations even when no line number is present.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 

--- a/.agents/skills/skillsaw-fix/SKILL.md
+++ b/.agents/skills/skillsaw-fix/SKILL.md
@@ -26,9 +26,10 @@ unavailable).
 
 ## Step 2: Run the lint and build an inventory
 
-Run `skillsaw` (lint) from the repo root and capture the output. Each
-violation line includes the severity, file path, line number, message, and
-rule ID — read them all.
+Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
+`--no-collapse` keeps repetitive findings individually visible to the agent.
+Each violation line includes the severity, file path, line number, message,
+and rule ID — read them all.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 
@@ -49,7 +50,8 @@ hunk is correct, run `skillsaw fix --suggest` to apply the tier. If any hunk is
 wrong, skip the tier entirely, handle those violations manually in Step 5, and
 keep only the edits you judged correct.
 
-Re-run `skillsaw` and report how many violations the autofixer resolved.
+Re-run `skillsaw lint --no-collapse .` and report how many violations the
+autofixer resolved.
 
 ## Step 4: Read fix guidance for each remaining rule
 
@@ -73,10 +75,11 @@ Handle the violations file by file. For each violation:
    structure, and formatting
 3. Keep edits minimal — never rewrite a whole file to fix one line
 
-After finishing a file, re-run `skillsaw` scoped to confirm the violations
-are gone and your edit introduced no new ones. Always re-lint even after an edit
-that looks obviously correct: wrap a path in a link, split a section,
-or add a directive, and you can trip a *different* rule you now have to fix.
+After finishing a file, re-run `skillsaw lint --no-collapse <path>` scoped to
+confirm the violations are gone and your edit introduced no new ones. Always
+re-lint even after an edit that looks obviously correct: wrap a path in a
+link, split a section, or add a directive, and you can trip a *different* rule
+you now have to fix.
 
 ### Handle common cases
 

--- a/.agents/skills/skillsaw-lint/SKILL.md
+++ b/.agents/skills/skillsaw-lint/SKILL.md
@@ -38,9 +38,10 @@ Run the linter scoped to the files or directories you created or edited:
 skillsaw lint --no-collapse <path>
 ```
 
-Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. Keep `--no-collapse` so repetitive findings remain
-individually visible to the agent. If the repository defines its own lint
+Read each violation line: it carries the severity, file path, message, rule ID,
+and a line number when tied to a specific line. File-level violations omit line
+numbers and still require handling. Keep `--no-collapse` so repetitive findings
+remain individually visible to the agent. If the repository defines its own lint
 entry point (a Makefile `lint` target that runs skillsaw, for example), run
 that first — it may pin a version or pass flags like `--strict` — then use the
 pinned CLI with `--no-collapse` when violations need inspection.

--- a/.agents/skills/skillsaw-lint/SKILL.md
+++ b/.agents/skills/skillsaw-lint/SKILL.md
@@ -35,13 +35,15 @@ with `uvx skillsaw==<version>` as the prefix for every command below (or
 Run the linter scoped to the files or directories you created or edited:
 
 ```sh
-skillsaw lint <path>
+skillsaw lint --no-collapse <path>
 ```
 
 Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. If the repository defines its own lint entry point (a
-Makefile `lint` target that runs skillsaw, for example), run that instead —
-it may pin a version or pass flags like `--strict`.
+message, and rule ID. Keep `--no-collapse` so repetitive findings remain
+individually visible to the agent. If the repository defines its own lint
+entry point (a Makefile `lint` target that runs skillsaw, for example), run
+that first — it may pin a version or pass flags like `--strict` — then use the
+pinned CLI with `--no-collapse` when violations need inspection.
 
 If the lint exits 0 with no violations, your work is clean — stop here and
 report done.
@@ -74,11 +76,11 @@ its guidance.
 
 ## Step 5: Re-lint until clean
 
-Re-run `skillsaw lint <path>` after your edits and repeat Steps 3–4 until it
-exits 0. Then run `skillsaw` from the repository root to confirm your changes
-introduced no violations elsewhere. The lint output ends with a letter grade
-for the repository's agentic content — leave it the same or better than you
-found it.
+Re-run `skillsaw lint --no-collapse <path>` after your edits and repeat Steps
+3–4 until it exits 0. Then run `skillsaw lint --no-collapse .` from the
+repository root to confirm your changes introduced no violations elsewhere.
+The lint output ends with a letter grade for the repository's agentic content
+— leave it the same or better than you found it.
 
 ## When to escalate
 

--- a/.claude/skills/skillsaw-fix/SKILL.md
+++ b/.claude/skills/skillsaw-fix/SKILL.md
@@ -28,8 +28,9 @@ unavailable).
 
 Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
 `--no-collapse` keeps repetitive findings individually visible to the agent.
-Each violation line includes the severity, file path, line number, message,
-and rule ID — read them all.
+Each violation line includes the severity, file path, message, and rule ID;
+line-specific violations also include a line number. Inventory file-level
+violations even when no line number is present.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 

--- a/.claude/skills/skillsaw-fix/SKILL.md
+++ b/.claude/skills/skillsaw-fix/SKILL.md
@@ -26,9 +26,10 @@ unavailable).
 
 ## Step 2: Run the lint and build an inventory
 
-Run `skillsaw` (lint) from the repo root and capture the output. Each
-violation line includes the severity, file path, line number, message, and
-rule ID — read them all.
+Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
+`--no-collapse` keeps repetitive findings individually visible to the agent.
+Each violation line includes the severity, file path, line number, message,
+and rule ID — read them all.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 
@@ -49,7 +50,8 @@ hunk is correct, run `skillsaw fix --suggest` to apply the tier. If any hunk is
 wrong, skip the tier entirely, handle those violations manually in Step 5, and
 keep only the edits you judged correct.
 
-Re-run `skillsaw` and report how many violations the autofixer resolved.
+Re-run `skillsaw lint --no-collapse .` and report how many violations the
+autofixer resolved.
 
 ## Step 4: Read fix guidance for each remaining rule
 
@@ -73,10 +75,11 @@ Handle the violations file by file. For each violation:
    structure, and formatting
 3. Keep edits minimal — never rewrite a whole file to fix one line
 
-After finishing a file, re-run `skillsaw` scoped to confirm the violations
-are gone and your edit introduced no new ones. Always re-lint even after an edit
-that looks obviously correct: wrap a path in a link, split a section,
-or add a directive, and you can trip a *different* rule you now have to fix.
+After finishing a file, re-run `skillsaw lint --no-collapse <path>` scoped to
+confirm the violations are gone and your edit introduced no new ones. Always
+re-lint even after an edit that looks obviously correct: wrap a path in a
+link, split a section, or add a directive, and you can trip a *different* rule
+you now have to fix.
 
 ### Handle common cases
 

--- a/.claude/skills/skillsaw-lint/SKILL.md
+++ b/.claude/skills/skillsaw-lint/SKILL.md
@@ -38,9 +38,10 @@ Run the linter scoped to the files or directories you created or edited:
 skillsaw lint --no-collapse <path>
 ```
 
-Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. Keep `--no-collapse` so repetitive findings remain
-individually visible to the agent. If the repository defines its own lint
+Read each violation line: it carries the severity, file path, message, rule ID,
+and a line number when tied to a specific line. File-level violations omit line
+numbers and still require handling. Keep `--no-collapse` so repetitive findings
+remain individually visible to the agent. If the repository defines its own lint
 entry point (a Makefile `lint` target that runs skillsaw, for example), run
 that first — it may pin a version or pass flags like `--strict` — then use the
 pinned CLI with `--no-collapse` when violations need inspection.

--- a/.claude/skills/skillsaw-lint/SKILL.md
+++ b/.claude/skills/skillsaw-lint/SKILL.md
@@ -35,13 +35,15 @@ with `uvx skillsaw==<version>` as the prefix for every command below (or
 Run the linter scoped to the files or directories you created or edited:
 
 ```sh
-skillsaw lint <path>
+skillsaw lint --no-collapse <path>
 ```
 
 Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. If the repository defines its own lint entry point (a
-Makefile `lint` target that runs skillsaw, for example), run that instead —
-it may pin a version or pass flags like `--strict`.
+message, and rule ID. Keep `--no-collapse` so repetitive findings remain
+individually visible to the agent. If the repository defines its own lint
+entry point (a Makefile `lint` target that runs skillsaw, for example), run
+that first — it may pin a version or pass flags like `--strict` — then use the
+pinned CLI with `--no-collapse` when violations need inspection.
 
 If the lint exits 0 with no violations, your work is clean — stop here and
 report done.
@@ -74,11 +76,11 @@ its guidance.
 
 ## Step 5: Re-lint until clean
 
-Re-run `skillsaw lint <path>` after your edits and repeat Steps 3–4 until it
-exits 0. Then run `skillsaw` from the repository root to confirm your changes
-introduced no violations elsewhere. The lint output ends with a letter grade
-for the repository's agentic content — leave it the same or better than you
-found it.
+Re-run `skillsaw lint --no-collapse <path>` after your edits and repeat Steps
+3–4 until it exits 0. Then run `skillsaw lint --no-collapse .` from the
+repository root to confirm your changes introduced no violations elsewhere.
+The lint output ends with a letter grade for the repository's agentic content
+— leave it the same or better than you found it.
 
 ## When to escalate
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,7 @@ Lint agent skills, plugins, and AI coding assistant context
 | `--strict` | Treat warnings as errors (equivalent to --fail-on warning; overrides the config file's strict/fail-on settings) |  |
 | `--fail-on` | Fail on violations at this severity or above (default: error; --strict is equivalent to --fail-on warning). Overrides the config file's strict/fail-on settings. (choices: error, warning, info) |  |
 | `--format` | Output format for stdout (default: text) (choices: text, json, sarif, html, code-climate, gitlab) | `text` |
+| `--no-collapse` | Show every text diagnostic instead of grouping repetitive findings (text output only) |  |
 | `--output` | Write output to FILE. Format is inferred from extension (.htm, .html, .json, .sarif, .txt) or set explicitly with a FORMAT: prefix (e.g. gitlab:report.json). Use the prefix when an extension is ambiguous (e.g. .json could be json or gitlab/code-climate). Can be specified multiple times. |  |
 | `--type` | Override auto-detected repository type (repeatable). Values: single-plugin, marketplace, agentskills, dot-claude, coderabbit, apm, promptfoo, codex-plugin, codex-marketplace, agent-plugin. |  |
 | `--rule` | Only run these rules (repeatable). Config still comes from .skillsaw.yaml. |  |

--- a/docs/rules/agentskill-unreferenced-files.md
+++ b/docs/rules/agentskill-unreferenced-files.md
@@ -115,6 +115,11 @@ is bundled. If the file is intentionally unlisted supporting data,
 either mention its directory (`assets/`) from SKILL.md or add a glob
 to the rule's `exclude` option:
 
+To keep interactive output readable, the text formatter shows three or
+more findings in the same top-level skill directory as one summary row.
+The summary count, baselines, machine-readable formats, and exit status
+still use every individual finding.
+
 ```yaml
 rules:
   agentskill-unreferenced-files:

--- a/docs/rules/agentskill-unreferenced-files.md
+++ b/docs/rules/agentskill-unreferenced-files.md
@@ -118,7 +118,8 @@ to the rule's `exclude` option:
 To keep interactive output readable, the text formatter shows three or
 more findings in the same top-level skill directory as one summary row.
 The summary count, baselines, machine-readable formats, and exit status
-still use every individual finding.
+still use every individual finding. Run `skillsaw lint --no-collapse <path>`
+to show every file as its own terminal row.
 
 ```yaml
 rules:

--- a/docs/rules/content-mcp-tool-name.md
+++ b/docs/rules/content-mcp-tool-name.md
@@ -109,6 +109,10 @@ A violation in a body decoded out of a non-markdown host — a JSON hook
 prompt, a folded (`>`) YAML scalar — is reported without an automatic fix;
 apply the same rewrites by hand.
 
+When three or more findings in one file share a server prefix, terminal
+output groups them into one readable row. This is presentation only: machine
+reports, baselines, counts, and fixes still retain every occurrence.
+
 ## Configuration
 
 ```yaml

--- a/docs/rules/content-mcp-tool-name.md
+++ b/docs/rules/content-mcp-tool-name.md
@@ -111,7 +111,9 @@ apply the same rewrites by hand.
 
 When three or more findings in one file share a server prefix, terminal
 output groups them into one readable row. This is presentation only: machine
-reports, baselines, counts, and fixes still retain every occurrence.
+reports, baselines, counts, and fixes still retain every occurrence. Run
+`skillsaw lint --no-collapse <path>` to show every occurrence as its own
+terminal row.
 
 ## Configuration
 

--- a/skills/skillsaw-fix/SKILL.md
+++ b/skills/skillsaw-fix/SKILL.md
@@ -28,8 +28,9 @@ unavailable).
 
 Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
 `--no-collapse` keeps repetitive findings individually visible to the agent.
-Each violation line includes the severity, file path, line number, message,
-and rule ID — read them all.
+Each violation line includes the severity, file path, message, and rule ID;
+line-specific violations also include a line number. Inventory file-level
+violations even when no line number is present.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 

--- a/skills/skillsaw-fix/SKILL.md
+++ b/skills/skillsaw-fix/SKILL.md
@@ -26,9 +26,10 @@ unavailable).
 
 ## Step 2: Run the lint and build an inventory
 
-Run `skillsaw` (lint) from the repo root and capture the output. Each
-violation line includes the severity, file path, line number, message, and
-rule ID — read them all.
+Run `skillsaw lint --no-collapse .` from the repo root and capture the output.
+`--no-collapse` keeps repetitive findings individually visible to the agent.
+Each violation line includes the severity, file path, line number, message,
+and rule ID — read them all.
 
 If the lint exits 0 with no violations, tell the user the repo is clean and stop.
 
@@ -49,7 +50,8 @@ hunk is correct, run `skillsaw fix --suggest` to apply the tier. If any hunk is
 wrong, skip the tier entirely, handle those violations manually in Step 5, and
 keep only the edits you judged correct.
 
-Re-run `skillsaw` and report how many violations the autofixer resolved.
+Re-run `skillsaw lint --no-collapse .` and report how many violations the
+autofixer resolved.
 
 ## Step 4: Read fix guidance for each remaining rule
 
@@ -73,10 +75,11 @@ Handle the violations file by file. For each violation:
    structure, and formatting
 3. Keep edits minimal — never rewrite a whole file to fix one line
 
-After finishing a file, re-run `skillsaw` scoped to confirm the violations
-are gone and your edit introduced no new ones. Always re-lint even after an edit
-that looks obviously correct: wrap a path in a link, split a section,
-or add a directive, and you can trip a *different* rule you now have to fix.
+After finishing a file, re-run `skillsaw lint --no-collapse <path>` scoped to
+confirm the violations are gone and your edit introduced no new ones. Always
+re-lint even after an edit that looks obviously correct: wrap a path in a
+link, split a section, or add a directive, and you can trip a *different* rule
+you now have to fix.
 
 ### Handle common cases
 

--- a/skills/skillsaw-lint/SKILL.md
+++ b/skills/skillsaw-lint/SKILL.md
@@ -38,9 +38,10 @@ Run the linter scoped to the files or directories you created or edited:
 skillsaw lint --no-collapse <path>
 ```
 
-Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. Keep `--no-collapse` so repetitive findings remain
-individually visible to the agent. If the repository defines its own lint
+Read each violation line: it carries the severity, file path, message, rule ID,
+and a line number when tied to a specific line. File-level violations omit line
+numbers and still require handling. Keep `--no-collapse` so repetitive findings
+remain individually visible to the agent. If the repository defines its own lint
 entry point (a Makefile `lint` target that runs skillsaw, for example), run
 that first — it may pin a version or pass flags like `--strict` — then use the
 pinned CLI with `--no-collapse` when violations need inspection.

--- a/skills/skillsaw-lint/SKILL.md
+++ b/skills/skillsaw-lint/SKILL.md
@@ -35,13 +35,15 @@ with `uvx skillsaw==<version>` as the prefix for every command below (or
 Run the linter scoped to the files or directories you created or edited:
 
 ```sh
-skillsaw lint <path>
+skillsaw lint --no-collapse <path>
 ```
 
 Read each violation line: it carries the severity, file path, line number,
-message, and rule ID. If the repository defines its own lint entry point (a
-Makefile `lint` target that runs skillsaw, for example), run that instead —
-it may pin a version or pass flags like `--strict`.
+message, and rule ID. Keep `--no-collapse` so repetitive findings remain
+individually visible to the agent. If the repository defines its own lint
+entry point (a Makefile `lint` target that runs skillsaw, for example), run
+that first — it may pin a version or pass flags like `--strict` — then use the
+pinned CLI with `--no-collapse` when violations need inspection.
 
 If the lint exits 0 with no violations, your work is clean — stop here and
 report done.
@@ -74,11 +76,11 @@ its guidance.
 
 ## Step 5: Re-lint until clean
 
-Re-run `skillsaw lint <path>` after your edits and repeat Steps 3–4 until it
-exits 0. Then run `skillsaw` from the repository root to confirm your changes
-introduced no violations elsewhere. The lint output ends with a letter grade
-for the repository's agentic content — leave it the same or better than you
-found it.
+Re-run `skillsaw lint --no-collapse <path>` after your edits and repeat Steps
+3–4 until it exits 0. Then run `skillsaw lint --no-collapse .` from the
+repository root to confirm your changes introduced no violations elsewhere.
+The lint output ends with a letter grade for the repository's agentic content
+— leave it the same or better than you found it.
 
 ## When to escalate
 

--- a/src/skillsaw/cli/_lint.py
+++ b/src/skillsaw/cli/_lint.py
@@ -248,6 +248,7 @@ def _run_lint(args):
         fail_level=fail_level,
         color=color,
         hyperlinks=hyperlinks_enabled(sys.stdout, color),
+        collapse=not args.no_collapse,
     )
     print(stdout_output)
 
@@ -265,6 +266,7 @@ def _run_lint(args):
                 duration=lint_duration,
                 grade=grade,
                 fail_level=fail_level,
+                collapse=not args.no_collapse,
             )
         out_path = Path(output_path)
         try:

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -143,6 +143,12 @@ For more information, visit: https://github.com/stbenjam/skillsaw
         help="Output format for stdout (default: text)",
     )
     lint_parser.add_argument(
+        "--no-collapse",
+        action="store_true",
+        help="Show every text diagnostic instead of grouping repetitive findings "
+        "(text output only)",
+    )
+    lint_parser.add_argument(
         "--output",
         dest="outputs",
         action="append",

--- a/src/skillsaw/formatters/__init__.py
+++ b/src/skillsaw/formatters/__init__.py
@@ -118,6 +118,7 @@ def format_report(
     fail_level: str = "error",
     color: bool = False,
     hyperlinks: bool = False,
+    collapse: bool = True,
 ) -> str:
     """
     Format lint results in the specified format.
@@ -139,6 +140,7 @@ def format_report(
         color: Emit ANSI colors (text format only — resolved by the caller
             via ``color_enabled()``; file outputs stay plain)
         hyperlinks: Emit OSC 8 terminal hyperlinks (text format only)
+        collapse: Group repetitive text diagnostics into summary rows
     """
     # Normalized once here, at the single point every format and every sink
     # — stdout and each --output file — passes through. A rule cannot know
@@ -159,6 +161,7 @@ def format_report(
             fail_level=fail_level,
             color=color,
             hyperlinks=hyperlinks,
+            collapse=collapse,
         )
     )
 
@@ -176,6 +179,7 @@ def _render_report(
     fail_level: str = "error",
     color: bool = False,
     hyperlinks: bool = False,
+    collapse: bool = True,
 ) -> str:
     """Dispatch to the per-format renderer. See :func:`format_report`."""
     if fmt == "text":
@@ -193,6 +197,7 @@ def _render_report(
             fail_level,
             color=color,
             hyperlinks=hyperlinks,
+            collapse=collapse,
         )
     elif fmt == "json":
         from .json_fmt import format_json

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -2,6 +2,7 @@
 Text output formatter — human-readable terminal output with optional ANSI colors.
 """
 
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,12 @@ from . import get_counts, relative_path, should_show_info
 from skillsaw.paths import contained_resolve, safe_resolve
 
 _COLLAPSE_THRESHOLD = 3
+# Keep the token portion aligned with content.mcp_tool_name's candidate
+# grammar and first-``__`` server/tool split. The trailing ordinal is part of
+# that rule's stable fingerprint discriminator, not presentation text.
+_MCP_DISCRIMINATOR_RE = re.compile(
+    r"(?P<token>mcp__(?P<server>[A-Za-z0-9_-]+?)__(?P<tool>[A-Za-z0-9_-]+)):(?P<ordinal>\d+)"
+)
 
 
 @dataclass(frozen=True)
@@ -109,8 +116,73 @@ def _collapse_unreferenced_skill_files(
     return plan
 
 
+def _mcp_server_prefix(violation: RuleViolation) -> Optional[str]:
+    """Read a validated MCP server prefix from the stable discriminator."""
+    discriminator = violation.fingerprint_discriminator
+    if not discriminator:
+        return None
+    match = _MCP_DISCRIMINATOR_RE.fullmatch(discriminator)
+    if match is None:
+        return None
+    return f"mcp__{match.group('server')}__"
+
+
+def _collapse_mcp_tool_names(
+    indexed: Sequence[Tuple[int, RuleViolation]], context
+) -> _TextCollapsePlan:
+    """Collapse repeated fully-qualified names for one file and server."""
+    grouped = defaultdict(list)
+    for position, violation in indexed:
+        if violation.file_path is None:
+            continue
+        server_prefix = _mcp_server_prefix(violation)
+        if server_prefix is None:
+            continue
+        key = (
+            _absolute_path(violation.file_path, context.root_path),
+            server_prefix,
+            violation.severity,
+            violation.source,
+            violation.fixable,
+            violation.fix_confidence,
+        )
+        grouped[key].append((position, violation))
+
+    plan: _TextCollapsePlan = {}
+    for (_, server_prefix, *_), members in grouped.items():
+        if len(members) < _COLLAPSE_THRESHOLD:
+            continue
+        distinct_lines = list(
+            dict.fromkeys(
+                violation.file_line for _, violation in members if violation.file_line is not None
+            )
+        )
+        line_summary = ""
+        if distinct_lines:
+            displayed_lines = ", ".join(str(line) for line in distinct_lines[:3])
+            if len(distinct_lines) > 3:
+                displayed_lines += ", …"
+            line_summary = f" (lines {displayed_lines})"
+
+        first_position, first_violation = members[0]
+        plan[first_position] = _TextDiagnostic(
+            violation=first_violation,
+            message=(
+                f"{len(members)} fully-qualified MCP tool names use the "
+                f"'{server_prefix}' server prefix — use short names because "
+                f"the prefix depends on the reader's server name{line_summary}"
+            ),
+            file_path=first_violation.file_path,
+            file_line=first_violation.file_line,
+        )
+        for position, _ in members[1:]:
+            plan[position] = None
+    return plan
+
+
 _TEXT_COLLAPSE_STRATEGIES: Dict[str, _TextCollapseStrategy] = {
     "agentskill-unreferenced-files": _collapse_unreferenced_skill_files,
+    "content-mcp-tool-name": _collapse_mcp_tool_names,
 }
 
 

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -248,6 +248,7 @@ def format_text(
     fail_level: str = "error",
     color: bool = False,
     hyperlinks: bool = False,
+    collapse: bool = True,
 ) -> str:
     show_info = should_show_info(verbose, fail_level)
     red = "\033[91m" if color else ""
@@ -295,24 +296,41 @@ def format_text(
             f"{terminal_safe(diagnostic.message)}"
         )
 
+    def diagnostics(items: Sequence[RuleViolation]) -> List[_TextDiagnostic]:
+        if collapse:
+            return _text_diagnostics(items, context)
+        return [_TextDiagnostic.individual(violation) for violation in items]
+
+    error_diagnostics = diagnostics(errors_list)
+    warning_diagnostics = diagnostics(warnings_list)
+    info_diagnostics = diagnostics(info_list) if show_info else []
+
     output = []
 
     if errors_list:
         output.append(f"\n{red}{bold}Errors:{reset}")
-        for diagnostic in _text_diagnostics(errors_list, context):
+        for diagnostic in error_diagnostics:
             output.append(f"  {fmt_violation(diagnostic)}")
 
     if warnings_list:
         output.append(f"\n{yellow}{bold}Warnings:{reset}")
-        for diagnostic in _text_diagnostics(warnings_list, context):
+        for diagnostic in warning_diagnostics:
             output.append(f"  {fmt_violation(diagnostic)}")
 
     if show_info and info_list:
         output.append(f"\n{blue}{bold}Info:{reset}")
-        for diagnostic in _text_diagnostics(info_list, context):
+        for diagnostic in info_diagnostics:
             output.append(f"  {fmt_violation(diagnostic)}")
 
     shown = errors_list + warnings_list + (info_list if show_info else [])
+    diagnostic_count = len(error_diagnostics) + len(warning_diagnostics) + len(info_diagnostics)
+    grouped_count = len(shown) - diagnostic_count
+    if grouped_count:
+        output.append(
+            f"\n{dim}{grouped_count} finding(s) grouped into summary rows above — "
+            f"run with `--no-collapse` to show every finding.{reset}"
+        )
+
     documented = sorted({v.rule_id for v in shown if v.rule_id in builtin_ids})
     if documented:
         if hyperlinks:

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -2,14 +2,136 @@
 Text output formatter — human-readable terminal output with optional ANSI colors.
 """
 
+from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from ..rule import AutofixConfidence, Rule, RuleViolation, Severity
 from ..rule_docs import rule_doc_url
 from ..diagnostics import terminal_safe
 from . import get_counts, relative_path, should_show_info
 from skillsaw.paths import contained_resolve, safe_resolve
+
+_COLLAPSE_THRESHOLD = 3
+
+
+@dataclass(frozen=True)
+class _TextDiagnostic:
+    """One human-facing row anchored to a real violation."""
+
+    violation: RuleViolation
+    message: str
+    file_path: Optional[Path]
+    file_line: Optional[int]
+
+    @classmethod
+    def individual(cls, violation: RuleViolation) -> "_TextDiagnostic":
+        return cls(
+            violation=violation,
+            message=violation.message,
+            file_path=violation.file_path,
+            file_line=violation.file_line,
+        )
+
+
+# A strategy receives positions for one rule and returns presentation-only
+# replacements. ``None`` hides a later row whose violations are represented
+# by the diagnostic at the group's first position. The original violation
+# list is never changed and remains authoritative for counts, baselines, exit
+# status, and every structured formatter.
+_TextCollapsePlan = Dict[int, Optional[_TextDiagnostic]]
+_TextCollapseStrategy = Callable[[Sequence[Tuple[int, RuleViolation]], object], _TextCollapsePlan]
+
+
+def _absolute_path(path: Path, root_path: Path) -> Path:
+    return path if path.is_absolute() else root_path / path
+
+
+def _skill_subtree(violation: RuleViolation, context) -> Optional[Tuple[Path, str]]:
+    """Return the first directory below the containing skill, if any."""
+    if violation.file_path is None:
+        return None
+    violation_path = _absolute_path(violation.file_path, context.root_path)
+    matches = []
+    for skill in context.skills:
+        skill_path = _absolute_path(Path(skill), context.root_path)
+        try:
+            relative = violation_path.relative_to(skill_path)
+        except ValueError:
+            continue
+        if len(relative.parts) >= 2:
+            matches.append((len(skill_path.parts), skill_path, relative.parts[0]))
+    if not matches:
+        return None
+    _, skill_path, directory = max(matches, key=lambda match: match[0])
+    return skill_path / directory, f"{directory}/"
+
+
+def _collapse_unreferenced_skill_files(
+    indexed: Sequence[Tuple[int, RuleViolation]], context
+) -> _TextCollapsePlan:
+    """Collapse unreferenced files sharing a skill's top-level subtree."""
+    grouped = defaultdict(list)
+    for position, violation in indexed:
+        subtree = _skill_subtree(violation, context)
+        if subtree is None:
+            continue
+        subtree_path, label = subtree
+        # Keep differently configured severities and presentation metadata
+        # isolated even though a normal run gives this rule one severity.
+        key = (
+            subtree_path,
+            label,
+            violation.severity,
+            violation.source,
+            violation.fixable,
+            violation.fix_confidence,
+        )
+        grouped[key].append((position, violation))
+
+    plan: _TextCollapsePlan = {}
+    for (subtree_path, label, *_), members in grouped.items():
+        if len(members) < _COLLAPSE_THRESHOLD:
+            continue
+        first_position = members[0][0]
+        plan[first_position] = _TextDiagnostic(
+            violation=members[0][1],
+            message=(
+                f"{len(members)} files under '{label}' are never referenced from "
+                "SKILL.md (directly or transitively)"
+            ),
+            file_path=subtree_path,
+            file_line=None,
+        )
+        for position, _ in members[1:]:
+            plan[position] = None
+    return plan
+
+
+_TEXT_COLLAPSE_STRATEGIES: Dict[str, _TextCollapseStrategy] = {
+    "agentskill-unreferenced-files": _collapse_unreferenced_skill_files,
+}
+
+
+def _text_diagnostics(violations: Sequence[RuleViolation], context) -> List[_TextDiagnostic]:
+    """Build presentation rows without changing the underlying findings."""
+    by_rule = defaultdict(list)
+    for position, violation in enumerate(violations):
+        if violation.rule_id in _TEXT_COLLAPSE_STRATEGIES:
+            by_rule[violation.rule_id].append((position, violation))
+
+    plan: _TextCollapsePlan = {}
+    for rule_id, indexed in by_rule.items():
+        plan.update(_TEXT_COLLAPSE_STRATEGIES[rule_id](indexed, context))
+
+    diagnostics = []
+    for position, violation in enumerate(violations):
+        if position not in plan:
+            diagnostics.append(_TextDiagnostic.individual(violation))
+        elif plan[position] is not None:
+            diagnostics.append(plan[position])
+    return diagnostics
 
 
 def format_duration(seconds: float) -> str:
@@ -80,14 +202,15 @@ def format_text(
             return ""
         return " [*]" if v.fix_confidence == AutofixConfidence.SAFE else " [?]"
 
-    def fmt_violation(v: RuleViolation) -> str:
+    def fmt_violation(diagnostic: _TextDiagnostic) -> str:
+        v = diagnostic.violation
         icon = {"error": "✗", "warning": "⚠", "info": "ℹ"}[v.severity.value]
-        rel = terminal_safe(relative_path(v.file_path, context.root_path) or "")
+        rel = terminal_safe(relative_path(diagnostic.file_path, context.root_path) or "")
         location = ""
         if rel:
-            loc_text = f"{rel}:{v.file_line}" if v.file_line else rel
+            loc_text = f"{rel}:{diagnostic.file_line}" if diagnostic.file_line else rel
             if hyperlinks:
-                uri = _file_uri(v.file_path, context.root_path)
+                uri = _file_uri(diagnostic.file_path, context.root_path)
                 if uri:
                     loc_text = _osc8(uri, loc_text)
             location = f" [{loc_text}]"
@@ -97,25 +220,25 @@ def format_text(
             rule_ref = _osc8(rule_doc_url(v.rule_id), safe_rule_id)
         return (
             f"{icon} {v.severity.value.upper()} ({rule_ref}){fix_marker(v)}{location}: "
-            f"{terminal_safe(v.message)}"
+            f"{terminal_safe(diagnostic.message)}"
         )
 
     output = []
 
     if errors_list:
         output.append(f"\n{red}{bold}Errors:{reset}")
-        for v in errors_list:
-            output.append(f"  {fmt_violation(v)}")
+        for diagnostic in _text_diagnostics(errors_list, context):
+            output.append(f"  {fmt_violation(diagnostic)}")
 
     if warnings_list:
         output.append(f"\n{yellow}{bold}Warnings:{reset}")
-        for v in warnings_list:
-            output.append(f"  {fmt_violation(v)}")
+        for diagnostic in _text_diagnostics(warnings_list, context):
+            output.append(f"  {fmt_violation(diagnostic)}")
 
     if show_info and info_list:
         output.append(f"\n{blue}{bold}Info:{reset}")
-        for v in info_list:
-            output.append(f"  {fmt_violation(v)}")
+        for diagnostic in _text_diagnostics(info_list, context):
+            output.append(f"  {fmt_violation(diagnostic)}")
 
     shown = errors_list + warnings_list + (info_list if show_info else [])
     documented = sorted({v.rule_id for v in shown if v.rule_id in builtin_ids})

--- a/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
+++ b/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
@@ -100,6 +100,11 @@ is bundled. If the file is intentionally unlisted supporting data,
 either mention its directory (`assets/`) from SKILL.md or add a glob
 to the rule's `exclude` option:
 
+To keep interactive output readable, the text formatter shows three or
+more findings in the same top-level skill directory as one summary row.
+The summary count, baselines, machine-readable formats, and exit status
+still use every individual finding.
+
 ```yaml
 rules:
   agentskill-unreferenced-files:

--- a/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
+++ b/src/skillsaw/rules/docs/agentskill-unreferenced-files.md
@@ -103,7 +103,8 @@ to the rule's `exclude` option:
 To keep interactive output readable, the text formatter shows three or
 more findings in the same top-level skill directory as one summary row.
 The summary count, baselines, machine-readable formats, and exit status
-still use every individual finding.
+still use every individual finding. Run `skillsaw lint --no-collapse <path>`
+to show every file as its own terminal row.
 
 ```yaml
 rules:

--- a/src/skillsaw/rules/docs/content-mcp-tool-name.md
+++ b/src/skillsaw/rules/docs/content-mcp-tool-name.md
@@ -94,3 +94,7 @@ replacement is a judgment call, which is yours to make in review:
 A violation in a body decoded out of a non-markdown host — a JSON hook
 prompt, a folded (`>`) YAML scalar — is reported without an automatic fix;
 apply the same rewrites by hand.
+
+When three or more findings in one file share a server prefix, terminal
+output groups them into one readable row. This is presentation only: machine
+reports, baselines, counts, and fixes still retain every occurrence.

--- a/src/skillsaw/rules/docs/content-mcp-tool-name.md
+++ b/src/skillsaw/rules/docs/content-mcp-tool-name.md
@@ -97,4 +97,6 @@ apply the same rewrites by hand.
 
 When three or more findings in one file share a server prefix, terminal
 output groups them into one readable row. This is presentation only: machine
-reports, baselines, counts, and fixes still retain every occurrence.
+reports, baselines, counts, and fixes still retain every occurrence. Run
+`skillsaw lint --no-collapse <path>` to show every occurrence as its own
+terminal row.

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/SKILL.md
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: image-catalog
+description: Catalog product images and produce a review manifest. Use when preparing a product-image inventory.
+---
+
+# Image Catalog
+
+Catalog product images and produce a review manifest for the user.
+
+## Workflow
+
+Inspect the provided image directory, identify each product, and return a
+manifest with the filename, product identifier, and review status.

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/back.png
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/back.png
@@ -1,0 +1,1 @@
+back image fixture

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/front.png
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/front.png
@@ -1,0 +1,1 @@
+front image fixture

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/side.png
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/assets/side.png
@@ -1,0 +1,1 @@
+side image fixture

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/orphan.txt
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/orphan.txt
@@ -1,0 +1,1 @@
+Unreferenced root-level fixture.

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/scripts/export.py
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/scripts/export.py
@@ -1,0 +1,1 @@
+"""Export the catalog from the review system."""

--- a/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/scripts/import.py
+++ b/tests/fixtures/agentskills/unreferenced-collapse/image-catalog/scripts/import.py
@@ -1,0 +1,1 @@
+"""Import the catalog into the review system."""

--- a/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/SKILL.md
+++ b/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: video-catalog
+description: Catalog product videos and produce a review manifest. Use when preparing a product-video inventory.
+---
+
+# Video Catalog
+
+Catalog product videos and produce a review manifest for the user.
+
+## Workflow
+
+Inspect the provided video directory, identify each product, and return a
+manifest with the filename, product identifier, and review status.

--- a/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/back.mp4
+++ b/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/back.mp4
@@ -1,0 +1,1 @@
+back video fixture

--- a/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/front.mp4
+++ b/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/front.mp4
@@ -1,0 +1,1 @@
+front video fixture

--- a/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/side.mp4
+++ b/tests/fixtures/agentskills/unreferenced-collapse/video-catalog/assets/side.mp4
@@ -1,0 +1,1 @@
+side video fixture

--- a/tests/fixtures/content/mcp-tool-name/CLAUDE.md
+++ b/tests/fixtures/content/mcp-tool-name/CLAUDE.md
@@ -14,6 +14,10 @@ someone has already picked up.
 Read the ticket body with `mcp__plugin_jira_atlassian__getJiraIssue` and quote
 the acceptance criteria in your plan before writing any code.
 
+<!-- skillsaw-assert content-mcp-tool-name -->
+Post progress with `mcp__plugin_jira_atlassian__addCommentToJiraIssue` when a
+review changes the agreed implementation plan.
+
 ## Reading files from GitHub
 
 <!-- skillsaw-assert content-mcp-tool-name -->

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -19,11 +19,14 @@ from skillsaw.formatters.json_fmt import format_json
 from skillsaw.formatters.sarif import format_sarif
 from skillsaw.formatters.html import format_html
 from skillsaw.formatters.code_climate import format_code_climate
+from skillsaw.formatters.text import _text_diagnostics
+from skillsaw.grade import compute_grade
 from skillsaw.rule import AutofixConfidence, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.config import LinterConfig
 from skillsaw.linter import Linter
 from skillsaw.lint_target import LintTarget
+from skillsaw.rules.builtin.content.mcp_tool_name import ContentMcpToolNameRule
 
 # --- Helpers ---
 
@@ -380,6 +383,198 @@ def test_structured_reports_keep_collapsed_text_findings_individual(valid_plugin
     html = format_html(violations, context, [], "1.0.0")
     assert all(path.name in html for path in paths)
     assert html.count("<code>agentskill-unreferenced-files</code>") == 3
+
+
+def _mcp_tool_name_violation(
+    path: Path,
+    line: int,
+    token: str,
+    ordinal: int,
+    *,
+    message: str,
+    **overrides,
+) -> RuleViolation:
+    values = {
+        "rule_id": "content-mcp-tool-name",
+        "severity": Severity.WARNING,
+        "message": message,
+        "file_path": path,
+        "line": line,
+        "source": "builtin",
+        "fixable": True,
+        "fix_confidence": AutofixConfidence.SUGGEST,
+        "fingerprint_discriminator": f"{token}:{ordinal}",
+    }
+    values.update(overrides)
+    return RuleViolation(**values)
+
+
+def test_text_mcp_collapse_keeps_raw_totals_and_order(valid_plugin):
+    """Only terminal rows collapse; all occurrence-level state stays intact."""
+    context = RepositoryContext(valid_plugin)
+    first_path = context.root_path / "CLAUDE.md"
+    second_path = context.root_path / "AGENTS.md"
+    jira = [
+        _mcp_tool_name_violation(
+            first_path,
+            line,
+            f"mcp__jira__tool__{index}",
+            index,
+            message=f"jira original {index}",
+        )
+        for index, line in enumerate((3, 3, 5, 7, 9))
+    ]
+    github = [
+        _mcp_tool_name_violation(
+            first_path,
+            12 + index,
+            f"mcp__github__tool_{index}",
+            0,
+            message=f"github original {index}",
+        )
+        for index in range(2)
+    ]
+    other_file = [
+        _mcp_tool_name_violation(
+            second_path,
+            4 + index,
+            f"mcp__jira__other_{index}",
+            0,
+            message=f"other-file original {index}",
+        )
+        for index in range(2)
+    ]
+    malformed = [
+        _mcp_tool_name_violation(
+            first_path,
+            20,
+            "mcp__jira__ignored",
+            0,
+            message="missing discriminator",
+            fingerprint_discriminator=None,
+        ),
+        _mcp_tool_name_violation(
+            first_path,
+            21,
+            "mcp__jira__ignored",
+            0,
+            message="malformed discriminator",
+            fingerprint_discriminator="mcp__jira__:0",
+        ),
+    ]
+    violations = jira + github + other_file + malformed
+    before = [
+        (
+            id(v),
+            v.file_path,
+            v.line,
+            v.message,
+            v.fingerprint_discriminator,
+            v.severity,
+            v.source,
+            v.fixable,
+            v.fix_confidence,
+        )
+        for v in violations
+    ]
+    grade = compute_grade(violations, 10_000)
+
+    output = format_text(
+        violations,
+        context,
+        [ContentMcpToolNameRule()],
+        "1.0.0",
+        grade=grade,
+    )
+
+    assert (
+        "[CLAUDE.md:3]: 5 fully-qualified MCP tool names use the "
+        "'mcp__jira__' server prefix" in output
+    )
+    assert "use short names because the prefix depends on the reader's server name" in output
+    assert "(lines 3, 5, 7, …)" in output
+    assert "jira original" not in output
+    # Below-threshold, different-file, and invalid-discriminator findings stay individual.
+    assert all(f"github original {index}" in output for index in range(2))
+    assert all(f"other-file original {index}" in output for index in range(2))
+    assert "missing discriminator" in output
+    assert "malformed discriminator" in output
+    assert "Warnings: 11" in output
+    assert "[?] 11 violation(s) fixable with `skillsaw fix --suggest`" in output
+    assert f"Grade:    {grade.letter} ({grade.density:.2f} weighted violations" in output
+    assert "https://skillsaw.org/rules/content-mcp-tool-name/" in output
+    assert [
+        (
+            id(v),
+            v.file_path,
+            v.line,
+            v.message,
+            v.fingerprint_discriminator,
+            v.severity,
+            v.source,
+            v.fixable,
+            v.fix_confidence,
+        )
+        for v in violations
+    ] == before
+
+
+def test_text_mcp_collapse_threshold_and_metadata_isolation(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    path = context.root_path / "CLAUDE.md"
+
+    def base(index: int, **overrides) -> RuleViolation:
+        return _mcp_tool_name_violation(
+            path,
+            index + 1,
+            f"mcp__jira__tool_{index}",
+            0,
+            message=f"original {index}",
+            **overrides,
+        )
+
+    pair = [base(0), base(1)]
+    assert len(_text_diagnostics(pair, context)) == 2
+    assert len(_text_diagnostics(pair + [base(2)], context)) == 1
+
+    # Two otherwise identical findings plus one changed metadata field must
+    # never cross the collapse threshold together.
+    for changed in (
+        {"severity": Severity.ERROR},
+        {"source": "plugin"},
+        {"fixable": False, "fix_confidence": None},
+        {"fix_confidence": AutofixConfidence.SAFE},
+    ):
+        diagnostics = _text_diagnostics(pair + [base(2, **changed)], context)
+        assert [d.message for d in diagnostics] == ["original 0", "original 1", "original 2"]
+
+
+def test_structured_reports_keep_mcp_tool_findings_individual(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    path = context.root_path / "CLAUDE.md"
+    violations = [
+        _mcp_tool_name_violation(
+            path,
+            index + 3,
+            f"mcp__jira__tool_{index}",
+            0,
+            message=f"original {index}",
+        )
+        for index in range(3)
+    ]
+
+    json_report = json.loads(format_json(violations, context, [], "1.0.0"))
+    assert [v["message"] for v in json_report["violations"]] == [
+        "original 0",
+        "original 1",
+        "original 2",
+    ]
+    sarif = json.loads(format_sarif(violations, context, [], "1.0.0"))
+    assert len(sarif["runs"][0]["results"]) == 3
+    assert len(json.loads(format_code_climate(violations, context, [], "1.0.0"))) == 3
+    html = format_html(violations, context, [], "1.0.0")
+    assert all(f"original {index}" in html for index in range(3))
+    assert html.count("<code>content-mcp-tool-name</code>") == 3
 
 
 # --- JSON formatter ---

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -356,8 +356,17 @@ def test_text_collapses_unreferenced_skill_subtrees_only(valid_plugin):
     assert "skills/first/scripts/two.py" in output
     assert "skills/first/orphan.txt" in output
     assert "Warnings: 9" in output
+    assert "4 finding(s) grouped into summary rows above" in output
+    assert "run with `--no-collapse` to show every finding" in output
     assert len(violations) == 9
     assert [(v.file_path, v.message) for v in violations] == before
+
+    expanded = format_text(violations, context, [], "1.0.0", collapse=False)
+
+    assert "files under 'assets/'" not in expanded
+    assert all(str(path.relative_to(context.root_path)) in expanded for path in paths)
+    assert "grouped into summary rows" not in expanded
+    assert "Warnings: 9" in expanded
 
 
 def test_structured_reports_keep_collapsed_text_findings_individual(valid_plugin):
@@ -500,6 +509,8 @@ def test_text_mcp_collapse_keeps_raw_totals_and_order(valid_plugin):
     assert "missing discriminator" in output
     assert "malformed discriminator" in output
     assert "Warnings: 11" in output
+    assert "4 finding(s) grouped into summary rows above" in output
+    assert "run with `--no-collapse` to show every finding" in output
     assert "[?] 11 violation(s) fixable with `skillsaw fix --suggest`" in output
     assert f"Grade:    {grade.letter} ({grade.density:.2f} weighted violations" in output
     assert "https://skillsaw.org/rules/content-mcp-tool-name/" in output

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -313,6 +313,75 @@ def test_text_non_verbose_hides_info(valid_plugin):
     assert "Info:" not in output
 
 
+def test_text_collapses_unreferenced_skill_subtrees_only(valid_plugin):
+    """Collapse noisy subtrees without merging skills or small/root groups."""
+    context = RepositoryContext(valid_plugin)
+    first_skill = context.root_path / "skills" / "first"
+    second_skill = context.root_path / "skills" / "second"
+    context.skills = [first_skill, second_skill]
+
+    paths = [
+        first_skill / "assets" / "one.png",
+        first_skill / "assets" / "two.png",
+        first_skill / "assets" / "nested" / "three.png",
+        first_skill / "scripts" / "one.py",
+        first_skill / "scripts" / "two.py",
+        first_skill / "orphan.txt",
+        second_skill / "assets" / "one.png",
+        second_skill / "assets" / "two.png",
+        second_skill / "assets" / "three.png",
+    ]
+    violations = [
+        RuleViolation(
+            rule_id="agentskill-unreferenced-files",
+            severity=Severity.WARNING,
+            message=f"'{path.name}' is never referenced from SKILL.md",
+            file_path=path,
+        )
+        for path in paths
+    ]
+    before = [(v.file_path, v.message) for v in violations]
+
+    output = format_text(violations, context, [], "1.0.0")
+
+    assert "[skills/first/assets]: 3 files under 'assets/'" in output
+    assert "[skills/second/assets]: 3 files under 'assets/'" in output
+    assert "skills/first/assets/one.png" not in output
+    assert "skills/second/assets/one.png" not in output
+    # Groups below the threshold and root-level files remain actionable rows.
+    assert "skills/first/scripts/one.py" in output
+    assert "skills/first/scripts/two.py" in output
+    assert "skills/first/orphan.txt" in output
+    assert "Warnings: 9" in output
+    assert len(violations) == 9
+    assert [(v.file_path, v.message) for v in violations] == before
+
+
+def test_structured_reports_keep_collapsed_text_findings_individual(valid_plugin):
+    """Text grouping must not alter structured report cardinality."""
+    context = RepositoryContext(valid_plugin)
+    skill = context.root_path / "skills" / "catalog"
+    context.skills = [skill]
+    paths = [skill / "assets" / f"image-{index}.png" for index in range(3)]
+    violations = [
+        RuleViolation(
+            rule_id="agentskill-unreferenced-files",
+            severity=Severity.WARNING,
+            message=f"'{path.name}' is never referenced from SKILL.md",
+            file_path=path,
+        )
+        for path in paths
+    ]
+
+    assert len(json.loads(format_json(violations, context, [], "1.0.0"))["violations"]) == 3
+    sarif = json.loads(format_sarif(violations, context, [], "1.0.0"))
+    assert len(sarif["runs"][0]["results"]) == 3
+    assert len(json.loads(format_code_climate(violations, context, [], "1.0.0"))) == 3
+    html = format_html(violations, context, [], "1.0.0")
+    assert all(path.name in html for path in paths)
+    assert html.count("<code>agentskill-unreferenced-files</code>") == 3
+
+
 # --- JSON formatter ---
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -703,6 +703,45 @@ class TestUnreferencedSkillFiles:
         assert r["rc"] == 0
         assert self.RULE not in rule_ids(r)
 
+    def test_text_collapses_subtrees_but_json_keeps_individual_findings(self, tmp_path):
+        repo = copy_fixture("agentskills/unreferenced-collapse", tmp_path)
+
+        raw = run_lint(repo, "--rule", self.RULE, "--strict")
+        raw_findings = by_rule(raw)[self.RULE]
+        assert raw["rc"] == 1
+        assert len(raw_findings) == 9
+        assert len({v["file_path"] for v in raw_findings}) == 9
+        assert summary(raw)["warnings"] == 9
+
+        text = run_lint(repo, "--rule", self.RULE, "--strict", fmt="text", verbose=False)
+        assert text["rc"] == raw["rc"]
+        assert text["stdout"].count("3 files under 'assets/'") == 2
+        assert "[image-catalog/assets]" in text["stdout"]
+        assert "[video-catalog/assets]" in text["stdout"]
+        assert "image-catalog/assets/front.png" not in text["stdout"]
+        assert "video-catalog/assets/front.mp4" not in text["stdout"]
+        assert "image-catalog/scripts/import.py" in text["stdout"]
+        assert "image-catalog/scripts/export.py" in text["stdout"]
+        assert "image-catalog/orphan.txt" in text["stdout"]
+        assert "Warnings: 9" in text["stdout"]
+
+    def test_baseline_still_records_and_suppresses_each_collapsed_finding(self, tmp_path):
+        repo = copy_fixture("agentskills/unreferenced-collapse", tmp_path)
+
+        result = run_cli(["baseline", "--no-custom-rules", str(repo)])
+        assert result.returncode == 0
+        baseline = json.loads((repo / ".skillsaw-baseline.json").read_text())
+        entries = [v for v in baseline["violations"] if v["rule_id"] == self.RULE]
+        assert len(entries) == 9
+        assert len({v["fingerprint"] for v in entries}) == 9
+        assert len({v["file_path"] for v in entries}) == 9
+
+        lint = run_lint(repo, "--rule", self.RULE)
+        assert lint["rc"] == 0
+        assert by_rule(lint).get(self.RULE, []) == []
+        assert summary(lint)["warnings"] == 0
+        assert summary(lint)["baseline_suppressed"] == 9
+
 
 # ── File Path Argument ──────────────────────────────────────────
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -725,6 +725,22 @@ class TestUnreferencedSkillFiles:
         assert "image-catalog/orphan.txt" in text["stdout"]
         assert "Warnings: 9" in text["stdout"]
 
+        expanded = run_lint(
+            repo,
+            "--rule",
+            self.RULE,
+            "--strict",
+            "--no-collapse",
+            fmt="text",
+            verbose=False,
+        )
+        assert expanded["rc"] == raw["rc"]
+        assert "files under 'assets/'" not in expanded["stdout"]
+        assert "image-catalog/assets/front.png" in expanded["stdout"]
+        assert "video-catalog/assets/front.mp4" in expanded["stdout"]
+        assert "grouped into summary rows" not in expanded["stdout"]
+        assert "Warnings: 9" in expanded["stdout"]
+
     def test_baseline_still_records_and_suppresses_each_collapsed_finding(self, tmp_path):
         repo = copy_fixture("agentskills/unreferenced-collapse", tmp_path)
 
@@ -4941,6 +4957,22 @@ class TestContentMcpToolNameSuggestGate:
             f"Grade:    {raw_grade['letter']} ({raw_grade['density']:.2f} weighted violations"
             in text["stdout"]
         )
+
+        expanded = run_lint(
+            repo,
+            "--rule",
+            "content-mcp-tool-name",
+            "--strict",
+            "--no-collapse",
+            fmt="text",
+            verbose=False,
+        )
+        assert expanded["rc"] == raw["rc"]
+        assert "fully-qualified MCP tool names use the" not in expanded["stdout"]
+        assert "mcp__plugin_jira_atlassian__getJiraIssue" in expanded["stdout"]
+        assert "mcp__plugin_jira_atlassian__searchJiraIssuesUsingJql" in expanded["stdout"]
+        assert "grouped into summary rows" not in expanded["stdout"]
+        assert "Warnings: 6" in expanded["stdout"]
 
     def test_baseline_keeps_each_collapsed_occurrence(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4905,6 +4905,57 @@ class TestContentMcpToolNameSuggestGate:
 
     FIXTURE = "content/mcp-tool-name"
 
+    def test_text_collapses_only_same_file_server_occurrences(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        raw = run_lint(repo, "--rule", "content-mcp-tool-name", "--strict")
+        findings = by_rule(raw)["content-mcp-tool-name"]
+        assert raw["rc"] == 1
+        assert len(findings) == 6
+        assert summary(raw)["warnings"] == 6
+
+        text = run_lint(
+            repo,
+            "--rule",
+            "content-mcp-tool-name",
+            "--strict",
+            fmt="text",
+            verbose=False,
+        )
+        assert text["rc"] == raw["rc"]
+        assert text["stdout"].count("3 fully-qualified MCP tool names") == 1
+        assert "'mcp__plugin_jira_atlassian__' server prefix" in text["stdout"]
+        assert "[CLAUDE.md:9]" in text["stdout"]
+        assert "mcp__plugin_github_github__get_file_contents" in text["stdout"]
+        # The same Jira prefix appears twice in a different file; that pair
+        # remains two actionable rows because files never merge and two is
+        # below the collapse threshold.
+        assert text["stdout"].count("[.claude/skills/jira-triage/SKILL.md:") == 2
+        assert "Warnings: 6" in text["stdout"]
+        assert "[?] 6 violation(s) fixable with `skillsaw fix --suggest`" in text["stdout"]
+        assert "Rule docs" in text["stdout"]
+        raw_grade = summary(raw)["grade"]
+        assert (
+            f"Grade:    {raw_grade['letter']} ({raw_grade['density']:.2f} weighted violations"
+            in text["stdout"]
+        )
+
+    def test_baseline_keeps_each_collapsed_occurrence(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        result = run_cli(["baseline", "--no-custom-rules", str(repo)])
+        assert result.returncode == 0
+        baseline = json.loads((repo / ".skillsaw-baseline.json").read_text())
+        entries = [v for v in baseline["violations"] if v["rule_id"] == "content-mcp-tool-name"]
+        assert len(entries) == 6
+        assert len({v["fingerprint"] for v in entries}) == 6
+
+        lint = run_lint(repo, "--rule", "content-mcp-tool-name")
+        assert lint["rc"] == 0
+        assert by_rule(lint).get("content-mcp-tool-name", []) == []
+        assert summary(lint)["warnings"] == 0
+        assert summary(lint)["baseline_suppressed"] == 6
+
     def test_plain_fix_applies_nothing(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
         before = _snapshot_contents(repo)
@@ -4913,6 +4964,8 @@ class TestContentMcpToolNameSuggestGate:
 
     def test_suggest_fix_strips_and_converges(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
+        before_lint = run_lint(repo, "--rule", "content-mcp-tool-name")
+        assert len(by_rule(before_lint)["content-mcp-tool-name"]) == 6
         before = _snapshot_contents(repo)
         _run_fix(repo, "--suggest")
         after = _snapshot_contents(repo)


### PR DESCRIPTION
## Summary

- add one shared, presentation-only text collapse mechanism
- collapse three or more agentskill-unreferenced-files findings in the same top-level skill directory
- collapse three or more content-mcp-tool-name findings sharing a file and server prefix, with sample line numbers
- preserve every underlying violation for fingerprints, baselines, fixes, counts, grade, exit status, and structured reports
- document both terminal-only behaviors and add realistic integration coverage

## Validation

- make test: 5139 passed on the exact combined tree
- make lint
- make update and self-lint
- latest openshift-eng/ai-helpers: exit 0
- formatter, baseline, structured-output, metadata-isolation, threshold, and fix-convergence coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lint terminal output now groups repetitive findings into concise summary rows.
  * Added `skillsaw lint --no-collapse` to display every diagnostic individually.
  * Grouping applies to repeated unreferenced-file and MCP tool-name findings.
  * Counts, exit statuses, baselines, fixes, and machine-readable reports continue to include every finding.

* **Documentation**
  * Updated CLI, rule, and skill guidance to explain output grouping and the opt-out option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->