### PR TITLE
Add weekly Lychee link checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,44 @@
+name: Link check
+
+on:
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lychee:
+    name: Check links
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check links with Lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --exclude-path '(^|/)tests/fixtures/'
+            --exclude-path '(^|/)src/skillsaw/marketplace/templates/'
+            './**/*.md'
+            './**/*.html'
+            './**/*.rst'
+          fail: false
+
+      - name: Open broken-link issue
+        if: steps.lychee.outputs.exit_code != '0'
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
+        with:
+          title: Weekly broken-link report
+          content-filepath: ./lychee/out.md


### PR DESCRIPTION
## Summary

- run the official Lychee GitHub Action weekly and on manual dispatch
- open an issue containing Lychee's Markdown report when broken links are found
- exclude intentional fixture links and unrendered marketplace templates
- pin every action to an immutable commit and grant only contents/read and issues/write

The existing broken documentation links are intentionally left in place so the first run exercises issue creation.

## Validation

- `make test` (5,246 passed)
- `make lint`
- `make update`
- `uvx zizmor --config zizmor.yml --no-progress .github/workflows/link-check.yml`
- fresh `openshift-eng/ai-helpers` clone passes `.venv/bin/skillsaw lint`
- local Lychee v0.24.2 scan produced the expected Markdown report with the existing failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly and on-demand checks for broken links in Markdown, HTML, and RST documentation.
  * Broken links are reported in a tracked issue for follow-up without interrupting other automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->