### PR TITLE
feat(cli): deprecate add and docs commands

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -254,6 +254,10 @@ See the [CLI reference](cli.md) for details.
 
 ## Committed generated docs
 
+!!! warning "Deprecated in 0.20.0"
+    `skillsaw docs` is deprecated and will be removed in an upcoming release.
+    Existing CI jobs can keep using it during the deprecation period.
+
 Some repositories commit the output of `skillsaw docs` and gate CI on it
 being current — regenerating in CI and failing if the working tree changed.
 Upgrading skillsaw can change that output, so plan on regenerating and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,7 +89,7 @@ Show documentation and effective configuration for a rule
 
 ## `skillsaw docs`
 
-Generate documentation for a Claude or Codex plugin, marketplace, or .claude repository
+Deprecated: generate repository documentation
 
 | Flag | Description | Default |
 |------|-------------|---------|
@@ -147,7 +147,7 @@ Grade the repository and write a shields.io badge JSON file
 
 ## `skillsaw add`
 
-Scaffold marketplaces, plugins, skills, commands, agents, and hooks
+Deprecated: scaffold marketplaces, plugins, and components
 
 ### `skillsaw add marketplace`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,6 +160,10 @@ Violations that `skillsaw fix` can resolve automatically are marked with
 
 ## More Commands
 
