### PR TITLE
[Auto] Repair weekly broken-link failures

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,6 +29,7 @@ jobs:
           args: >-
             --verbose
             --no-progress
+            --user-agent 'Mozilla/5.0 (compatible; skillsaw-link-check/1.0; +https://github.com/stbenjam/skillsaw)'
             --exclude-path '(^|/)tests/fixtures/'
             --exclude-path '(^|/)src/skillsaw/marketplace/templates/'
             './**/*.md'

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ uvx skillsaw baseline  # Accept existing findings and fail only on new ones
 
 The `description-routing` rule checks when-to-use phrasing and descriptions that
 only repeat a skill, agent, or command name. Both checks can be configured
-independently; see the [rule reference](https://skillsaw.org/rules/description-routing/).
+independently; see the [rule reference](https://skillsaw.org/rules/content-description-routing/).
 
 Copilot and VS Code custom agents under `.github/agents/` (plus legacy
 `.github/chatmodes/`) also receive target-aware structural validation through

--- a/docs/designs/content-rules-research.md
+++ b/docs/designs/content-rules-research.md
@@ -475,8 +475,9 @@ template directories where placeholder links are expected.
 - [W3C: Link Checking](https://www.w3.org/QA/Tools/) — Broken links are a
   recognized web quality defect; the same principle applies to interlinked
   instruction files
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Don't force readers to backtrack because a link doesn't work"
+- [Google style guide: Make headings into link
+  targets](https://developers.google.com/style/headings-targets) — Keep old
+  anchors when headings change so existing links keep working
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — Context that references missing information degrades agent performance
@@ -507,9 +508,9 @@ names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Use meaningful link text" — paths mentioned without links are
-  un-navigable and un-verifiable
+- [Google style guide: Cross-references and
+  linking](https://developers.google.com/style/cross-references) — Use
+  descriptive link text so readers can navigate to related material
 - [Microsoft Writing Style Guide: Links](https://learn.microsoft.com/en-us/style-guide/urls-web-addresses)
   — Bare URLs and paths should be formatted as actionable links
 
@@ -528,20 +529,16 @@ nonexistent endpoint or asking the user to fill in information that should
 already be present.
 
 This is standard software engineering hygiene applied to a new file type.
-`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-comments`,
-SonarQube's "Track uses of 'TODO' tags") for decades because they
-indicate incomplete implementation. The same principle applies to instruction
-files: if the content isn't ready, it shouldn't be in the agent's context.
+`TODO` and `FIXME` markers have been tracked by linters such as ESLint's
+`no-warning-comments` for decades because they indicate incomplete
+implementation. The same principle applies to instruction files: if the
+content isn't ready, it shouldn't be in the agent's context.
 
 **References:**
 
 - [ESLint: no-warning-comments](https://eslint.org/docs/latest/rules/no-warning-comments)
   — Tracks TODO/FIXME as code quality signals; the same pattern applies to
   instruction files
-- [SonarSource: Track uses of "TODO"
-  tags](https://rules.sonarsource.com/python/RSPEC-1135/) — "TODO tags are
-  commonly used to mark places where some more code is required, but which the
-  developer wants to implement later"
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — "Keep your context informative, yet tight" — placeholder text is

--- a/docs/research.md
+++ b/docs/research.md
@@ -412,8 +412,9 @@ template directories where placeholder links are expected.
 - [W3C: Link Checking](https://www.w3.org/QA/Tools/) — Broken links are a
   recognized web quality defect; the same principle applies to interlinked
   instruction files
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Don't force readers to backtrack because a link doesn't work"
+- [Google style guide: Make headings into link
+  targets](https://developers.google.com/style/headings-targets) — Keep old
+  anchors when headings change so existing links keep working
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — Context that references missing information degrades agent performance
@@ -446,9 +447,9 @@ names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Use meaningful link text" — paths mentioned without links are
-  un-navigable and un-verifiable
+- [Google style guide: Cross-references and
+  linking](https://developers.google.com/style/cross-references) — Use
+  descriptive link text so readers can navigate to related material
 - [Microsoft Writing Style Guide: Links](https://learn.microsoft.com/en-us/style-guide/urls-web-addresses)
   — Bare URLs and paths should be formatted as actionable links
 
@@ -469,20 +470,16 @@ nonexistent endpoint or asking the user to fill in information that should
 already be present.
 
 This is standard software engineering hygiene applied to a new file type.
-`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-comments`,
-SonarQube's "Track uses of 'TODO' tags") for decades because they
-indicate incomplete implementation. The same principle applies to instruction
-files: if the content isn't ready, it shouldn't be in the agent's context.
+`TODO` and `FIXME` markers have been tracked by linters such as ESLint's
+`no-warning-comments` for decades because they indicate incomplete
+implementation. The same principle applies to instruction files: if the
+content isn't ready, it shouldn't be in the agent's context.
 
 **References:**
 
 - [ESLint: no-warning-comments](https://eslint.org/docs/latest/rules/no-warning-comments)
   — Tracks TODO/FIXME as code quality signals; the same pattern applies to
   instruction files
-- [SonarSource: Track uses of "TODO"
-  tags](https://rules.sonarsource.com/python/RSPEC-1135/) — "TODO tags are
-  commonly used to mark places where some more code is required, but which the
-  developer wants to implement later"
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — "Keep your context informative, yet tight" — placeholder text is

--- a/docs/rules/content-broken-internal-reference.md
+++ b/docs/rules/content-broken-internal-reference.md
@@ -83,8 +83,9 @@ template directories where placeholder links are expected.
 - [W3C: Link Checking](https://www.w3.org/QA/Tools/) — Broken links are a
   recognized web quality defect; the same principle applies to interlinked
   instruction files
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Don't force readers to backtrack because a link doesn't work"
+- [Google style guide: Make headings into link
+  targets](https://developers.google.com/style/headings-targets) — Keep old
+  anchors when headings change so existing links keep working
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — Context that references missing information degrades agent performance

--- a/docs/rules/content-placeholder-text.md
+++ b/docs/rules/content-placeholder-text.md
@@ -65,20 +65,16 @@ nonexistent endpoint or asking the user to fill in information that should
 already be present.
 
 This is standard software engineering hygiene applied to a new file type.
-`TODO` and `FIXME` markers have been tracked by linters (ESLint's `no-warning-comments`,
-SonarQube's "Track uses of 'TODO' tags") for decades because they
-indicate incomplete implementation. The same principle applies to instruction
-files: if the content isn't ready, it shouldn't be in the agent's context.
+`TODO` and `FIXME` markers have been tracked by linters such as ESLint's
+`no-warning-comments` for decades because they indicate incomplete
+implementation. The same principle applies to instruction files: if the
+content isn't ready, it shouldn't be in the agent's context.
 
 **References:**
 
 - [ESLint: no-warning-comments](https://eslint.org/docs/latest/rules/no-warning-comments)
   — Tracks TODO/FIXME as code quality signals; the same pattern applies to
   instruction files
-- [SonarSource: Track uses of "TODO"
-  tags](https://rules.sonarsource.com/python/RSPEC-1135/) — "TODO tags are
-  commonly used to mark places where some more code is required, but which the
-  developer wants to implement later"
 - [Anthropic: Effective Context
   Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
   — "Keep your context informative, yet tight" — placeholder text is

--- a/docs/rules/content-progressive-disclosure.md
+++ b/docs/rules/content-progressive-disclosure.md
@@ -44,7 +44,7 @@ and only when it finds zero disclosure references. What counts as a reference di
   `copilot-instructions.md`, …) an `@path` token is just prose, so
   those files disclose through markdown links. Bare path mentions and
   directory links deliberately do not count — "`src/api/` contains the
-  handlers" and "see [src](src/)" are structure narration, not an
+  handlers" and "see the `src/` directory" are structure narration, not an
   instruction to load a file on demand.
 
 ## Examples

--- a/docs/rules/content-unlinked-internal-reference.md
+++ b/docs/rules/content-unlinked-internal-reference.md
@@ -78,9 +78,9 @@ names and illustrative paths that cannot be turned into working local links.
 
 **References:**
 
-- [Google Technical Writing: Links](https://developers.google.com/tech-writing/two/links)
-  — "Use meaningful link text" — paths mentioned without links are
-  un-navigable and un-verifiable
+- [Google style guide: Cross-references and
+  linking](https://developers.google.com/style/cross-references) — Use
+  descriptive link text so readers can navigate to related material
 - [Microsoft Writing Style Guide: Links](https://learn.microsoft.com/en-us/style-guide/urls-web-addresses)
   — Bare URLs and paths should be formatted as actionable links
 

--- a/src/skillsaw/rules/docs/content-progressive-disclosure.md
+++ b/src/skillsaw/rules/docs/content-progressive-disclosure.md
@@ -30,7 +30,7 @@ and only when it finds zero disclosure references. What counts as a reference di
   `copilot-instructions.md`, …) an `@path` token is just prose, so
   those files disclose through markdown links. Bare path mentions and
   directory links deliberately do not count — "`src/api/` contains the
-  handlers" and "see [src](src/)" are structure narration, not an
+  handlers" and "see the `src/` directory" are structure narration, not an
   instruction to load a file on demand.
 
 ## Examples


### PR DESCRIPTION
Closes #553

## Summary

- replace the deleted Google technical-writing link with current, claim-specific Google style-guide references
- correct the README rule URL to the canonical `content-description-routing` page
- give Lychee an honest browser-compatible user agent so the valid PsycNET citation remains checked
- remove the redundant unreachable Sonar citation and rewrite a pseudo-link that Lychee treated as a local file
- regenerate the derived rule and research documentation

## Validation

- exact Lychee 0.24.2 workflow command: 791 links checked, 791 successful, 0 errors
- `make test`: 5,664 passed
- `make lint`
- `make update`
- focused site-content and release-metadata tests: 27 passed
- isolated adversarial review of exact commit `5b52bd12`: PASS

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `description-routing` rule link in the README.
  - Refined rule guidance and examples for progressive disclosure, internal references, and placeholder text.
  - Updated research citations to more relevant Google style-guide references.
  - Clarified that plain directory mentions do not count as disclosure references.
- **Chores**
  - Improved automated link checking by identifying itself as a browser-like client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->