### PR TITLE
Collapse repeated MCP tool names in text output

### DIFF
--- a/docs/rules/content-mcp-tool-name.md
+++ b/docs/rules/content-mcp-tool-name.md
@@ -109,6 +109,10 @@ A violation in a body decoded out of a non-markdown host — a JSON hook
 prompt, a folded (`>`) YAML scalar — is reported without an automatic fix;
 apply the same rewrites by hand.
 
+When three or more findings in one file share a server prefix, terminal
+output groups them into one readable row. This is presentation only: machine
+reports, baselines, counts, and fixes still retain every occurrence.
+
 ## Configuration
 
 ```yaml

--- a/src/skillsaw/formatters/text.py
+++ b/src/skillsaw/formatters/text.py
@@ -2,6 +2,7 @@
 Text output formatter — human-readable terminal output with optional ANSI colors.
 """
 
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,12 @@ from . import get_counts, relative_path, should_show_info
 from skillsaw.paths import contained_resolve, safe_resolve
 
 _COLLAPSE_THRESHOLD = 3
+# Keep the token portion aligned with content.mcp_tool_name's candidate
+# grammar and first-``__`` server/tool split. The trailing ordinal is part of
+# that rule's stable fingerprint discriminator, not presentation text.
+_MCP_DISCRIMINATOR_RE = re.compile(
+    r"(?P<token>mcp__(?P<server>[A-Za-z0-9_-]+?)__(?P<tool>[A-Za-z0-9_-]+)):(?P<ordinal>\d+)"
+)
 
 
 @dataclass(frozen=True)
@@ -109,8 +116,73 @@ def _collapse_unreferenced_skill_files(
     return plan
 
 
+def _mcp_server_prefix(violation: RuleViolation) -> Optional[str]:
+    """Read a validated MCP server prefix from the stable discriminator."""
+    discriminator = violation.fingerprint_discriminator
+    if not discriminator:
+        return None
+    match = _MCP_DISCRIMINATOR_RE.fullmatch(discriminator)
+    if match is None:
+        return None
+    return f"mcp__{match.group('server')}__"
+
+
+def _collapse_mcp_tool_names(
+    indexed: Sequence[Tuple[int, RuleViolation]], context
+) -> _TextCollapsePlan:
+    """Collapse repeated fully-qualified names for one file and server."""
+    grouped = defaultdict(list)
+    for position, violation in indexed:
+        if violation.file_path is None:
+            continue
+        server_prefix = _mcp_server_prefix(violation)
+        if server_prefix is None:
+            continue
+        key = (
+            _absolute_path(violation.file_path, context.root_path),
+            server_prefix,
+            violation.severity,
+            violation.source,
+            violation.fixable,
+            violation.fix_confidence,
+        )
+        grouped[key].append((position, violation))
+
+    plan: _TextCollapsePlan = {}
+    for (_, server_prefix, *_), members in grouped.items():
+        if len(members) < _COLLAPSE_THRESHOLD:
+            continue
+        distinct_lines = list(
+            dict.fromkeys(
+                violation.file_line for _, violation in members if violation.file_line is not None
+            )
+        )
+        line_summary = ""
+        if distinct_lines:
+            displayed_lines = ", ".join(str(line) for line in distinct_lines[:3])
+            if len(distinct_lines) > 3:
+                displayed_lines += ", …"
+            line_summary = f" (lines {displayed_lines})"
+
+        first_position, first_violation = members[0]
+        plan[first_position] = _TextDiagnostic(
+            violation=first_violation,
+            message=(
+                f"{len(members)} fully-qualified MCP tool names use the "
+                f"'{server_prefix}' server prefix — use short names because "
+                f"the prefix depends on the reader's server name{line_summary}"
+            ),
+            file_path=first_violation.file_path,
+            file_line=first_violation.file_line,
+        )
+        for position, _ in members[1:]:
+            plan[position] = None
+    return plan
+
+
 _TEXT_COLLAPSE_STRATEGIES: Dict[str, _TextCollapseStrategy] = {
     "agentskill-unreferenced-files": _collapse_unreferenced_skill_files,
+    "content-mcp-tool-name": _collapse_mcp_tool_names,
 }
 
 

--- a/src/skillsaw/rules/docs/content-mcp-tool-name.md
+++ b/src/skillsaw/rules/docs/content-mcp-tool-name.md
@@ -94,3 +94,7 @@ replacement is a judgment call, which is yours to make in review:
 A violation in a body decoded out of a non-markdown host — a JSON hook
 prompt, a folded (`>`) YAML scalar — is reported without an automatic fix;
 apply the same rewrites by hand.
+
+When three or more findings in one file share a server prefix, terminal
+output groups them into one readable row. This is presentation only: machine
+reports, baselines, counts, and fixes still retain every occurrence.

--- a/tests/fixtures/content/mcp-tool-name/CLAUDE.md
+++ b/tests/fixtures/content/mcp-tool-name/CLAUDE.md
@@ -14,6 +14,10 @@ someone has already picked up.
 Read the ticket body with `mcp__plugin_jira_atlassian__getJiraIssue` and quote
 the acceptance criteria in your plan before writing any code.
 
+<!-- skillsaw-assert content-mcp-tool-name -->
+Post progress with `mcp__plugin_jira_atlassian__addCommentToJiraIssue` when a
+review changes the agreed implementation plan.
+
 ## Reading files from GitHub
 
 <!-- skillsaw-assert content-mcp-tool-name -->

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -19,11 +19,14 @@ from skillsaw.formatters.json_fmt import format_json
 from skillsaw.formatters.sarif import format_sarif
 from skillsaw.formatters.html import format_html
 from skillsaw.formatters.code_climate import format_code_climate
+from skillsaw.formatters.text import _text_diagnostics
+from skillsaw.grade import compute_grade
 from skillsaw.rule import AutofixConfidence, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
 from skillsaw.config import LinterConfig
 from skillsaw.linter import Linter
 from skillsaw.lint_target import LintTarget
+from skillsaw.rules.builtin.content.mcp_tool_name import ContentMcpToolNameRule
 
 # --- Helpers ---
 
@@ -380,6 +383,198 @@ def test_structured_reports_keep_collapsed_text_findings_individual(valid_plugin
     html = format_html(violations, context, [], "1.0.0")
     assert all(path.name in html for path in paths)
     assert html.count("<code>agentskill-unreferenced-files</code>") == 3
+
+
+def _mcp_tool_name_violation(
+    path: Path,
+    line: int,
+    token: str,
+    ordinal: int,
+    *,
+    message: str,
+    **overrides,
+) -> RuleViolation:
+    values = {
+        "rule_id": "content-mcp-tool-name",
+        "severity": Severity.WARNING,
+        "message": message,
+        "file_path": path,
+        "line": line,
+        "source": "builtin",
+        "fixable": True,
+        "fix_confidence": AutofixConfidence.SUGGEST,
+        "fingerprint_discriminator": f"{token}:{ordinal}",
+    }
+    values.update(overrides)
+    return RuleViolation(**values)
+
+
+def test_text_mcp_collapse_keeps_raw_totals_and_order(valid_plugin):
+    """Only terminal rows collapse; all occurrence-level state stays intact."""
+    context = RepositoryContext(valid_plugin)
+    first_path = context.root_path / "CLAUDE.md"
+    second_path = context.root_path / "AGENTS.md"
+    jira = [
+        _mcp_tool_name_violation(
+            first_path,
+            line,
+            f"mcp__jira__tool__{index}",
+            index,
+            message=f"jira original {index}",
+        )
+        for index, line in enumerate((3, 3, 5, 7, 9))
+    ]
+    github = [
+        _mcp_tool_name_violation(
+            first_path,
+            12 + index,
+            f"mcp__github__tool_{index}",
+            0,
+            message=f"github original {index}",
+        )
+        for index in range(2)
+    ]
+    other_file = [
+        _mcp_tool_name_violation(
+            second_path,
+            4 + index,
+            f"mcp__jira__other_{index}",
+            0,
+            message=f"other-file original {index}",
+        )
+        for index in range(2)
+    ]
+    malformed = [
+        _mcp_tool_name_violation(
+            first_path,
+            20,
+            "mcp__jira__ignored",
+            0,
+            message="missing discriminator",
+            fingerprint_discriminator=None,
+        ),
+        _mcp_tool_name_violation(
+            first_path,
+            21,
+            "mcp__jira__ignored",
+            0,
+            message="malformed discriminator",
+            fingerprint_discriminator="mcp__jira__:0",
+        ),
+    ]
+    violations = jira + github + other_file + malformed
+    before = [
+        (
+            id(v),
+            v.file_path,
+            v.line,
+            v.message,
+            v.fingerprint_discriminator,
+            v.severity,
+            v.source,
+            v.fixable,
+            v.fix_confidence,
+        )
+        for v in violations
+    ]
+    grade = compute_grade(violations, 10_000)
+
+    output = format_text(
+        violations,
+        context,
+        [ContentMcpToolNameRule()],
+        "1.0.0",
+        grade=grade,
+    )
+
+    assert (
+        "[CLAUDE.md:3]: 5 fully-qualified MCP tool names use the "
+        "'mcp__jira__' server prefix" in output
+    )
+    assert "use short names because the prefix depends on the reader's server name" in output
+    assert "(lines 3, 5, 7, …)" in output
+    assert "jira original" not in output
+    # Below-threshold, different-file, and invalid-discriminator findings stay individual.
+    assert all(f"github original {index}" in output for index in range(2))
+    assert all(f"other-file original {index}" in output for index in range(2))
+    assert "missing discriminator" in output
+    assert "malformed discriminator" in output
+    assert "Warnings: 11" in output
+    assert "[?] 11 violation(s) fixable with `skillsaw fix --suggest`" in output
+    assert f"Grade:    {grade.letter} ({grade.density:.2f} weighted violations" in output
+    assert "https://skillsaw.org/rules/content-mcp-tool-name/" in output
+    assert [
+        (
+            id(v),
+            v.file_path,
+            v.line,
+            v.message,
+            v.fingerprint_discriminator,
+            v.severity,
+            v.source,
+            v.fixable,
+            v.fix_confidence,
+        )
+        for v in violations
+    ] == before
+
+
+def test_text_mcp_collapse_threshold_and_metadata_isolation(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    path = context.root_path / "CLAUDE.md"
+
+    def base(index: int, **overrides) -> RuleViolation:
+        return _mcp_tool_name_violation(
+            path,
+            index + 1,
+            f"mcp__jira__tool_{index}",
+            0,
+            message=f"original {index}",
+            **overrides,
+        )
+
+    pair = [base(0), base(1)]
+    assert len(_text_diagnostics(pair, context)) == 2
+    assert len(_text_diagnostics(pair + [base(2)], context)) == 1
+
+    # Two otherwise identical findings plus one changed metadata field must
+    # never cross the collapse threshold together.
+    for changed in (
+        {"severity": Severity.ERROR},
+        {"source": "plugin"},
+        {"fixable": False, "fix_confidence": None},
+        {"fix_confidence": AutofixConfidence.SAFE},
+    ):
+        diagnostics = _text_diagnostics(pair + [base(2, **changed)], context)
+        assert [d.message for d in diagnostics] == ["original 0", "original 1", "original 2"]
+
+
+def test_structured_reports_keep_mcp_tool_findings_individual(valid_plugin):
+    context = RepositoryContext(valid_plugin)
+    path = context.root_path / "CLAUDE.md"
+    violations = [
+        _mcp_tool_name_violation(
+            path,
+            index + 3,
+            f"mcp__jira__tool_{index}",
+            0,
+            message=f"original {index}",
+        )
+        for index in range(3)
+    ]
+
+    json_report = json.loads(format_json(violations, context, [], "1.0.0"))
+    assert [v["message"] for v in json_report["violations"]] == [
+        "original 0",
+        "original 1",
+        "original 2",
+    ]
+    sarif = json.loads(format_sarif(violations, context, [], "1.0.0"))
+    assert len(sarif["runs"][0]["results"]) == 3
+    assert len(json.loads(format_code_climate(violations, context, [], "1.0.0"))) == 3
+    html = format_html(violations, context, [], "1.0.0")
+    assert all(f"original {index}" in html for index in range(3))
+    assert html.count("<code>content-mcp-tool-name</code>") == 3
 
 
 # --- JSON formatter ---

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4905,6 +4905,57 @@ class TestContentMcpToolNameSuggestGate:
 
     FIXTURE = "content/mcp-tool-name"
 
+    def test_text_collapses_only_same_file_server_occurrences(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        raw = run_lint(repo, "--rule", "content-mcp-tool-name", "--strict")
+        findings = by_rule(raw)["content-mcp-tool-name"]
+        assert raw["rc"] == 1
+        assert len(findings) == 6
+        assert summary(raw)["warnings"] == 6
+
+        text = run_lint(
+            repo,
+            "--rule",
+            "content-mcp-tool-name",
+            "--strict",
+            fmt="text",
+            verbose=False,
+        )
+        assert text["rc"] == raw["rc"]
+        assert text["stdout"].count("3 fully-qualified MCP tool names") == 1
+        assert "'mcp__plugin_jira_atlassian__' server prefix" in text["stdout"]
+        assert "[CLAUDE.md:9]" in text["stdout"]
+        assert "mcp__plugin_github_github__get_file_contents" in text["stdout"]
+        # The same Jira prefix appears twice in a different file; that pair
+        # remains two actionable rows because files never merge and two is
+        # below the collapse threshold.
+        assert text["stdout"].count("[.claude/skills/jira-triage/SKILL.md:") == 2
+        assert "Warnings: 6" in text["stdout"]
+        assert "[?] 6 violation(s) fixable with `skillsaw fix --suggest`" in text["stdout"]
+        assert "Rule docs" in text["stdout"]
+        raw_grade = summary(raw)["grade"]
+        assert (
+            f"Grade:    {raw_grade['letter']} ({raw_grade['density']:.2f} weighted violations"
+            in text["stdout"]
+        )
+
+    def test_baseline_keeps_each_collapsed_occurrence(self, tmp_path):
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+
+        result = run_cli(["baseline", "--no-custom-rules", str(repo)])
+        assert result.returncode == 0
+        baseline = json.loads((repo / ".skillsaw-baseline.json").read_text())
+        entries = [v for v in baseline["violations"] if v["rule_id"] == "content-mcp-tool-name"]
+        assert len(entries) == 6
+        assert len({v["fingerprint"] for v in entries}) == 6
+
+        lint = run_lint(repo, "--rule", "content-mcp-tool-name")
+        assert lint["rc"] == 0
+        assert by_rule(lint).get("content-mcp-tool-name", []) == []
+        assert summary(lint)["warnings"] == 0
+        assert summary(lint)["baseline_suppressed"] == 6
+
     def test_plain_fix_applies_nothing(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
         before = _snapshot_contents(repo)
@@ -4913,6 +4964,8 @@ class TestContentMcpToolNameSuggestGate:
 
     def test_suggest_fix_strips_and_converges(self, tmp_path):
         repo = copy_fixture(self.FIXTURE, tmp_path)
+        before_lint = run_lint(repo, "--rule", "content-mcp-tool-name")
+        assert len(by_rule(before_lint)["content-mcp-tool-name"]) == 6
         before = _snapshot_contents(repo)
         _run_fix(repo, "--suggest")
         after = _snapshot_contents(repo)


### PR DESCRIPTION
## Summary

- collapse three or more content-mcp-tool-name findings sharing a file and server prefix into one terminal row
- preserve every underlying occurrence for fingerprints, baselines, fixes, counts, exit status, grade, and structured reports
- retain actionable first-location context plus up to three distinct sample lines
- document the presentation-only behavior and cover threshold, metadata isolation, malformed discriminators, baselines, and fix convergence

## Stack

This PR is intentionally based on #536 because it reuses that PR's generic text-collapse infrastructure. Its diff is MCP-only. After #536 merges, this PR should be retargeted to main and updated from latest main before merge.

## Validation

- make test: 5139 passed
- make lint
- make update and self-lint
- latest openshift-eng/ai-helpers: exit 0
- focused formatter and MCP rule tests: 126 passed
- focused integration tests: passed