### PR TITLE
Simplify high-complexity audit hotspots

### DIFF
--- a/src/skillsaw/blocks/frontmatter.py
+++ b/src/skillsaw/blocks/frontmatter.py
@@ -59,6 +59,34 @@ def _parse_file_frontmatter(
     return fm, None, None, body, fm_line_count
 
 
+def _compose_frontmatter_document(content: Optional[str], fm: str) -> str:
+    """Return *content* with its frontmatter replaced by normalized *fm*."""
+    if not content:
+        return f"---\n{fm}---\n"
+
+    match = _FRONTMATTER_RE.match(content)
+    if match:
+        return f"---\n{fm}---\n{content[match.end() :]}"
+
+    if not content.startswith("---"):
+        return f"---\n{fm}---\n{content}"
+
+    lines = content.split("\n")
+    close_idx = None
+    for index, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            close_idx = index
+            break
+    if close_idx is None:
+        body_after = "\n".join(lines[1:])
+        return f"---\n{fm}---\n{body_after}"
+
+    body_after = "\n".join(lines[close_idx + 1 :])
+    if body_after and not body_after.startswith("\n"):
+        body_after = "\n" + body_after
+    return f"---\n{fm}---{body_after}"
+
+
 @dataclass(eq=False)
 class FrontmatterField(LintTarget):
     """A single key-value pair from YAML frontmatter, exposed as a tree node."""
@@ -276,35 +304,9 @@ class FrontmatteredBlock(LintTarget):
             raise ValueError("Frontmatter must be a YAML mapping")
 
         fm = new_fm_text.rstrip("\n") + "\n"
-
         content = read_text(self.path)
-        if not content:
-            self.path.write_text(f"---\n{fm}---\n", encoding="utf-8")
-            self._fm_parsed = None
-            self.invalidate_find_cache()
-            return
-
-        m = _FRONTMATTER_RE.match(content)
-        if m:
-            body_after = content[m.end() :]
-            self.path.write_text(f"---\n{fm}---\n{body_after}", encoding="utf-8")
-        elif content.startswith("---"):
-            lines = content.split("\n")
-            close_idx = None
-            for i, line in enumerate(lines[1:], 1):
-                if line.strip() == "---":
-                    close_idx = i
-                    break
-            if close_idx is not None:
-                body_after = "\n".join(lines[close_idx + 1 :])
-                if body_after and not body_after.startswith("\n"):
-                    body_after = "\n" + body_after
-                self.path.write_text(f"---\n{fm}---{body_after}", encoding="utf-8")
-            else:
-                body_after = "\n".join(lines[1:])
-                self.path.write_text(f"---\n{fm}---\n{body_after}", encoding="utf-8")
-        else:
-            self.path.write_text(f"---\n{fm}---\n{content}", encoding="utf-8")
+        updated = _compose_frontmatter_document(content, fm)
+        self.path.write_text(updated, encoding="utf-8")
         self._fm_parsed = None
         # Children will be rebuilt on the next walk — cached find() results
         # on this node and its ancestors must not serve the old fields.

--- a/src/skillsaw/cli/_fix.py
+++ b/src/skillsaw/cli/_fix.py
@@ -142,7 +142,10 @@ def _run_fix(args):
                         print(f"      {line}")
                 print(f"      {c['dim']}{'─' * 40}{c['reset']}")
     else:
-        print("No auto-fixable violations found.")
+        if suggested:
+            print("No safe fixes found.")
+        else:
+            print("No auto-fixable violations found.")
 
     if suggested:
         print(f"\nSuggested fixes ({len(suggested)} — review before applying):")

--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -463,14 +463,16 @@ class RepositoryContext(
         that also has a .coderabbit.yaml).  SINGLE_PLUGIN and MARKETPLACE are
         mutually exclusive (elif chain), but everything else is independent.
         """
+        scan = self._repository_scan()
         types = {
             RepositoryType(label)
             for label in detect_discovery.marker_types(
                 self.root_path,
                 apm=self.has_apm,
                 should_skip=self._should_skip_dir,
-                walk_files=self._walk_files,
-                tool_dirs=self._repository_scan().tool_dirs,
+                promptfoo_named_files=scan.promptfoo_named_files,
+                promptfoo_eval_files=scan.promptfoo_eval_files,
+                tool_dirs=scan.tool_dirs,
             )
         }
 
@@ -536,9 +538,8 @@ class RepositoryContext(
             for item in children
         )
 
-    #: Both walks live in discovery, which is where filesystem traversal
-    #: belongs; the context keeps the names its callers use.
-    _walk_files = staticmethod(detect_discovery.walk_files)
+    #: Filesystem traversal policy lives in discovery; context keeps the
+    #: predicate name used by its stateful orchestration.
     _should_skip_dir = staticmethod(detect_discovery.should_skip_dir)
 
     def has_marketplace(self) -> bool:

--- a/src/skillsaw/discovery/detect.py
+++ b/src/skillsaw/discovery/detect.py
@@ -7,9 +7,10 @@ This module deliberately returns string labels rather than importing
 from __future__ import annotations
 
 from dataclasses import dataclass
+import fnmatch
 from pathlib import Path
 import os
-from typing import Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Set, Tuple
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 
 from skillsaw.discovery import CONVENTIONAL_SKILL_DIRS, exact_name_exists
 from skillsaw.formats.promptfoo import is_promptfoo_config
@@ -53,6 +54,8 @@ class RepositoryScan:
     mcp_registry_files: Tuple[Path, ...]
     package_json_files: Tuple[Path, ...]
     skills_lock_files: Tuple[Path, ...]
+    promptfoo_named_files: Tuple[Path, ...]
+    promptfoo_eval_files: Dict[Path, Tuple[Path, ...]]
 
 
 #: Pre-directory instruction files, read from the nearest enclosing directory
@@ -72,10 +75,25 @@ def scan_repository(root: Path, root_names: Iterable[str]) -> RepositoryScan:
     mcp_registry_files: List[Path] = []
     package_json_files: List[Path] = []
     skills_locks: List[Path] = []
+    promptfoo_named: List[Path] = []
+    promptfoo_evals: Dict[Path, List[Path]] = {}
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [name for name in dirnames if name not in WALK_SKIP_DIRS]
         here = Path(dirpath)
         vendored = bool(VENDOR_DIR_NAMES.intersection(here.relative_to(root).parts))
+        for name in filenames:
+            path = here / name
+            if fnmatch.fnmatch(name, "promptfooconfig*.yaml") or fnmatch.fnmatch(
+                name, "promptfooconfig*.yml"
+            ):
+                promptfoo_named.append(path)
+            if not (fnmatch.fnmatch(name, "*.yaml") or fnmatch.fnmatch(name, "*.yml")):
+                continue
+            relative_parts = path.relative_to(root).parts
+            for index, part in enumerate(relative_parts[:-1]):
+                if os.path.normcase(part) == os.path.normcase("evals"):
+                    evals_dir = root.joinpath(*relative_parts[: index + 1])
+                    promptfoo_evals.setdefault(evals_dir, []).append(path)
         found.update(here / name for name in filenames if name.endswith(".instructions.md"))
         if not vendored:
             found.update(here / name for name in filenames if devin.is_instruction_filename(name))
@@ -104,6 +122,13 @@ def scan_repository(root: Path, root_names: Iterable[str]) -> RepositoryScan:
         mcp_registry_files=tuple(sorted(mcp_registry_files)),
         package_json_files=tuple(sorted(package_json_files)),
         skills_lock_files=tuple(sorted(skills_locks)),
+        promptfoo_named_files=tuple(
+            sorted(promptfoo_named, key=lambda path: (path.suffix == ".yml", path))
+        ),
+        promptfoo_eval_files={
+            directory: tuple(sorted(paths, key=lambda path: (path.suffix == ".yml", path)))
+            for directory, paths in promptfoo_evals.items()
+        },
     )
 
 
@@ -295,14 +320,6 @@ def instruction_formats(
     return found
 
 
-def walk_files(root: Path) -> Iterator[Path]:
-    """Yield every file under *root*, pruning :data:`WALK_SKIP_DIRS`."""
-    for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [name for name in dirnames if name not in WALK_SKIP_DIRS]
-        for name in filenames:
-            yield Path(dirpath) / name
-
-
 def should_skip_dir(item: Path) -> bool:
     """Whether *item* is not a directory worth recursing into."""
     return not item.is_dir() or item.name.startswith(".") or item.name in WALK_SKIP_DIRS
@@ -388,17 +405,18 @@ def is_dot_claude(root: Path, apm: bool) -> bool:
     )
 
 
-def is_promptfoo_repo(root: Path, walk_files: Callable[[Path], object]) -> bool:
+def is_promptfoo_repo(
+    root: Path,
+    named_files: Iterable[Path],
+    eval_files: Mapping[Path, Iterable[Path]],
+) -> bool:
     """Return whether repository files include a Promptfoo configuration."""
     if any(
         path.name.startswith("promptfooconfig") and path.suffix in (".yaml", ".yml")
-        for path in walk_files(root)
+        for path in named_files
     ):
         return True
-    evals = root / "evals"
-    if not evals.is_dir():
-        return False
-    for path in walk_files(evals):
+    for path in eval_files.get(root / "evals", ()):
         if path.suffix not in (".yaml", ".yml"):
             continue
         data, error = read_yaml(path)
@@ -412,7 +430,8 @@ def marker_types(
     *,
     apm: bool,
     should_skip: Callable[[Path], bool],
-    walk_files: Callable[[Path], object],
+    promptfoo_named_files: Iterable[Path],
+    promptfoo_eval_files: Mapping[Path, Iterable[Path]],
     tool_dirs: Optional[Mapping[str, Iterable[Path]]] = None,
 ) -> Set[str]:
     """Return independently detectable type labels (excluding ecosystems)."""
@@ -436,6 +455,6 @@ def marker_types(
         found.add("apm")
     if is_dot_claude(root, apm):
         found.add("dot-claude")
-    if is_promptfoo_repo(root, walk_files):
+    if is_promptfoo_repo(root, promptfoo_named_files, promptfoo_eval_files):
         found.add("promptfoo")
     return found

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -1336,24 +1336,12 @@ def _build_promptfoo_nodes(
         config_nodes.append(node)
 
     def _scan_evals_dir(evals_dir: Path, parent: LintTarget) -> None:
-        if not evals_dir.is_dir():
-            return
-        for pattern in ("*.yaml", "*.yml"):
-            for yaml_file in sorted(evals_dir.rglob(pattern)):
-                _try_add_config(yaml_file, parent, require_keys=True)
+        for yaml_file in context.promptfoo_eval_files(evals_dir):
+            _try_add_config(yaml_file, parent, require_keys=True)
 
     # Pass 1a: promptfooconfig* anywhere in repo (naming convention → no key
-    # check).  One pruned walk instead of two whole-repo rglobs — pruning
-    # matches the repo-type detector, which already skips .git/node_modules/
-    # .venv and friends.
-    yaml_matches: list[Path] = []
-    yml_matches: list[Path] = []
-    for f in context._walk_files(context.root_path):
-        if fnmatch.fnmatch(f.name, "promptfooconfig*.yaml"):
-            yaml_matches.append(f)
-        elif fnmatch.fnmatch(f.name, "promptfooconfig*.yml"):
-            yml_matches.append(f)
-    for yaml_file in sorted(yaml_matches) + sorted(yml_matches):
+    # check), reusing candidates from the repository's shared discovery walk.
+    for yaml_file in context.promptfoo_named_files():
         _try_add_config(yaml_file, root, require_keys=False)
 
     # Pass 1b: evals/ at repo root

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Protocol, Set, TYPE_CHECKING, Tuple
+from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple
 
 from .diagnostics import safe_display
 
@@ -172,56 +173,154 @@ if TYPE_CHECKING:
     from .context import RepositoryContext
 
 
-class _BlockAdder(Protocol):
-    """The shared attachment primitive supplied by ``build_lint_tree``."""
+@dataclass
+class _TreeBuildState:
+    """Shared state and attachment primitives for one lint-tree build."""
 
-    def __call__(
+    context: "RepositoryContext"
+    root: LintTarget
+    repo_root: Path
+    seen: Set[Path] = field(default_factory=set)
+    seen_roles: Set[Tuple[Path, type]] = field(default_factory=set)
+    openai_seen: Set[Tuple[Path, Path]] = field(default_factory=set)
+    opencode_configs: List[OpenCodeConfigBlock] = field(default_factory=list)
+
+    def resolve_repo_path(self, path: Path) -> Path | None:
+        """Resolve *path* only when repository containment is safe."""
+        return contained_resolve(path, self.repo_root)
+
+    def add_block(
         self,
         parent: LintTarget,
         p: Path,
         block_cls: type,
         owner: Path | None = None,
         content_suppressed: bool = False,
-    ) -> None: ...
+    ) -> None:
+        """Add one safely resolved block unless its role is already present."""
+        resolved = self.resolve_repo_path(p)
+        if (
+            resolved is None
+            or resolved in self.seen
+            or not safe_exists(resolved)
+            or self.context.is_path_excluded(p)
+        ):
+            return
+        self.seen.add(resolved)
+        self.seen_roles.add((resolved, block_cls))
+        block = block_cls(path=p)
+        block.plugin_owner = owner
+        block.content_suppressed = content_suppressed
+        parent.children.append(block)
+
+    def add_parser_block(
+        self,
+        parent: LintTarget,
+        p: Path,
+        block_cls: type,
+        owner: Path | None = None,
+        content_suppressed: bool = False,
+    ) -> Optional[LintTarget]:
+        """Attach a structured document once for each parser role.
+
+        A JSON document may legitimately contain both hooks and MCP servers.
+        Path-only deduplication would hide whichever parser runs second, while
+        role-aware deduplication still prevents duplicate findings when two
+        discovery paths select the same parser.
+        """
+        resolved = self.resolve_repo_path(p)
+        if resolved is None:
+            return None
+        role = (resolved, block_cls)
+        if (
+            role in self.seen_roles
+            or not safe_is_file(resolved)
+            or self.context.is_path_excluded(p)
+        ):
+            return None
+        # seen_roles only — never the path-only ``seen`` set: a manifest can
+        # declare ``hooks``/``mcpServers`` at any in-plugin markdown file,
+        # and poisoning ``seen`` would drop that file from every content
+        # rule that attaches later.
+        self.seen_roles.add(role)
+        block = block_cls(path=p)
+        block.plugin_owner = owner
+        block.content_suppressed = content_suppressed
+        parent.children.append(block)
+        return block
+
+    def add_openai_metadata(
+        self,
+        parent: LintTarget,
+        path: Path,
+        *,
+        metadata_root: Path,
+        containment_root: Path,
+    ) -> None:
+        """Attach structured OpenAI metadata."""
+        # Existence first: this runs once per SkillNode, and `agents/
+        # openai.yaml` is absent in the overwhelming majority of them — the
+        # three resolves below cost a realpath each and answer nothing when
+        # there is no file to attach.
+        if not safe_is_file(path) or self.context.is_path_excluded(path):
+            return
+        resolved = safe_resolve(path)
+        root = safe_resolve(containment_root)
+        owner = safe_resolve(metadata_root)
+        if (
+            resolved is None
+            or root is None
+            or owner is None
+            or (resolved, owner) in self.openai_seen
+            or not resolved.is_relative_to(root)
+        ):
+            return
+        # Metadata paths have owner-relative semantics, so the same contained
+        # file may need validation once for each skill that links to it. Keep
+        # this separate from the content-block dedupe set for the same reason.
+        self.openai_seen.add((resolved, owner))
+        block = OpenAIMetadataBlock(
+            path=path,
+            metadata_root=metadata_root,
+            containment_root=containment_root,
+        )
+        parent.children.append(block)
 
 
 def _attach_apm_skills(
-    context: "RepositoryContext",
+    state: _TreeBuildState,
     apm_node: ApmNode,
     apm_skills: Path,
-    add_block: _BlockAdder,
 ) -> None:
     """Attach authored APM skills and their Markdown references."""
     if not apm_skills.is_dir():
         return
 
-    for skill_path in context.skills:
+    for skill_path in state.context.skills:
         if not (safe_resolve(skill_path) or skill_path).is_relative_to(
             safe_resolve(apm_skills) or apm_skills
         ):
             continue
         skill_node = SkillNode(path=skill_path)
-        add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
+        state.add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
         refs_dir = skill_path / "references"
         if refs_dir.is_dir():
             for ref_file in sorted(refs_dir.glob("*.md")):
-                add_block(skill_node, ref_file, SkillRefBlock)
+                state.add_block(skill_node, ref_file, SkillRefBlock)
         apm_node.children.append(skill_node)
 
 
 def _attach_apm_tree(
-    context: "RepositoryContext",
-    root: LintTarget,
-    add_block: _BlockAdder,
-    is_excluded: Callable[[Path], bool],
+    state: _TreeBuildState,
 ) -> None:
     """Attach APM's manifest and authored primitives at their original stage."""
+    context = state.context
     if not context.has_apm:
         return
 
     apm_yml = context.root_path / "apm.yml"
-    if apm_yml.exists() and not is_excluded(apm_yml):
-        root.children.append(ApmConfigNode(path=apm_yml))
+    if apm_yml.exists() and not context.is_path_excluded(apm_yml):
+        state.root.children.append(ApmConfigNode(path=apm_yml))
 
     # `.apm/` holds a package's authored primitives. A consumer-only
     # manifest — `apm.yml` with `dependencies:`/`targets:` and no authored
@@ -237,15 +336,15 @@ def _attach_apm_tree(
         if not content_dir.is_dir():
             continue
         for markdown_file in sorted(content_dir.glob(pattern)):
-            add_block(apm_node, markdown_file, block_cls)
+            state.add_block(apm_node, markdown_file, block_cls)
 
     # Hooks and settings inside .apm/ are supply-chain attack surfaces.
-    add_block(apm_node, apm_dir / "hooks" / "hooks.json", HooksBlock)
-    add_block(apm_node, apm_dir / "settings.json", SettingsBlock)
-    add_block(apm_node, apm_dir / "settings.local.json", SettingsBlock)
+    state.add_block(apm_node, apm_dir / "hooks" / "hooks.json", HooksBlock)
+    state.add_block(apm_node, apm_dir / "settings.json", SettingsBlock)
+    state.add_block(apm_node, apm_dir / "settings.local.json", SettingsBlock)
 
-    _attach_apm_skills(context, apm_node, apm_dir / "skills", add_block)
-    root.children.append(apm_node)
+    _attach_apm_skills(state, apm_node, apm_dir / "skills")
+    state.root.children.append(apm_node)
 
 
 def build_lint_tree(context: "RepositoryContext") -> LintTarget:
@@ -272,19 +371,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         logger.error(message)
         root.set_parents()
         return root
-    seen: Set[Path] = set()
-    seen_roles: Set[Tuple[Path, type]] = set()
-    openai_seen: Set[Tuple[Path, Path]] = set()
-    opencode_configs: List[OpenCodeConfigBlock] = []
+    state = _TreeBuildState(context=context, root=root, repo_root=repo_root)
 
     _is_excluded = context.is_path_excluded
     _is_in_compiled_dir = context.in_apm_compiled_dir
-
-    def _resolve_repo_path(path: Path) -> Path | None:
-        """Resolve *path* only when the repository root and containment are safe."""
-        if repo_root is None:
-            return None
-        return contained_resolve(path, repo_root)
 
     apm_source_root = (
         (safe_resolve((context.root_path / ".apm")) or (context.root_path / ".apm"))
@@ -396,55 +486,6 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         resolved = safe_resolve(path)
         return resolved is not None and resolved in apm_compiled_github
 
-    def _add_block(
-        parent: LintTarget,
-        p: Path,
-        block_cls: type,
-        owner: Path | None = None,
-        content_suppressed: bool = False,
-    ) -> None:
-        """Add one safely resolved block unless its role is already present."""
-        resolved = _resolve_repo_path(p)
-        if resolved is None or resolved in seen or not safe_exists(resolved) or _is_excluded(p):
-            return
-        seen.add(resolved)
-        seen_roles.add((resolved, block_cls))
-        block = block_cls(path=p)
-        block.plugin_owner = owner
-        block.content_suppressed = content_suppressed
-        parent.children.append(block)
-
-    def _add_parser_block(
-        parent: LintTarget,
-        p: Path,
-        block_cls: type,
-        owner: Path | None = None,
-        content_suppressed: bool = False,
-    ) -> Optional[LintTarget]:
-        """Attach a structured document once for each parser role.
-
-        A JSON document may legitimately contain both hooks and MCP servers.
-        Path-only deduplication would hide whichever parser runs second, while
-        role-aware deduplication still prevents duplicate findings when two
-        discovery paths select the same parser.
-        """
-        resolved = _resolve_repo_path(p)
-        if resolved is None:
-            return None
-        role = (resolved, block_cls)
-        if role in seen_roles or not safe_is_file(resolved) or _is_excluded(p):
-            return None
-        # seen_roles only — never the path-only ``seen`` set: a manifest can
-        # declare ``hooks``/``mcpServers`` at any in-plugin markdown file,
-        # and poisoning ``seen`` would drop that file from every content
-        # rule that attaches later.
-        seen_roles.add(role)
-        block = block_cls(path=p)
-        block.plugin_owner = owner
-        block.content_suppressed = content_suppressed
-        parent.children.append(block)
-        return block
-
     # Nearest package ownership, with the roots resolved once per context.
     _contained_plugin_owner = context.contained_plugin_owning
     agent_plugin_roots = set(context.agent_plugin_roots())
@@ -475,7 +516,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         resolved = safe_resolve(p)
         if root is None or resolved is None or not resolved.is_relative_to(root):
             return
-        _add_parser_block(parent, p, block_cls, owner=owner)
+        state.add_parser_block(parent, p, block_cls, owner=owner)
 
     def _add_plugin_prose(parent: LintTarget, plugin_dir: Path, owner: Path) -> None:
         """The one prose attach for every plugin container.
@@ -524,46 +565,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 continue
             for md in files:
                 if _contained(md):
-                    _add_block(parent, md, block_cls, owner=owner)
+                    state.add_block(parent, md, block_cls, owner=owner)
         readme = plugin_dir / "README.md"
         if _contained(readme):
-            _add_block(parent, readme, ReadmeBlock, owner=owner)
-
-    def _add_openai_metadata(
-        parent: LintTarget,
-        path: Path,
-        *,
-        metadata_root: Path,
-        containment_root: Path,
-    ) -> None:
-        """Attach structured OpenAI metadata."""
-        # Existence first: this runs once per SkillNode, and `agents/
-        # openai.yaml` is absent in the overwhelming majority of them — the
-        # three resolves below cost a realpath each and answer nothing when
-        # there is no file to attach.
-        if not safe_is_file(path) or _is_excluded(path):
-            return
-        resolved = safe_resolve(path)
-        root = safe_resolve(containment_root)
-        owner = safe_resolve(metadata_root)
-        if (
-            resolved is None
-            or root is None
-            or owner is None
-            or (resolved, owner) in openai_seen
-            or not resolved.is_relative_to(root)
-        ):
-            return
-        # Metadata paths have owner-relative semantics, so the same contained
-        # file may need validation once for each skill that links to it. Keep
-        # this separate from the content-block dedupe set for the same reason.
-        openai_seen.add((resolved, owner))
-        block = OpenAIMetadataBlock(
-            path=path,
-            metadata_root=metadata_root,
-            containment_root=containment_root,
-        )
-        parent.children.append(block)
+            state.add_block(parent, readme, ReadmeBlock, owner=owner)
 
     # --- Root-level instruction files (skip .apm/ — handled in APM section) ---
     for f in context.instruction_files:
@@ -575,11 +580,11 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # security rules still scan the copy that ships.
         compiled = _is_apm_compiled_github(f.parent)
         block_cls = _instruction_block_type(f)
-        _add_block(root, f, block_cls, content_suppressed=compiled)
+        state.add_block(root, f, block_cls, content_suppressed=compiled)
 
     # --- .claude/settings.json (supply-chain attack surface) ---
-    _add_block(root, context.root_path / ".claude" / "settings.json", SettingsBlock)
-    _add_block(root, context.root_path / ".claude" / "settings.local.json", SettingsBlock)
+    state.add_block(root, context.root_path / ".claude" / "settings.json", SettingsBlock)
+    state.add_block(root, context.root_path / ".claude" / "settings.local.json", SettingsBlock)
 
     # --- Root-level .mcp.json (MCP server configuration) ---
     # A dual-format package may symlink both conventional paths to one file.
@@ -590,7 +595,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     )
     root_native_mcp = context.root_path / ".mcp.json"
     if not _shadowed_by_agent_plugin_mcp(root_native_mcp, root_agent_plugin_mcp):
-        _add_block(root, root_native_mcp, McpBlock)
+        state.add_block(root, root_native_mcp, McpBlock)
 
     # --- MCP Registry publisher metadata ---
     # server.json is not an MCP client configuration file: it describes one
@@ -598,10 +603,10 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     # reaches content-quality rules as prose.
     registry_servers = context.mcp_registry_server_paths()
     for server_json in registry_servers:
-        _add_parser_block(root, server_json, McpRegistryServerBlock)
+        state.add_parser_block(root, server_json, McpRegistryServerBlock)
     if registry_servers:
         for package_json in context.package_json_paths():
-            _add_parser_block(root, package_json, McpRegistryNpmPackageBlock)
+            state.add_parser_block(root, package_json, McpRegistryNpmPackageBlock)
 
     # --- Editor-owned content directories (Cursor, Copilot/VS Code, Cline) ---
     # These tools read AGENTS.md for portable instructions — already attached
@@ -641,7 +646,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # symlink at the base even though it will not follow one during
         # ``**`` descent, so a ``.clinerules -> /`` symlink would walk the
         # filesystem before a single match was rejected.
-        if _resolve_repo_path(directory) is None:
+        if state.resolve_repo_path(directory) is None:
             return
         try:
             matches = sorted(directory.glob(pattern))
@@ -663,13 +668,13 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             if skip_dirs and relative and relative[0] in skip_dirs:
                 continue
             if safe_is_file(match):
-                _add_block(parent, match, block_cls, content_suppressed=content_suppressed)
+                state.add_block(parent, match, block_cls, content_suppressed=content_suppressed)
 
     # Cursor reads the legacy file from the nearest enclosing directory too,
     # so a monorepo package keeps its own — discovered in the same walk that
     # finds `.cursor/`, which is what keeps detection and attachment agreeing.
     for legacy_cursor in context.legacy_editor_files(".cursorrules"):
-        _add_block(root, legacy_cursor, InstructionBlock)
+        state.add_block(root, legacy_cursor, InstructionBlock)
 
     for cursor_dir in context.agent_tool_dirs(".cursor"):
         # APM's cursor target compiles ``.apm/instructions/`` into
@@ -691,15 +696,15 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             content_suppressed=rules_suppressed,
         )
         _add_glob(root, cursor_dir / "commands", "**/*.md", CursorCommandBlock)
-        _add_parser_block(root, cursor_dir / "mcp.json", CursorMcpBlock)
-        _add_parser_block(root, cursor_dir / "hooks.json", CursorHooksBlock)
+        state.add_parser_block(root, cursor_dir / "mcp.json", CursorMcpBlock)
+        state.add_parser_block(root, cursor_dir / "hooks.json", CursorHooksBlock)
 
     for github_dir in context.agent_tool_dirs(".github"):
         # A compiled Copilot copy duplicates its ``.apm/`` source for the
         # content rules, so those findings are dropped — but it is attached,
         # not removed, so the security rules still scan what actually ships.
         copilot_instructions = github_dir / "copilot-instructions.md"
-        _add_block(
+        state.add_block(
             root,
             copilot_instructions,
             InstructionBlock,
@@ -728,12 +733,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             )
 
     for vscode_dir in context.agent_tool_dirs(".vscode"):
-        _add_parser_block(root, vscode_dir / "mcp.json", VsCodeMcpBlock)
+        state.add_parser_block(root, vscode_dir / "mcp.json", VsCodeMcpBlock)
 
     # The skills CLI writes one project lockfile at each project root. A
     # monorepo may therefore have several, all found by the shared walk.
     for lockfile in context.skills_lock_files():
-        _add_parser_block(root, lockfile, SkillsLockBlock)
+        state.add_parser_block(root, lockfile, SkillsLockBlock)
 
     def _add_opencode_config(directory: Path) -> None:
         """Attach every ``opencode.json`` and ``opencode.jsonc`` in *directory*.
@@ -744,14 +749,14 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         ``opencode-config-valid``, and its ``mcp`` section is additionally
         exposed as an :class:`McpBlock` so the ecosystem-neutral policy and
         security rules read OpenCode's servers the way they read every other
-        host's. ``_add_parser_block`` is role-aware, so this is one file
+        host's. ``state.add_parser_block`` is role-aware, so this is one file
         appearing twice in the tree rather than two findings for one defect.
         """
         for name in _OPENCODE_CONFIG_NAMES:
-            config = _add_parser_block(root, directory / name, OpenCodeConfigBlock)
+            config = state.add_parser_block(root, directory / name, OpenCodeConfigBlock)
             if isinstance(config, OpenCodeConfigBlock):
-                opencode_configs.append(config)
-            _add_parser_block(root, directory / name, OpenCodeMcpBlock)
+                state.opencode_configs.append(config)
+            state.add_parser_block(root, directory / name, OpenCodeMcpBlock)
 
     def _add_opencode_instructions() -> None:
         """Attach local files selected by each OpenCode ``instructions`` entry.
@@ -769,7 +774,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         """
         searched: Set[Tuple[Path, str]] = set()
         searches: List[Tuple[Path, str]] = []
-        for config in opencode_configs:
+        for config in state.opencode_configs:
             data = config.raw_data
             instructions = data.get("instructions") if data is not None else None
             if not isinstance(instructions, list):
@@ -779,7 +784,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 if config.path.parent.name == ".opencode"
                 else config.path.parent
             )
-            if _resolve_repo_path(project_dir) is None:
+            if state.resolve_repo_path(project_dir) is None:
                 continue
             search_dirs: List[Path] = []
             current = project_dir
@@ -788,7 +793,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 if current == context.root_path:
                     break
                 parent = current.parent
-                if parent == current or _resolve_repo_path(parent) is None:
+                if parent == current or state.resolve_repo_path(parent) is None:
                     break
                 current = parent
 
@@ -813,7 +818,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                     candidates = tuple((base, raw_pattern) for base in search_dirs)
 
                 for glob_base, pattern in candidates:
-                    resolved_base = _resolve_repo_path(glob_base)
+                    resolved_base = state.resolve_repo_path(glob_base)
                     search = (resolved_base, pattern) if resolved_base is not None else None
                     if search is None or search in searched or not safe_is_dir(glob_base):
                         continue
@@ -843,9 +848,9 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
 
         for matches in matches_by_search:
             for match in matches:
-                resolved_match = _resolve_repo_path(match)
+                resolved_match = state.resolve_repo_path(match)
                 if resolved_match is not None and safe_is_file(resolved_match):
-                    _add_block(
+                    state.add_block(
                         root,
                         match,
                         _instruction_block_type(match),
@@ -882,27 +887,27 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
     for dir_name in devin.TOOL_DIR_NAMES:
         for devin_dir in context.agent_tool_dirs(dir_name):
             _add_glob(root, devin_dir / "rules", "**/*.md", DevinRuleBlock)
-            _add_block(root, devin_dir / "global_rules.md", DevinGlobalRuleBlock)
+            state.add_block(root, devin_dir / "global_rules.md", DevinGlobalRuleBlock)
 
     kiro_steering = context.root_path / ".kiro" / "steering"
     if kiro_steering.is_dir():
         for md in sorted(kiro_steering.glob("*.md")):
-            _add_block(root, md, InstructionBlock)
+            state.add_block(root, md, InstructionBlock)
 
-    _add_block(root, context.root_path / ".windsurfrules", InstructionBlock)
+    state.add_block(root, context.root_path / ".windsurfrules", InstructionBlock)
 
     # Same story as `.cursorrules`: the file form of `.clinerules` is read
     # from the workspace directory, so a package that carries its own is
     # linted alongside the root's.
     for clinerules_file in context.legacy_editor_files(".clinerules"):
-        _add_block(root, clinerules_file, InstructionBlock)
+        state.add_block(root, clinerules_file, InstructionBlock)
     for clinerules_dir in context.agent_tool_dirs(".clinerules"):
         # Cline concatenates every .md and .txt under .clinerules/ into the
         # system prompt, but its loader excludes three subdirectories:
         # workflows/ (on demand), skills/ (on demand, and discovered as
         # skills), and hooks/ (executables, not prose). Sweeping them in
         # would budget content Cline never loads as always-on context.
-        # Claim the workflows first: ``_add_block`` keeps the first role a
+        # Claim the workflows first: ``state.add_block`` keeps the first role a
         # path gets.
         _add_glob(root, clinerules_dir / "workflows", "**/*.md", ClineWorkflowBlock)
         for pattern in ("**/*.md", "**/*.txt"):
@@ -1027,21 +1032,21 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         # unclaimed packages. Portable-only packages must not accidentally
         # inherit Claude's hooks, .mcp.json, or settings semantics.
         if prov.claude or (not prov.ecosystems and not is_agent_plugin):
-            _add_block(
+            state.add_block(
                 container, plugin_path / "hooks" / "hooks.json", HooksBlock, owner=resolved_plugin
             )
             native_mcp = plugin_path / ".mcp.json"
             if not _shadowed_by_agent_plugin_mcp(native_mcp, agent_plugin_mcp):
-                _add_block(container, native_mcp, McpBlock, owner=resolved_plugin)
+                state.add_block(container, native_mcp, McpBlock, owner=resolved_plugin)
         # settings.json is Claude-side configuration with no Codex
         # counterpart: attached only for Claude-style directories, keeping
-        # _add_block's bare resolve() away from content a hostile
+        # the generic attachment path away from content a hostile
         # Codex-only checkout controls.
         if prov.claude or (not prov.ecosystems and not is_agent_plugin):
-            _add_block(
+            state.add_block(
                 container, plugin_path / "settings.json", SettingsBlock, owner=resolved_plugin
             )
-            _add_block(
+            state.add_block(
                 container, plugin_path / "settings.local.json", SettingsBlock, owner=resolved_plugin
             )
 
@@ -1057,7 +1062,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             # against the excluded manifest itself.
             node = CodexPluginConfigNode(path=manifest)
             node.plugin_owner = resolved_plugin
-            _add_openai_metadata(
+            state.add_openai_metadata(
                 node,
                 plugin_path / "agents" / "openai.yaml",
                 metadata_root=plugin_path,
@@ -1074,7 +1079,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             # payloads have no file of their own, so they borrow the
             # manifest path.
             for declared_hooks in codex_declared_hook_files(plugin_path):
-                _add_parser_block(node, declared_hooks, HooksBlock, owner=resolved_plugin)
+                state.add_parser_block(node, declared_hooks, HooksBlock, owner=resolved_plugin)
             for inline_hooks in codex_inline_hooks(plugin_path):
                 inline_block = CodexInlineHooksBlock(path=manifest, inline_data=inline_hooks)
                 inline_block.plugin_owner = resolved_plugin
@@ -1087,7 +1092,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             for declared_mcp in codex_declared_mcp_files(plugin_path):
                 if _shadowed_by_agent_plugin_mcp(declared_mcp, agent_plugin_mcp):
                     continue
-                _add_parser_block(node, declared_mcp, McpBlock, owner=resolved_plugin)
+                state.add_parser_block(node, declared_mcp, McpBlock, owner=resolved_plugin)
             for inline_mcp in codex_inline_mcp_servers(plugin_path):
                 inline_block = CodexInlineMcpBlock(path=manifest, inline_data=inline_mcp)
                 inline_block.plugin_owner = resolved_plugin
@@ -1125,13 +1130,13 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         native_devin = devin.is_devin_native_skill_dir(skill_path)
         skill_node = DevinSkillNode(path=skill_path) if native_devin else SkillNode(path=skill_path)
         block_cls = DevinSkillBlock if native_devin else SkillBlock
-        _add_block(skill_node, skill_path / "SKILL.md", block_cls)
+        state.add_block(skill_node, skill_path / "SKILL.md", block_cls)
         # Contained against the owning package: rules both read and
         # rewrite these files, so a symlink here is a read *and* a write
         # outside the checkout.
         ref_root = _contained_plugin_owner(skill_path)
 
-        _add_openai_metadata(
+        state.add_openai_metadata(
             skill_node,
             skill_path / "agents" / "openai.yaml",
             metadata_root=skill_path,
@@ -1148,7 +1153,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
         if refs_dir.is_dir():
             for ref_file in sorted(refs_dir.glob("*.md")):
                 if _contained_in_plugin(ref_file):
-                    _add_block(skill_node, ref_file, SkillRefBlock)
+                    state.add_block(skill_node, ref_file, SkillRefBlock)
 
         # Nearest plugin ancestor via dict lookups — iterating all plugins
         # with is_relative_to() is O(skills x plugins) and dominated tree
@@ -1176,15 +1181,15 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
 
     # --- .coderabbit.yaml ---
     cr_path = context.root_path / ".coderabbit.yaml"
-    cr_resolved = _resolve_repo_path(cr_path)
+    cr_resolved = state.resolve_repo_path(cr_path)
     if cr_resolved is not None and safe_exists(cr_resolved) and not _is_excluded(cr_path):
         cr_container = CodeRabbitNode(path=cr_path)
-        cr_blocks = CodeRabbitContentBlock.gather(context, seen, _is_excluded)
+        cr_blocks = CodeRabbitContentBlock.gather(context, state.seen, _is_excluded)
         cr_container.children.extend(cr_blocks)
         root.children.append(cr_container)
 
     # --- Promptfoo eval configs ---
-    _build_promptfoo_nodes(context, root, plugin_nodes, seen, _is_excluded)
+    _build_promptfoo_nodes(context, root, plugin_nodes, state.seen, _is_excluded)
 
     # --- Cursor prompt-hook content blocks ---
     # Attached to the root rather than to the hooks block: a JsonConfigBlock
@@ -1201,7 +1206,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 break
 
     # --- APM ---
-    _attach_apm_tree(context, root, _add_block, _is_excluded)
+    _attach_apm_tree(state)
 
     # --- Extra content paths from config ---
     # User-configured content paths plus globs contributed by detected
@@ -1222,13 +1227,13 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 continue
             extra_resolved = safe_resolve(extra)
             if extra_resolved is not None and any(
-                claimed == extra_resolved for claimed, _ in seen_roles
+                claimed == extra_resolved for claimed, _ in state.seen_roles
             ):
                 # Already attached under a structured parser role (hooks,
                 # MCP): re-attaching it as prose would make every
                 # content-quality rule lint structured config as text.
                 continue
-            _add_block(root, extra, ExtraBlock)
+            state.add_block(root, extra, ExtraBlock)
 
     # --- Plugin tree contributors ---
     # Contributors return pre-constructed nodes (typically ContentBlock or
@@ -1248,12 +1253,12 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
             raise TypeError(f"contributor returned {block!r}, which is not a lint tree node")
         if not isinstance(block.path, Path):
             raise TypeError(f"contributor returned a node with invalid path {block.path!r}")
-        resolved = _resolve_repo_path(block.path)
+        resolved = state.resolve_repo_path(block.path)
         if resolved is None:
             raise ValueError(f"contributor path is unresolved or outside repository: {block.path}")
-        if resolved in seen or not safe_exists(resolved) or _is_excluded(block.path):
+        if resolved in state.seen or not safe_exists(resolved) or _is_excluded(block.path):
             return False
-        seen.add(resolved)
+        state.seen.add(resolved)
         block.children = [child for child in block.children if _admit_contributed_node(child)]
         return True
 

--- a/src/skillsaw/lint_tree.py
+++ b/src/skillsaw/lint_tree.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple
+from typing import Callable, Dict, List, Optional, Protocol, Set, TYPE_CHECKING, Tuple
 
 from .diagnostics import safe_display
 
@@ -156,9 +156,96 @@ _OPENCODE_CONTENT_DIRS = tuple(
 #: loads is its business rather than a defect in either file.
 _OPENCODE_CONFIG_NAMES = ("opencode.json", "opencode.jsonc")
 
+# Authored APM content directories, in lint-tree attachment order. Keeping the
+# directory, file convention, and semantic block together makes format support
+# a data change rather than another nested branch in the tree orchestrator.
+_APM_CONTENT_GLOBS = (
+    ("instructions", "*.instructions.md", InstructionBlock),
+    ("agents", "*.agent.md", AgentBlock),
+    ("prompts", "*.md", PromptBlock),
+    ("chatmodes", "*.md", ChatmodeBlock),
+    ("context", "*.md", ContextFileBlock),
+)
+
 
 if TYPE_CHECKING:
     from .context import RepositoryContext
+
+
+class _BlockAdder(Protocol):
+    """The shared attachment primitive supplied by ``build_lint_tree``."""
+
+    def __call__(
+        self,
+        parent: LintTarget,
+        p: Path,
+        block_cls: type,
+        owner: Path | None = None,
+        content_suppressed: bool = False,
+    ) -> None: ...
+
+
+def _attach_apm_skills(
+    context: "RepositoryContext",
+    apm_node: ApmNode,
+    apm_skills: Path,
+    add_block: _BlockAdder,
+) -> None:
+    """Attach authored APM skills and their Markdown references."""
+    if not apm_skills.is_dir():
+        return
+
+    for skill_path in context.skills:
+        if not (safe_resolve(skill_path) or skill_path).is_relative_to(
+            safe_resolve(apm_skills) or apm_skills
+        ):
+            continue
+        skill_node = SkillNode(path=skill_path)
+        add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
+        refs_dir = skill_path / "references"
+        if refs_dir.is_dir():
+            for ref_file in sorted(refs_dir.glob("*.md")):
+                add_block(skill_node, ref_file, SkillRefBlock)
+        apm_node.children.append(skill_node)
+
+
+def _attach_apm_tree(
+    context: "RepositoryContext",
+    root: LintTarget,
+    add_block: _BlockAdder,
+    is_excluded: Callable[[Path], bool],
+) -> None:
+    """Attach APM's manifest and authored primitives at their original stage."""
+    if not context.has_apm:
+        return
+
+    apm_yml = context.root_path / "apm.yml"
+    if apm_yml.exists() and not is_excluded(apm_yml):
+        root.children.append(ApmConfigNode(path=apm_yml))
+
+    # `.apm/` holds a package's authored primitives. A consumer-only
+    # manifest — `apm.yml` with `dependencies:`/`targets:` and no authored
+    # content — has no `.apm/` directory, so don't invent an ApmNode for a
+    # path that doesn't exist (issue #472).
+    apm_dir = context.root_path / ".apm"
+    if not apm_dir.is_dir():
+        return
+
+    apm_node = ApmNode(path=apm_dir)
+    for dirname, pattern, block_cls in _APM_CONTENT_GLOBS:
+        content_dir = apm_dir / dirname
+        if not content_dir.is_dir():
+            continue
+        for markdown_file in sorted(content_dir.glob(pattern)):
+            add_block(apm_node, markdown_file, block_cls)
+
+    # Hooks and settings inside .apm/ are supply-chain attack surfaces.
+    add_block(apm_node, apm_dir / "hooks" / "hooks.json", HooksBlock)
+    add_block(apm_node, apm_dir / "settings.json", SettingsBlock)
+    add_block(apm_node, apm_dir / "settings.local.json", SettingsBlock)
+
+    _attach_apm_skills(context, apm_node, apm_dir / "skills", add_block)
+    root.children.append(apm_node)
 
 
 def build_lint_tree(context: "RepositoryContext") -> LintTarget:
@@ -1114,64 +1201,7 @@ def build_lint_tree(context: "RepositoryContext") -> LintTarget:
                 break
 
     # --- APM ---
-    if context.has_apm:
-        apm_yml = context.root_path / "apm.yml"
-        if apm_yml.exists() and not _is_excluded(apm_yml):
-            root.children.append(ApmConfigNode(path=apm_yml))
-
-        # `.apm/` holds a package's authored primitives. A consumer-only
-        # manifest — `apm.yml` with `dependencies:`/`targets:` and no
-        # authored content — has no `.apm/` directory, so don't invent an
-        # ApmNode for a path that doesn't exist (issue #472).
-        apm_dir = context.root_path / ".apm"
-        if apm_dir.is_dir():
-            apm_node = ApmNode(path=apm_dir)
-
-            apm_instructions = apm_dir / "instructions"
-            if apm_instructions.is_dir():
-                for md in sorted(apm_instructions.glob("*.instructions.md")):
-                    _add_block(apm_node, md, InstructionBlock)
-
-            apm_agents = apm_dir / "agents"
-            if apm_agents.is_dir():
-                for md in sorted(apm_agents.glob("*.agent.md")):
-                    _add_block(apm_node, md, AgentBlock)
-
-            apm_prompts = apm_dir / "prompts"
-            if apm_prompts.is_dir():
-                for md in sorted(apm_prompts.glob("*.md")):
-                    _add_block(apm_node, md, PromptBlock)
-
-            apm_chatmodes = apm_dir / "chatmodes"
-            if apm_chatmodes.is_dir():
-                for md in sorted(apm_chatmodes.glob("*.md")):
-                    _add_block(apm_node, md, ChatmodeBlock)
-
-            apm_context = apm_dir / "context"
-            if apm_context.is_dir():
-                for md in sorted(apm_context.glob("*.md")):
-                    _add_block(apm_node, md, ContextFileBlock)
-
-            # Hooks and settings inside .apm/ (supply-chain attack surface)
-            _add_block(apm_node, apm_dir / "hooks" / "hooks.json", HooksBlock)
-            _add_block(apm_node, apm_dir / "settings.json", SettingsBlock)
-            _add_block(apm_node, apm_dir / "settings.local.json", SettingsBlock)
-
-            apm_skills = apm_dir / "skills"
-            if apm_skills.is_dir():
-                for skill_path in context.skills:
-                    if (safe_resolve(skill_path) or skill_path).is_relative_to(
-                        (safe_resolve(apm_skills) or apm_skills)
-                    ):
-                        skill_node = SkillNode(path=skill_path)
-                        _add_block(skill_node, skill_path / "SKILL.md", SkillBlock)
-                        refs_dir = skill_path / "references"
-                        if refs_dir.is_dir():
-                            for ref_file in sorted(refs_dir.glob("*.md")):
-                                _add_block(skill_node, ref_file, SkillRefBlock)
-                        apm_node.children.append(skill_node)
-
-            root.children.append(apm_node)
+    _attach_apm_tree(context, root, _add_block, _is_excluded)
 
     # --- Extra content paths from config ---
     # User-configured content paths plus globs contributed by detected

--- a/src/skillsaw/repository_scan.py
+++ b/src/skillsaw/repository_scan.py
@@ -62,6 +62,14 @@ class RepositoryScanMixin:
             if not self.is_path_excluded(path)
         ]
 
+    def promptfoo_named_files(self) -> List[Path]:
+        """Promptfoo conventionally named files from the shared repository walk."""
+        return list(self._repository_scan().promptfoo_named_files)
+
+    def promptfoo_eval_files(self, evals_dir: Path) -> List[Path]:
+        """YAML candidates beneath one lexical ``evals/`` directory."""
+        return list(self._repository_scan().promptfoo_eval_files.get(evals_dir, ()))
+
     def _detect_formats(self) -> set[str]:
         return detect_discovery.instruction_formats(
             self.root_path,

--- a/src/skillsaw/rules/builtin/copilot/agent_valid.py
+++ b/src/skillsaw/rules/builtin/copilot/agent_valid.py
@@ -757,8 +757,29 @@ class CopilotAgentValidRule(Rule):
             )
             return False
 
+        # Run every phase: one malformed field must not hide later diagnostics.
+        required_valid = self._check_hook_required_fields(
+            block, path, hook_type, handler, line, violations
+        )
+        optional_valid = self._check_hook_optional_fields(block, path, handler, line, violations)
+        self._warn_hook_field_compatibility(block, path, hook_type, handler, line, violations)
+
+        valid = required_valid
+        if not optional_valid:
+            valid = False
+        return valid
+
+    def _check_hook_required_fields(
+        self,
+        block: CopilotAgentBlock,
+        path: str,
+        hook_type: str,
+        handler: dict,
+        line: Optional[int],
+        violations: List[RuleViolation],
+    ) -> bool:
+        """Validate the fields that make a handler of *hook_type* runnable."""
         valid = True
-        required_fields = _TYPE_REQUIRED_FIELDS[hook_type]
         if hook_type == "command":
             present_commands = [key for key in HOOK_COMMAND_FIELDS if key in handler]
             if not present_commands:
@@ -783,9 +804,9 @@ class CopilotAgentValidRule(Rule):
                         )
                     )
                     valid = False