+!!! warning "Deprecated in 0.20.0"
+    `skillsaw docs` and `skillsaw add` remain available for now, but both
+    commands will be removed in an upcoming release.
+
 ```bash
 # Your coding agent can fix content violations directly — just run
 # skillsaw and let the agent read the output. For detailed guidance:
@@ -180,7 +184,7 @@ skillsaw --fail-on info
 # List all rules with fix support info
 skillsaw list-rules
 
-# Generate plugin/skill documentation
+# Deprecated: generate plugin/skill documentation
 skillsaw docs
 
 # Output in different formats (text, json, sarif, html, code-climate, gitlab)
@@ -198,7 +202,7 @@ skillsaw --output json:native-report.json
 # Multiple outputs in one run
 skillsaw --output report.sarif --output gitlab:gl-code-quality.json
 
-# Scaffold a new marketplace, plugin, or skill
+# Deprecated: scaffold a new marketplace, plugin, or skill
 skillsaw add marketplace
 skillsaw add plugin my-plugin
 skillsaw add skill my-skill

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,14 +68,15 @@ dead zones, and structural issues with more than 60 rules, then auto-fixes them.
 
     ---
 
-    `skillsaw add` generates plugins, skills, commands, agents, and hooks with best-practice
-    structure.
+    **Deprecated in 0.20.0.** `skillsaw add` remains available for now but
+    will be removed in an upcoming release.
 
 -   :memo:{ .lg .middle } **Documentation**
 
     ---
 
-    `skillsaw docs` generates HTML or Markdown documentation for your plugins and marketplaces.
+    **Deprecated in 0.20.0.** `skillsaw docs` remains available for now but
+    will be removed in an upcoming release.
 
 </div>
 

--- a/docs/repo-types.md
+++ b/docs/repo-types.md
@@ -213,7 +213,10 @@ vendor-managed installed content.
 
 Paths that leave the plugin root are not followed; `codex-plugin-json-valid` reports them.
 
-`skillsaw docs` describes Codex-only plugins as well, reading name, version, description, `interface.displayName`, author and license from the Codex manifest.
+!!! warning "Deprecated in 0.20.0"
+    `skillsaw docs` is deprecated and will be removed in an upcoming release.
+    During the deprecation period, it continues to describe Codex-only plugins
+    using their manifest metadata.
 
 ## OpenAI Codex Marketplace
 

--- a/docs/rules/claude-marketplace-registration.md
+++ b/docs/rules/claude-marketplace-registration.md
@@ -44,8 +44,7 @@ entry for it.
 ## How to fix
 
 Add the plugin to the `plugins` array in `marketplace.json` with at
-least its `name` and `path`. Use `skillsaw add plugin` to register
-new plugins automatically.
+least its `name` and `path`.
 
 `skillsaw fix` can append the missing entry, except when the
 violation is reported without the fixable marker because the file

--- a/docs/rules/claude-plugin-json-required.md
+++ b/docs/rules/claude-plugin-json-required.md
@@ -48,8 +48,8 @@ my-plugin/
 ## How to fix
 
 Create a `.claude-plugin/plugin.json` file with the required fields
-(`name`, `description`, `version`). Use `skillsaw add plugin` to
-scaffold a new plugin with the correct structure.
+(`name`, `description`, `version`). Put commands, agents, skills, and other
+plugin content beside the `.claude-plugin/` directory.
 
 ## Codex plugins
 

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -1,5 +1,9 @@
 # Scaffolding
 
+!!! warning "Deprecated in 0.20.0"
+    `skillsaw add` is deprecated and will be removed in an upcoming release.
+    It remains available during the deprecation period.
+
 `skillsaw add` scaffolds marketplaces, plugins, and components with best-practice structure, CI, and branding out of the box.
 
 ## Initialize a Marketplace

--- a/src/skillsaw/cli/__init__.py
+++ b/src/skillsaw/cli/__init__.py
@@ -22,11 +22,24 @@ _SUBCOMMANDS = {
     "port",
 }
 
+_DEPRECATED_COMMANDS = frozenset({"add", "docs"})
+
+
+def _warn_deprecated_command(command: str) -> None:
+    print(
+        f"Warning: 'skillsaw {command}' is deprecated and will be removed "
+        "in an upcoming release.",
+        file=sys.stderr,
+    )
+
 
 def main():
     from ._helpers import install_warning_display
 
     install_warning_display()
+
+    if len(sys.argv) > 1 and sys.argv[1] in _DEPRECATED_COMMANDS:
+        _warn_deprecated_command(sys.argv[1])
 
     # When no subcommand is given (or the first arg looks like a path/flag),
     # default to "lint" so bare `skillsaw` and `skillsaw /path` keep working.

--- a/src/skillsaw/cli/_parser.py
+++ b/src/skillsaw/cli/_parser.py
@@ -43,8 +43,6 @@ Examples:
   skillsaw lint /path/to/skills   # Lint specific directory
   skillsaw init                   # Generate default config
   skillsaw list-rules             # List available rules
-  skillsaw docs                   # Generate documentation
-  skillsaw add marketplace        # Scaffold a new marketplace
 
 For more information, visit: https://github.com/stbenjam/skillsaw
         """,
@@ -341,8 +339,10 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     # --- docs ---
     docs_parser = subparsers.add_parser(
         "docs",
-        help="Generate documentation for a Claude or Codex plugin, marketplace, or .claude repository",
-        description="Generate documentation for a Claude or Codex plugin, marketplace, or .claude repository",
+        help="Deprecated: generate repository documentation",
+        description="Deprecated: Generate documentation for a Claude or Codex plugin, "
+        "marketplace, or .claude repository. This command will be removed in an "
+        "upcoming release.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     docs_parser.add_argument(
@@ -544,7 +544,7 @@ For more information, visit: https://github.com/stbenjam/skillsaw
     # --- add ---
     subparsers.add_parser(
         "add",
-        help="Scaffold marketplaces, plugins, skills, commands, agents, and hooks",
+        help="Deprecated: scaffold marketplaces, plugins, and components",
         add_help=False,
     )
 

--- a/src/skillsaw/docs/__init__.py
+++ b/src/skillsaw/docs/__init__.py
@@ -1,4 +1,8 @@
-"""Documentation generation for skillsaw-linted repositories."""
+"""Deprecated documentation generation, retained for compatibility.
+
+The ``skillsaw docs`` CLI was deprecated in 0.20.0 and will be removed in an
+upcoming release. Importing this package does not emit a runtime warning.
+"""
 
 from skillsaw.docs.extractor import extract_docs
 from skillsaw.docs.html_renderer import render_html

--- a/src/skillsaw/marketplace/__init__.py
+++ b/src/skillsaw/marketplace/__init__.py
@@ -1,1 +1,5 @@
-"""Marketplace scaffolding and management for Claude Code plugin marketplaces."""
+"""Deprecated marketplace scaffolding, retained for compatibility.
+
+The ``skillsaw add`` CLI was deprecated in 0.20.0 and will be removed in an
+upcoming release. Importing this package does not emit a runtime warning.
+"""

--- a/src/skillsaw/marketplace/cli.py
+++ b/src/skillsaw/marketplace/cli.py
@@ -77,7 +77,8 @@ def _build_add_parser():
     """
     parser = argparse.ArgumentParser(
         prog="skillsaw add",
-        description="Scaffold marketplaces, plugins, skills, commands, agents, and hooks",
+        description="Deprecated: scaffold marketplaces, plugins, and components. "
+        "This command will be removed in an upcoming release.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:

--- a/src/skillsaw/marketplace/templates/claude-code/docs_readme.md
+++ b/src/skillsaw/marketplace/templates/claude-code/docs_readme.md
@@ -1,5 +1,8 @@
 # Documentation
 
+> **Deprecated in skillsaw 0.20.0:** This generated workflow uses
+> `skillsaw docs`, which will be removed in an upcoming release.
+
 This directory contains the generated documentation website for the marketplace.
 
 The website is served via GitHub Pages from this directory.

--- a/src/skillsaw/marketplace/templates/claude-code/makefile
+++ b/src/skillsaw/marketplace/templates/claude-code/makefile
@@ -9,10 +9,10 @@ help: ## Show this help message
 lint: ## Run plugin linter (verbose, strict mode)
 	skillsaw -v --strict
 
-docs: ## Generate documentation
+docs: ## Generate documentation (deprecated in skillsaw 0.20.0)
 	skillsaw docs --format html -o docs/
 
-new-plugin: ## Create a new plugin (usage: make new-plugin NAME=my-plugin)
+new-plugin: ## Create a plugin (deprecated; usage: make new-plugin NAME=my-plugin)
 	@if [ -z "$(NAME)" ]; then \
 		echo "Error: NAME is required. Usage: make new-plugin NAME=my-plugin"; \
 		exit 1; \

--- a/src/skillsaw/marketplace/templates/claude-code/marketplace_readme.md
+++ b/src/skillsaw/marketplace/templates/claude-code/marketplace_readme.md
@@ -26,6 +26,9 @@ make lint
 
 Update documentation:
 
+> **Deprecated in skillsaw 0.20.0:** `make docs` uses `skillsaw docs`, which
+> will be removed in an upcoming release.
+
 ```bash
 make docs
 ```

--- a/src/skillsaw/rules/docs/claude-marketplace-registration.md
+++ b/src/skillsaw/rules/docs/claude-marketplace-registration.md
@@ -27,8 +27,7 @@ entry for it.
 ## How to fix
 
 Add the plugin to the `plugins` array in `marketplace.json` with at
-least its `name` and `path`. Use `skillsaw add plugin` to register
-new plugins automatically.
+least its `name` and `path`.
 
 `skillsaw fix` can append the missing entry, except when the
 violation is reported without the fixable marker because the file

--- a/src/skillsaw/rules/docs/claude-plugin-json-required.md
+++ b/src/skillsaw/rules/docs/claude-plugin-json-required.md
@@ -31,8 +31,8 @@ my-plugin/
 ## How to fix
 
 Create a `.claude-plugin/plugin.json` file with the required fields
-(`name`, `description`, `version`). Use `skillsaw add plugin` to
-scaffold a new plugin with the correct structure.
+(`name`, `description`, `version`). Put commands, agents, skills, and other
+plugin content beside the `.claude-plugin/` directory.
 
 ## Codex plugins
 

--- a/tests/test_cli_deprecations.py
+++ b/tests/test_cli_deprecations.py
@@ -1,0 +1,74 @@
+"""CLI deprecation notices for features leaving after 0.20.0."""
+
+from tests.cli_runner import run_cli
+
+
+def _warning(command: str) -> str:
+    return (
+        f"Warning: 'skillsaw {command}' is deprecated and will be removed "
+        "in an upcoming release."
+    )
+
+
+def _assert_one_stderr_warning(result, command: str) -> None:
+    warning = _warning(command)
+    assert result.stderr.count(warning) == 1
+    assert warning not in result.stdout
+
+
+def test_deprecated_command_help_warns_once_per_invocation() -> None:
+    for command in ("add", "docs"):
+        for _ in range(2):
+            result = run_cli([command, "--help"])
+            assert result.returncode == 0
+            assert "Deprecated:" in result.stdout
+            _assert_one_stderr_warning(result, command)
+
+
+def test_add_still_scaffolds_with_one_deprecation_warning(tmp_path) -> None:
+    result = run_cli(["add", "skill", "release-helper", "--path", tmp_path])
+
+    assert result.returncode == 0
+    assert (tmp_path / "release-helper" / "SKILL.md").is_file()
+    _assert_one_stderr_warning(result, "add")
+
+
+def test_docs_still_generates_with_one_deprecation_warning(tmp_path) -> None:
+    skill_dir = tmp_path / "release-helper"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: release-helper\n"
+        "description: Prepare and verify a project release\n"
+        "---\n\n"
+        "# Release Helper\n\n"
+        "Review the release checklist and report any blockers.\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "release-helper.md"
+
+    result = run_cli(["docs", skill_dir, "--format", "markdown", "--output", output])
+
+    assert result.returncode == 0
+    assert output.is_file()
+    _assert_one_stderr_warning(result, "docs")
+
+
+def test_deprecated_command_parse_errors_still_warn_once() -> None:
+    for command, args in (
+        ("add", ["add", "unknown-component"]),
+        ("docs", ["docs", "--format", "unknown-format"]),
+    ):
+        result = run_cli(args)
+
+        assert result.returncode == 2
+        assert result.stdout == ""
+        _assert_one_stderr_warning(result, command)
+
+
+def test_unrelated_command_has_no_feature_deprecation_warning() -> None:
+    result = run_cli(["list-rules"])
+
+    assert result.returncode == 0
+    assert "is deprecated and will be removed in an upcoming release" not in result.stderr
+    assert "is deprecated and will be removed in an upcoming release" not in result.stdout


### PR DESCRIPTION
## Summary

- emit one stderr warning whenever `skillsaw add` or `skillsaw docs` is invoked, including help and argument errors
- keep both commands, their stdout, exit behavior, modules, templates, and packaging intact until a later removal release
- mark the commands deprecated in CLI help and user documentation, and stop recommending scaffolding from rule guidance
- document the retained Python packages as deprecated without adding runtime warning filters or import-time noise

## Validation

- `make test`: 5,664 passed
- `make lint`: 340 files clean
- `make update`: generated files clean; self-lint 0 errors / 0 warnings
- fresh `openshift-eng/ai-helpers` clone: exit 0, 0 errors / 0 warnings
- exact commit `0264df8b` received adversarial PASS after preserving successful-command stdout and adding parse-error coverage