-            required_fields = {}
+            return valid
 
-        for key, expected in required_fields.items():
+        for key, expected in _TYPE_REQUIRED_FIELDS[hook_type].items():
             if key not in handler:
                 violations.append(
                     self._finding(
@@ -809,7 +830,18 @@ class CopilotAgentValidRule(Rule):
                     )
                 )
                 valid = False
+        return valid
 
+    def _check_hook_optional_fields(
+        self,
+        block: CopilotAgentBlock,
+        path: str,
+        handler: dict,
+        line: Optional[int],
+        violations: List[RuleViolation],
+    ) -> bool:
+        """Validate common optional fields and command argument members."""
+        valid = True
         for key, expected in _OPTIONAL_FIELD_TYPES.items():
             if key not in handler:
                 continue
@@ -837,6 +869,18 @@ class CopilotAgentValidRule(Rule):
                         )
                     )
                     valid = False
+        return valid
+
+    def _warn_hook_field_compatibility(
+        self,
+        block: CopilotAgentBlock,
+        path: str,
+        hook_type: str,
+        handler: dict,
+        line: Optional[int],
+        violations: List[RuleViolation],
+    ) -> None:
+        """Warn when a valid field belongs to a different handler type."""
         for key in handler:
             allowed_types = (
                 {"command"} if key in HOOK_COMMAND_FIELDS else _TYPE_SPECIFIC_FIELDS.get(key)
@@ -852,7 +896,6 @@ class CopilotAgentValidRule(Rule):
                         discriminator=f"hooks:{path}:{key}:compatibility",
                     )
                 )
-        return valid
 
     def _compatibility_warning(
         self,

--- a/src/skillsaw/rules/builtin/opencode/config_valid.py
+++ b/src/skillsaw/rules/builtin/opencode/config_valid.py
@@ -63,23 +63,23 @@ def _json_values_equal(left: Any, right: Any) -> bool:
     return True
 
 
-def _lower_model_selection(value: Any) -> Dict[str, str] | None:
-    """Lower one valid OpenCode 2.0 model selection to its 1.x fields."""
-    if isinstance(value, str):
-        if "/" not in value:
-            return None
-        provider, selected = value.split("/", 1)
-        if not provider or "#" in provider or not selected or selected.count("#") > 1:
-            return None
-        if "#" not in selected:
-            return {"model": value}
-        model, variant = selected.split("#", 1)
-        if not model or not variant:
-            return None
-        return {"model": f"{provider}/{model}", "variant": variant}
-
-    if not isinstance(value, dict):
+def _lower_string_model_selection(value: str) -> Dict[str, str] | None:
+    """Lower a provider/model string with an optional ``#variant`` suffix."""
+    if "/" not in value:
         return None
+    provider, selected = value.split("/", 1)
+    if not provider or "#" in provider or not selected or selected.count("#") > 1:
+        return None
+    if "#" not in selected:
+        return {"model": value}
+    model, variant = selected.split("#", 1)
+    if not model or not variant:
+        return None
+    return {"model": f"{provider}/{model}", "variant": variant}
+
+
+def _lower_object_model_selection(value: Dict[str, Any]) -> Dict[str, str] | None:
+    """Lower a provider/model selection object to OpenCode 1.x fields."""
     provider = value.get("providerID")
     model = value.get("model")
     if (
@@ -99,6 +99,15 @@ def _lower_model_selection(value: Any) -> Dict[str, str] | None:
             return None
         lowered["variant"] = variant
     return lowered
+
+
+def _lower_model_selection(value: Any) -> Dict[str, str] | None:
+    """Lower one valid OpenCode 2.0 model selection to its 1.x fields."""
+    if isinstance(value, str):
+        return _lower_string_model_selection(value)
+    if isinstance(value, dict):
+        return _lower_object_model_selection(value)
+    return None
 
 
 def _lower_native_command(entry: Any) -> Dict[str, Any] | None:

--- a/tests/test_content_analysis.py
+++ b/tests/test_content_analysis.py
@@ -847,6 +847,74 @@ class TestContentBlockReadWrite:
         result = f.read_text(encoding="utf-8")
         assert result == "---\ndescription: A test rule\nglobs: '*.py'\n---\nNew body content\n"
 
+    @pytest.mark.parametrize(
+        ("original", "expected"),
+        [
+            (
+                b"---\ndescription: Old\n---\nBody\n",
+                b"---\ndescription: New\n---\nBody\n",
+            ),
+            (
+                b"---\ndescription: Old\n---\n\nBody\n",
+                b"---\ndescription: New\n---\n\nBody\n",
+            ),
+            (b"Body\n", b"---\ndescription: New\n---\nBody\n"),
+            (b"", b"---\ndescription: New\n---\n"),
+            (
+                b"---\ndescription: Old\nBody\n",
+                b"---\ndescription: New\n---\ndescription: Old\nBody\n",
+            ),
+        ],
+        ids=("replace", "body-leading-blank", "prepend", "empty", "missing-close"),
+    )
+    def test_write_frontmatter_text_preserves_existing_byte_contract(
+        self, temp_dir, monkeypatch, original, expected
+    ):
+        f = temp_dir / "test.mdc"
+        f.write_bytes(original)
+        block = CursorRuleBlock(path=f)
+        original_write_text = Path.write_text
+        writes = 0
+
+        def tracked_write_text(path, *args, **kwargs):
+            nonlocal writes
+            writes += 1
+            return original_write_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", tracked_write_text)
+
+        block.write_frontmatter_text("description: New\n")
+
+        assert writes == 1
+        assert f.read_bytes() == expected
+
+    @pytest.mark.parametrize(
+        ("new_frontmatter", "error"),
+        [
+            ("description: [broken", "Invalid YAML"),
+            ("- description: New\n", "Frontmatter must be a YAML mapping"),
+        ],
+    )
+    def test_write_frontmatter_text_validation_never_writes(
+        self, temp_dir, monkeypatch, new_frontmatter, error
+    ):
+        f = temp_dir / "test.mdc"
+        original = b"---\ndescription: Old\n---\nBody\n"
+        f.write_bytes(original)
+        block = CursorRuleBlock(path=f)
+        assert block.field_value("description") == "Old"
+
+        def fail_write_text(*_args, **_kwargs):
+            pytest.fail("validation error must not write")
+
+        monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+        with pytest.raises(ValueError, match=error):
+            block.write_frontmatter_text(new_frontmatter)
+
+        assert f.read_bytes() == original
+        assert block.field_value("description") == "Old"
+
     def test_frontmattered_block_no_frontmatter(self, temp_dir):
         """FrontmatteredBlock without frontmatter has BodyContent with full content."""
         f = temp_dir / "test.mdc"

--- a/tests/test_copilot_agent_valid.py
+++ b/tests/test_copilot_agent_valid.py
@@ -598,6 +598,161 @@ def test_embedded_yaml_payload_token_estimate_does_not_expand_alias_dag(tmp_path
     assert 0 < embedded[0].estimate_tokens() < 1_000
 
 
+def test_all_supported_hook_handler_types_are_valid(tmp_path):
+    _write_agent(
+        tmp_path,
+        "description: Runs typed lifecycle hooks\n"
+        "target: vscode\n"
+        "hooks:\n"
+        "  PostToolUse:\n"
+        "    - hooks:\n"
+        "        - type: command\n"
+        "          command: make lint\n"
+        "          args: [--quiet]\n"
+        "        - type: http\n"
+        "          url: https://example.test/hooks\n"
+        "          headers: {Authorization: bearer-token}\n"
+        "        - type: mcp_tool\n"
+        "          server: local-tools\n"
+        "          tool: summarize\n"
+        "          input: {format: concise}\n"
+        "        - type: prompt\n"
+        "          prompt: Review the tool result.\n"
+        "          model: GPT-5\n"
+        "        - type: agent\n"
+        "          prompt: Investigate the failure.\n"
+        "          model: GPT-5",
+    )
+
+    assert _check(tmp_path) == []
+
+
+def test_hook_handler_diagnostics_preserve_order_and_metadata(tmp_path):
+    _write_agent(
+        tmp_path,
+        "description: Exercises malformed lifecycle hooks\n"
+        "target: vscode\n"
+        "hooks:\n"
+        "  PostToolUse:\n"
+        "    - hooks:\n"
+        "        - not-a-mapping\n"
+        "        - type: future\n"
+        "        - type: command\n"
+        "        - type: command\n"
+        "          command: []\n"
+        "        - type: http\n"
+        "          prompt: misplaced\n"
+        "        - type: mcp_tool\n"
+        "          server: ''\n"
+        "          tool: 7\n"
+        "          args:\n"
+        "            - --ok\n"
+        "            - 9\n"
+        "          timeout: true\n"
+        "          url: misplaced\n"
+        "        - type: prompt\n"
+        "          prompt: ''\n"
+        "          headers: []",
+    )
+
+    found = _check(tmp_path)
+
+    assert [(v.severity, v.line, v.message, v.fingerprint_discriminator) for v in found] == [
+        (
+            Severity.ERROR,
+            7,
+            "Hook 'PostToolUse[0].hooks[0]' must be a mapping",
+            "hooks:PostToolUse[0].hooks[0]:type",
+        ),
+        (
+            Severity.ERROR,
+            8,
+            "Hook 'PostToolUse[0].hooks[1]' has invalid type 'future'",
+            "hooks:PostToolUse[0].hooks[1]:handler-type",
+        ),
+        (
+            Severity.ERROR,
+            9,
+            "Hook 'PostToolUse[0].hooks[2]' of type 'command' requires at least one of: "
+            "command, windows, linux, osx",
+            "hooks:PostToolUse[0].hooks[2]:command:missing",
+        ),
+        (
+            Severity.ERROR,
+            11,
+            "Hook 'PostToolUse[0].hooks[3]' field 'command' must be a non-empty string",
+            "hooks:PostToolUse[0].hooks[3]:command:type",
+        ),
+        (
+            Severity.ERROR,
+            12,
+            "Hook 'PostToolUse[0].hooks[4]' of type 'http' requires 'url'",
+            "hooks:PostToolUse[0].hooks[4]:url:missing",
+        ),
+        (
+            Severity.WARNING,
+            13,
+            "Hook 'PostToolUse[0].hooks[4]' field 'prompt' is only valid for types: "
+            "agent, prompt",
+            "hooks:PostToolUse[0].hooks[4]:prompt:compatibility",
+        ),
+        (
+            Severity.ERROR,
+            15,
+            "Hook 'PostToolUse[0].hooks[5]' field 'server' must be a non-empty str",
+            "hooks:PostToolUse[0].hooks[5]:server:type",
+        ),
+        (
+            Severity.ERROR,
+            16,
+            "Hook 'PostToolUse[0].hooks[5]' field 'tool' must be a non-empty str",
+            "hooks:PostToolUse[0].hooks[5]:tool:type",
+        ),
+        (
+            Severity.ERROR,
+            20,
+            "Hook 'PostToolUse[0].hooks[5]' field 'timeout' must be a int/float",
+            "hooks:PostToolUse[0].hooks[5]:timeout:optional-type",
+        ),
+        (
+            Severity.ERROR,
+            19,
+            "Hook 'PostToolUse[0].hooks[5]' field 'args[1]' must be a string",
+            "hooks:PostToolUse[0].hooks[5]:args:1",
+        ),
+        (
+            Severity.WARNING,
+            17,
+            "Hook 'PostToolUse[0].hooks[5]' field 'args' is only valid for types: command",
+            "hooks:PostToolUse[0].hooks[5]:args:compatibility",
+        ),
+        (
+            Severity.WARNING,
+            21,
+            "Hook 'PostToolUse[0].hooks[5]' field 'url' is only valid for types: http",
+            "hooks:PostToolUse[0].hooks[5]:url:compatibility",
+        ),
+        (
+            Severity.ERROR,
+            23,
+            "Hook 'PostToolUse[0].hooks[6]' field 'prompt' must be a non-empty str",
+            "hooks:PostToolUse[0].hooks[6]:prompt:type",
+        ),
+        (
+            Severity.ERROR,
+            24,
+            "Hook 'PostToolUse[0].hooks[6]' field 'headers' must be a dict",
+            "hooks:PostToolUse[0].hooks[6]:headers:optional-type",
+        ),
+        (
+            Severity.WARNING,
+            24,
+            "Hook 'PostToolUse[0].hooks[6]' field 'headers' is only valid for types: http",
+            "hooks:PostToolUse[0].hooks[6]:headers:compatibility",
+        ),
+    ]
+
+
 def test_hook_shape_and_dangerous_command_logic_are_shared(tmp_path):
     _write_agent(
         tmp_path,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6911,6 +6911,18 @@ class TestRenameRefsAutofix:
 
     FIXTURE = "autofix/rename-refs-substring"
 
+    def test_plain_fix_distinguishes_suggestions_from_no_fixes(self, tmp_path):
+        """A SUGGEST-only result must not claim that no fix exists."""
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        _run_fix(repo, "--rule", "agentskill-name")
+
+        result = _run_fix(repo, "--rule", "agentskill-rename-refs")
+
+        assert "No safe fixes found." in result.stdout
+        assert "Suggested fixes" in result.stdout
+        assert "skillsaw fix --suggest" in result.stdout
+        assert "No auto-fixable violations found." not in result.stdout
+
     def test_substring_matches_not_corrupted(self, tmp_path):
         """'metadata-parser'/'data-parser-staging' must survive a rename of 'data-parser'."""
         repo = copy_fixture(self.FIXTURE, tmp_path)

--- a/tests/test_lint_tree.py
+++ b/tests/test_lint_tree.py
@@ -6,15 +6,23 @@ import json
 from pathlib import Path
 
 from skillsaw.blocks import (
+    AgentBlock,
     BodyContent,
+    ChatmodeBlock,
     ClineWorkflowBlock,
+    ContextFileBlock,
     CopilotAgentBlock,
     CopilotPromptBlock,
     CursorCommandBlock,
     CursorPromptHookBlock,
     CursorRuleBlock,
+    HooksBlock,
     InstructionBlock,
+    PromptBlock,
     QwenMdBlock,
+    SettingsBlock,
+    SkillBlock,
+    SkillRefBlock,
     VsCodeMcpBlock,
 )
 from skillsaw.config import LinterConfig
@@ -242,6 +250,51 @@ def test_tree_contains_apm_nodes(temp_dir):
     assert len(tree.find(ApmConfigNode)) == 1
     assert tree.find(ApmConfigNode)[0].path.name == "apm.yml"
     assert len(tree.find(ApmNode)) == 1
+
+
+def test_tree_preserves_apm_primitive_types_and_order(temp_dir):
+    """APM primitives keep their semantic roles and deterministic order."""
+    (temp_dir / "apm.yml").write_text("name: test\nversion: 1.0.0\ndescription: Test\n")
+    apm_dir = temp_dir / ".apm"
+    files = (
+        ("instructions/coding.instructions.md", "# Coding\n"),
+        ("agents/reviewer.agent.md", "# Reviewer\n"),
+        ("prompts/review.md", "# Review\n"),
+        ("chatmodes/planning.md", "# Planning\n"),
+        ("context/project.md", "# Project\n"),
+        ("hooks/hooks.json", "{}\n"),
+        ("settings.json", "{}\n"),
+        ("settings.local.json", "{}\n"),
+        (
+            "skills/release/SKILL.md",
+            "---\nname: release\ndescription: Use when preparing a release.\n---\n\n# Release\n",
+        ),
+        ("skills/release/references/checklist.md", "# Checklist\n"),
+    )
+    for relative_path, content in files:
+        path = apm_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    apm_node = RepositoryContext(temp_dir).lint_tree.find(ApmNode)[0]
+    assert [
+        (type(child), child.path.relative_to(apm_dir).as_posix()) for child in apm_node.children
+    ] == [
+        (InstructionBlock, "instructions/coding.instructions.md"),
+        (AgentBlock, "agents/reviewer.agent.md"),
+        (PromptBlock, "prompts/review.md"),
+        (ChatmodeBlock, "chatmodes/planning.md"),
+        (ContextFileBlock, "context/project.md"),
+        (HooksBlock, "hooks/hooks.json"),
+        (SettingsBlock, "settings.json"),
+        (SettingsBlock, "settings.local.json"),
+        (SkillNode, "skills/release"),
+    ]
+    skill_node = apm_node.children[-1]
+    assert [(type(child), child.path.name) for child in skill_node.children] == [
+        (SkillBlock, "SKILL.md"),
+        (SkillRefBlock, "checklist.md"),
+    ]
 
 
 def test_tree_contains_coderabbit_node(temp_dir):

--- a/tests/test_opencode_config_valid.py
+++ b/tests/test_opencode_config_valid.py
@@ -2,7 +2,81 @@
 
 import tracemalloc
 
-from skillsaw.rules.builtin.opencode.config_valid import _json_values_equal
+import pytest
+
+from skillsaw.rules.builtin.opencode.config_valid import (
+    _json_values_equal,
+    _lower_model_selection,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_items"),
+    [
+        ("anthropic/claude-sonnet", [("model", "anthropic/claude-sonnet")]),
+        (
+            "anthropic/claude-sonnet#thinking",
+            [("model", "anthropic/claude-sonnet"), ("variant", "thinking")],
+        ),
+        (
+            "anthropic/family/claude-sonnet",
+            [("model", "anthropic/family/claude-sonnet")],
+        ),
+        (" anthropic/claude-sonnet ", [("model", " anthropic/claude-sonnet ")]),
+        (
+            {"providerID": "anthropic", "model": "claude-sonnet"},
+            [("model", "anthropic/claude-sonnet")],
+        ),
+        (
+            {"providerID": "anthropic", "model": "family/claude-sonnet"},
+            [("model", "anthropic/family/claude-sonnet")],
+        ),
+        (
+            {
+                "providerID": "anthropic",
+                "model": "claude-sonnet",
+                "variant": "thinking",
+                "future-field": "ignored",
+            },
+            [("model", "anthropic/claude-sonnet"), ("variant", "thinking")],
+        ),
+    ],
+)
+def test_lower_model_selection_preserves_accepted_forms_and_field_order(value, expected_items):
+    lowered = _lower_model_selection(value)
+
+    assert lowered is not None
+    assert list(lowered.items()) == expected_items
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        [("providerID", "anthropic"), ("model", "claude-sonnet")],
+        "claude-sonnet",
+        "/claude-sonnet",
+        "anthropic/",
+        "anthropic#host/claude-sonnet",
+        "anthropic/claude-sonnet#",
+        "anthropic/claude-sonnet#thinking#fast",
+        {},
+        {"providerID": 7, "model": "claude-sonnet"},
+        {"providerID": "anthropic/team", "model": "claude-sonnet"},
+        {"providerID": "anthropic#host", "model": "claude-sonnet"},
+        {"providerID": "anthropic", "model": 7},
+        {"providerID": "anthropic", "model": "claude-sonnet#thinking"},
+        {"providerID": "anthropic", "model": "claude-sonnet", "variant": None},
+        {"providerID": "anthropic", "model": "claude-sonnet", "variant": ""},
+        {
+            "providerID": "anthropic",
+            "model": "claude-sonnet",
+            "variant": "thinking#fast",
+        },
+    ],
+)
+def test_lower_model_selection_rejects_malformed_forms(value):
+    assert _lower_model_selection(value) is None
 
 
 def test_json_value_comparison_matches_mapping_keys_not_insertion_order():

--- a/tests/test_promptfoo_rules.py
+++ b/tests/test_promptfoo_rules.py
@@ -9,6 +9,7 @@ import yaml
 
 from skillsaw.config import LinterConfig
 from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.discovery import detect as detect_discovery
 from skillsaw.lint_target import PromptfooConfigNode
 from skillsaw.rule import Severity
 from skillsaw.rules.builtin.promptfoo import (
@@ -288,6 +289,66 @@ def test_non_promptfoo_yaml_in_evals_not_detected(temp_dir):
     _write_yaml(evals / "unrelated.yaml", {"name": "not-promptfoo", "version": "1.0"})
     context = RepositoryContext(temp_dir)
     assert RepositoryType.PROMPTFOO not in context.repo_types
+
+
+def test_promptfoo_discovery_reuses_the_repository_walk(temp_dir, monkeypatch):
+    """Type detection and tree attachment share one pruned filesystem walk."""
+    _write_yaml(temp_dir / "nested" / "promptfooconfig.yaml", {"tests": []})
+    _write_yaml(
+        temp_dir / "evals" / "smoke.yaml",
+        {"providers": [{"id": "test"}], "tests": [{"description": "smoke"}]},
+    )
+    ignored = temp_dir / "evals" / "node_modules" / "dep" / "ignored.yaml"
+    _write_yaml(ignored, {"providers": [{"id": "dependency"}], "tests": []})
+    walked = []
+    real_walk = detect_discovery.os.walk
+
+    def recording_walk(top, *args, **kwargs):
+        walked.append(Path(top).resolve())
+        return real_walk(top, *args, **kwargs)
+
+    monkeypatch.setattr(detect_discovery.os, "walk", recording_walk)
+
+    context = RepositoryContext(temp_dir)
+    paths = {
+        node.path.relative_to(temp_dir).as_posix()
+        for node in context.lint_tree.find(PromptfooConfigNode)
+    }
+
+    assert paths == {"evals/smoke.yaml", "nested/promptfooconfig.yaml"}
+    assert walked == [temp_dir.resolve()]
+
+
+def test_arbitrary_nested_evals_do_not_expand_promptfoo_scope(temp_dir):
+    """Only root, plugin, and skill evals are supported discovery surfaces."""
+    _write_yaml(
+        temp_dir / "package" / "evals" / "smoke.yaml",
+        {"providers": [{"id": "test"}], "tests": [{"description": "smoke"}]},
+    )
+
+    context = RepositoryContext(temp_dir)
+
+    assert RepositoryType.PROMPTFOO not in context.repo_types
+    assert context.lint_tree.find(PromptfooConfigNode) == []
+
+
+def test_tree_keeps_platform_native_promptfoo_glob_matching(temp_dir, monkeypatch):
+    """The candidate cache stays as broad as native globs on case-insensitive hosts."""
+    _write_yaml(temp_dir / "PromptfooConfig.YAML", {"tests": []})
+    _write_yaml(
+        temp_dir / "evals" / "SMOKE.YAML",
+        {"providers": [{"id": "test"}], "tests": [{"description": "smoke"}]},
+    )
+    monkeypatch.setattr(detect_discovery.os.path, "normcase", lambda value: str(value).lower())
+
+    context = RepositoryContext(temp_dir)
+    paths = {
+        node.path.relative_to(temp_dir).as_posix()
+        for node in context.lint_tree.find(PromptfooConfigNode)
+    }
+
+    assert RepositoryType.PROMPTFOO not in context.repo_types
+    assert paths == {"PromptfooConfig.YAML", "evals/SMOKE.YAML"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- reuse the repository scan for Promptfoo discovery and prune excluded eval trees
- distinguish suggest-only fixes from cases where no fixes exist
- extract APM attachment and centralize shared lint-tree build state
- decompose Copilot hook validation and OpenCode model lowering
- consolidate frontmatter rewriting behind one pure composition boundary

No rule defaults, severities, or enforcement semantics change in this PR.

## Architectural result

`build_lint_tree` drops from cyclomatic complexity 145 to 124 and cognitive complexity 485 to 402. The APM stage and shared mutable build state now have explicit boundaries. A broader plugin-loop extraction was deliberately deferred after adversarial review judged it too risky for the lint-tree core in this batch.

All seven commits were adversarially reviewed in isolation. Exact tree snapshots, node counts, violation ordering, and exit codes remained stable across representative APM, plugin, OpenCode, Copilot, and Promptfoo fixtures. Two independent roll-up reviewers approved the combined branch.

## Validation

- `make test`: 5,702 passed
- `make lint`: clean
- `make update`: clean; no generated diff
- medium benchmark: no regression; 1,373 nodes and 151 violations preserved
- Python 3.9 grammar checks passed for changed production files
- ai-helpers smoke test: branch and exact `origin/main` both report the same pre-existing stale `docs/index.html` custom-rule error; no branch-specific downstream delta


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frontmatter updates, including empty, incomplete, and missing-frontmatter documents, while preserving file content.
  - Validation now reports all applicable hook issues instead of stopping after the first malformed field.
  - Improved model selection validation for supported string and mapping formats.
  - Promptfoo and related configuration discovery is more consistent across repository layouts and platforms.

- **CLI**
  - Clarified fix results with separate messages for suggested fixes and cases with no available fixes.

- **Tests**
  - Added coverage for frontmatter handling, validation diagnostics, repository discovery, tree output, and fix messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->