### PR TITLE
feat: add skillsaw-update skill for upgrading to new releases

### DIFF
--- a/.agents/skills/skillsaw-update/SKILL.md
+++ b/.agents/skills/skillsaw-update/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: skillsaw-update
+description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
+compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
+license: Apache-2.0
+metadata:
+  author: stbenjam
+  version: "1.0"
+---
+
+# skillsaw Update
+
+Update this repository from its installed skillsaw to the newest release:
+upgrade the local install, report which rules are new and what they find in
+this repository, and bump every pinned skillsaw version (GitHub Actions
+SHAs, Makefile targets, pre-commit hooks, container tags).
+
+## Workflow
+
+Ask one routing question at a time and wait for the answer. An explicit choice
+in the user's request already counts as an answer. Read a reference only after
+its condition or a yes answer routes to it; do not read the reference to
+formulate the question. After completing it, return here. If the answer is no,
+continue to the next checkpoint without reading it. Carry forward the command
+prefixes, versions, rule lists, and changed-file list.
+
+Resolve every `references/...` path relative to the directory containing this
+`SKILL.md`, never relative to the target repository or the process's current
+working directory. If this file was fetched from the web, resolve each
+reference against the parent URL of this file and fetch it from that sibling
+location.
+
+Replace brace-delimited fields below with facts from the repository or scan;
+never show placeholders to the user, and render singular or plural wording
+naturally.
+
+### 1. Upgrade to the newest version
+
+Read [versions](references/01-versions.md). It records the installed and
+latest versions, captures the old rule list, upgrades the install (or selects
+the new command prefix), and verifies the result. Report both versions before
+offering changes.
+
+### 2. Report new rules
+
+Read [new rules](references/02-new-rules.md). It diffs the old and new rule
+lists, explains each added rule, and scans the repository with the new
+version so every new rule is presented with its actual findings here.
+
+### 3. Update version pins
+
+If the repository pins skillsaw anywhere (GitHub Actions workflows, Makefile
+targets, pre-commit hooks, container image tags), ask:
+
+> I found skillsaw pinned in {locations}. Bumping them to {latest} keeps CI
+> and local runs on the version just installed. Should I update those pins?
+
+If yes, read [pins](references/03-pins.md). If no, preserve the locations.
+
+### 4. Triage findings from new rules
+
+If the new version reports findings from added rules, read
+[triage](references/04-triage.md) and present its summary table for
+confirmation before making changes. Carry the agreed buckets forward.
+
+### 5. Verify the result
+
+After all accepted routes finish, always read
+[verification](references/05-verify.md).

--- a/.agents/skills/skillsaw-update/references/01-versions.md
+++ b/.agents/skills/skillsaw-update/references/01-versions.md
@@ -1,0 +1,68 @@
+# Resolve versions and upgrade
+
+Record the installed version first; nothing below upgrades until the old
+rule list is captured in the next section.
+
+## Installed version
+
+Run `skillsaw --version`. If it works, retain that command prefix and note
+the version as `{installed}`.
+
+Otherwise the repository is not on a working install yet: prefer zero-install
+execution with `uvx skillsaw`, then `pip install skillsaw`, then the
+installed container runtime (`podman` or `docker`). Verify with `--version`
+and treat that version as both `{installed}` and the starting prefix.
+
+## Latest version
+
+Resolve the newest release to `{latest}`:
+
+```console
+python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/skillsaw/json'))['info']['version'])"
+```
+
+If PyPI is unreachable:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v*' | sort -t/ -k3 -V | tail -1
+```
+
+Strip the leading `v` from the tag for the `{latest}` version number.
+
+If `{installed}` equals `{latest}`, report that the install is current and
+continue: there are no new rules, but pins may still lag behind.
+
+## Capture the old rule list
+
+Before upgrading, save the rule IDs the installed version knows:
+
+```console
+<installed-prefix> list-rules > /tmp/skillsaw-rules-old.txt
+```
+
+Keep this file; the next section diffs it against the new version.
+
+## Upgrade
+
+Ask before changing the local environment:
+
+> Installed skillsaw is {installed} and the newest release is {latest}.
+> Should I upgrade the local install?
+
+If yes, follow the method behind the retained prefix:
+
+- **uvx**: nothing to install. The new prefix is
+  `uvx skillsaw=={latest}`; the old one stays usable for comparison.
+- **pip**: `pip install "skillsaw=={latest}"`.
+- **Container**: pull the pinned image,
+  `podman pull ghcr.io/stbenjam/skillsaw:v{latest}`
+  (or `docker pull ...`). A `:latest` tag floats and needs no pull to
+  float, but prefer the pinned `v{latest}` tag for repeatability.
+
+Verify the new prefix with `<new-prefix> --version` and save its rules:
+
+```console
+<new-prefix> list-rules > /tmp/skillsaw-rules-new.txt
+```
+
+Retain both prefixes and both files, then return to the router.

--- a/.agents/skills/skillsaw-update/references/02-new-rules.md
+++ b/.agents/skills/skillsaw-update/references/02-new-rules.md
@@ -1,0 +1,41 @@
+# Report new rules and their findings
+
+Compare the rule-ID lists captured in the versions step. Rule IDs are the
+indented names in `list-rules` output:
+
+```console
+comm -13 <(sort /tmp/skillsaw-rules-old.txt) <(sort /tmp/skillsaw-rules-new.txt)
+```
+
+Rules printed by `comm -23` with the files swapped were removed: findings or
+baseline entries naming them are stale, and the triage step handles them.
+
+## When no rule was added
+
+Report that the upgrade adds no new checks and return to the router. The pin
+updates and the verification step still apply.
+
+## Explain each added rule
+
+For every added rule ID, run `<new-prefix> explain <rule-id>` and summarize
+in one line each: what it checks, its default severity, whether it has an
+autofix, and its most useful option. Prefer the explanation's own words over
+the violation message when describing the rule.
+
+## Scan the repository with the new version
+
+Run the new version over the repository and keep the machine-readable result:
+
+```console
+<new-prefix> lint --format json -v > /tmp/skillsaw-update-scan.json
+```
+
+Group the findings by `rule_id`, then present one section per added rule:
+
+- the one-line rule summary from its explanation;
+- the finding count and severities in this repository;
+- two or three representative findings with file paths and line numbers.
+
+Do not propose fixes yet; the triage step sorts each group into fixing,
+baselining, or configuring. Record the per-rule groups and return to
+the router.

--- a/.agents/skills/skillsaw-update/references/03-pins.md
+++ b/.agents/skills/skillsaw-update/references/03-pins.md
@@ -1,0 +1,71 @@
+# Update version pins
+
+Change only pins that reference skillsaw; leave third-party actions and
+unrelated tooling untouched. Track each edited file for the final summary.
+
+## GitHub Actions
+
+Find workflows using the skillsaw action:
+
+```console
+grep -rn "stbenjam/skillsaw@" .github/workflows/
+```
+
+This covers both the lint action (`stbenjam/skillsaw@<SHA>`) and the review
+action (`stbenjam/skillsaw/review@<SHA>`). Resolve the commit SHA of the
+newest release tag before editing:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v{latest}'
+```
+
+An annotated tag yields two lines; use the SHA on the `^{}` line, which is
+the commit the tag points to. Replace the old SHA with it and refresh the
+trailing version comment to `# v{latest}`:
+
+```yaml
+- uses: stbenjam/skillsaw@<NEW_SHA> # v{latest}
+```
+
+## Makefile targets
+
+Find the pinned version:
+
+```console
+grep -n "SKILLSAW_VERSION" Makefile
+```
+
+Set `SKILLSAW_VERSION := {latest}`. When the targets run through a container,
+the image tag below it references the same variable
+(`ghcr.io/stbenjam/skillsaw:v$(SKILLSAW_VERSION)`), so one edit covers both.
+Never overwrite existing `lint` or `lint-fix` target bodies; only the version
+assignment changes.
+
+## Pre-commit hooks
+
+Find the skillsaw entry in `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/stbenjam/skillsaw
+    rev: v{latest}
+    hooks:
+      - id: skillsaw
+```
+
+Set `rev:` to the `v{latest}` tag. Tags are the pre-commit convention here;
+a full commit SHA also works when the project prefers immutable pins.
+
+## Container image tags
+
+A GitLab job or Dockerfile may reference the published image directly:
+
+```console
+grep -rn "ghcr.io/stbenjam/skillsaw" .gitlab-ci.yml Dockerfile* 2>/dev/null
+```
+
+Retag `:v{old}` to `:v{latest}`. A `:latest` tag floats onto the new release
+by itself; recommend pinning it to `:v{latest}` for repeatable pipelines,
+but only change it after the user agrees.
+
+Return to the router with the list of edited files.

--- a/.agents/skills/skillsaw-update/references/04-triage.md
+++ b/.agents/skills/skillsaw-update/references/04-triage.md
@@ -1,0 +1,62 @@
+# Triage findings from new rules
+
+Only findings from added rules are in scope; findings from existing rules
+were already triaged when skillsaw was adopted. For any group with more than
+20 findings or making up over 10% of the scan total, review 3–5 sample
+findings to understand the pattern before sorting it.
+
+Sort each added-rule group into one of three buckets:
+
+## 1. Fix now
+
+Best for high-priority issues and quick wins:
+
+- All `error` severity findings by default; an error the user accepts as debt
+  may move to Baseline instead
+- Findings with `"fixable": true`: safe fixes apply with
+  `skillsaw fix --rule <rule-id>`, suggested ones with `--suggest` added.
+  Naming the rule repairs it at any severity
+- Small groups of straightforward corrections
+
+## 2. Baseline
+
+Best for valid findings that are not urgent to fix immediately. Recording them
+with `skillsaw baseline` absorbs the new findings into the existing baseline
+file so CI passes while preventing regressions on future changes. Only errors
+and warnings can go here: `skillsaw baseline` never records info findings.
+
+A removed rule may leave stale baseline entries behind. Refreshing the
+baseline with `skillsaw baseline` drops entries that no longer match, so
+mention that cleanup when removed rules were reported.
+
+## 3. Configure
+
+Best when a new rule clashes with an intentional project convention. Check
+`skillsaw explain <rule-id>` for options such as `exclude` or limits first,
+then consider lowering to `severity: info`, and use `enabled: false` only as
+a last resort for advisory content rules. Always add a brief `#` comment in
+`.skillsaw.yaml` explaining the rationale.
+
+> [!NOTE]
+> Keep security rules (`security-*`, `content-embedded-secrets`,
+> `claude-settings-dangerous`), hook rules (`hooks-*`), MCP rules, and
+> structural validity rules (`*-valid`, `claude-*-frontmatter`) enabled. Fix
+> or baseline these rather than turning them off.
+
+## Presenting the plan to the user
+
+Share the summary table and confirm the plan:
+
+> The upgrade adds {new rule count} with {total} findings in this repo. Here
+> is a proposed plan:
+> - **Fix now**: {fix count} issues (errors, autofixable findings, and small
+>   manual corrections)
+> - **Baseline**: {baseline count} existing items to resolve over time
+> - **Configure**: {configure count} project-wide conventions in
+>   `.skillsaw.yaml`
+>
+> Would you like to proceed with this plan, or adjust any of the categories?
+
+The fix-now set drives the next edits, the configure set becomes
+`.skillsaw.yaml` settings, and the baseline set is recorded with
+`skillsaw baseline`. Then return to the router.

--- a/.agents/skills/skillsaw-update/references/05-verify.md
+++ b/.agents/skills/skillsaw-update/references/05-verify.md
@@ -1,0 +1,15 @@
+# Run final verification
+
+Run the linter once more with the new version and confirm it exits
+successfully. Summarize:
+
+- installed and latest versions;
+- added rules, with each rule's finding count in this repository;
+- removed rules and any baseline cleanup applied;
+- pins updated (workflows, Makefile, pre-commit config, container tags);
+- triage outcomes: fixed, baselined, and configured counts;
+- every file created or modified.
+
+Remind the user to commit every applicable artifact, including
+`.skillsaw.yaml`, `.skillsaw-baseline.json`, workflow files,
+`.pre-commit-config.yaml`, Makefile changes, and edited context files.

--- a/.claude/skills/skillsaw-update/SKILL.md
+++ b/.claude/skills/skillsaw-update/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: skillsaw-update
+description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
+compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
+license: Apache-2.0
+metadata:
+  author: stbenjam
+  version: "1.0"
+---
+
+# skillsaw Update
+
+Update this repository from its installed skillsaw to the newest release:
+upgrade the local install, report which rules are new and what they find in
+this repository, and bump every pinned skillsaw version (GitHub Actions
+SHAs, Makefile targets, pre-commit hooks, container tags).
+
+## Workflow
+
+Ask one routing question at a time and wait for the answer. An explicit choice
+in the user's request already counts as an answer. Read a reference only after
+its condition or a yes answer routes to it; do not read the reference to
+formulate the question. After completing it, return here. If the answer is no,
+continue to the next checkpoint without reading it. Carry forward the command
+prefixes, versions, rule lists, and changed-file list.
+
+Resolve every `references/...` path relative to the directory containing this
+`SKILL.md`, never relative to the target repository or the process's current
+working directory. If this file was fetched from the web, resolve each
+reference against the parent URL of this file and fetch it from that sibling
+location.
+
+Replace brace-delimited fields below with facts from the repository or scan;
+never show placeholders to the user, and render singular or plural wording
+naturally.
+
+### 1. Upgrade to the newest version
+
+Read [versions](references/01-versions.md). It records the installed and
+latest versions, captures the old rule list, upgrades the install (or selects
+the new command prefix), and verifies the result. Report both versions before
+offering changes.
+
+### 2. Report new rules
+
+Read [new rules](references/02-new-rules.md). It diffs the old and new rule
+lists, explains each added rule, and scans the repository with the new
+version so every new rule is presented with its actual findings here.
+
+### 3. Update version pins
+
+If the repository pins skillsaw anywhere (GitHub Actions workflows, Makefile
+targets, pre-commit hooks, container image tags), ask:
+
+> I found skillsaw pinned in {locations}. Bumping them to {latest} keeps CI
+> and local runs on the version just installed. Should I update those pins?
+
+If yes, read [pins](references/03-pins.md). If no, preserve the locations.
+
+### 4. Triage findings from new rules
+
+If the new version reports findings from added rules, read
+[triage](references/04-triage.md) and present its summary table for
+confirmation before making changes. Carry the agreed buckets forward.
+
+### 5. Verify the result
+
+After all accepted routes finish, always read
+[verification](references/05-verify.md).

--- a/.claude/skills/skillsaw-update/references/01-versions.md
+++ b/.claude/skills/skillsaw-update/references/01-versions.md
@@ -1,0 +1,68 @@
+# Resolve versions and upgrade
+
+Record the installed version first; nothing below upgrades until the old
+rule list is captured in the next section.
+
+## Installed version
+
+Run `skillsaw --version`. If it works, retain that command prefix and note
+the version as `{installed}`.
+
+Otherwise the repository is not on a working install yet: prefer zero-install
+execution with `uvx skillsaw`, then `pip install skillsaw`, then the
+installed container runtime (`podman` or `docker`). Verify with `--version`
+and treat that version as both `{installed}` and the starting prefix.
+
+## Latest version
+
+Resolve the newest release to `{latest}`:
+
+```console
+python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/skillsaw/json'))['info']['version'])"
+```
+
+If PyPI is unreachable:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v*' | sort -t/ -k3 -V | tail -1
+```
+
+Strip the leading `v` from the tag for the `{latest}` version number.
+
+If `{installed}` equals `{latest}`, report that the install is current and
+continue: there are no new rules, but pins may still lag behind.
+
+## Capture the old rule list
+
+Before upgrading, save the rule IDs the installed version knows:
+
+```console
+<installed-prefix> list-rules > /tmp/skillsaw-rules-old.txt
+```
+
+Keep this file; the next section diffs it against the new version.
+
+## Upgrade
+
+Ask before changing the local environment:
+
+> Installed skillsaw is {installed} and the newest release is {latest}.
+> Should I upgrade the local install?
+
+If yes, follow the method behind the retained prefix:
+
+- **uvx**: nothing to install. The new prefix is
+  `uvx skillsaw=={latest}`; the old one stays usable for comparison.
+- **pip**: `pip install "skillsaw=={latest}"`.
+- **Container**: pull the pinned image,
+  `podman pull ghcr.io/stbenjam/skillsaw:v{latest}`
+  (or `docker pull ...`). A `:latest` tag floats and needs no pull to
+  float, but prefer the pinned `v{latest}` tag for repeatability.
+
+Verify the new prefix with `<new-prefix> --version` and save its rules:
+
+```console
+<new-prefix> list-rules > /tmp/skillsaw-rules-new.txt
+```
+
+Retain both prefixes and both files, then return to the router.

--- a/.claude/skills/skillsaw-update/references/02-new-rules.md
+++ b/.claude/skills/skillsaw-update/references/02-new-rules.md
@@ -1,0 +1,41 @@
+# Report new rules and their findings
+
+Compare the rule-ID lists captured in the versions step. Rule IDs are the
+indented names in `list-rules` output:
+
+```console
+comm -13 <(sort /tmp/skillsaw-rules-old.txt) <(sort /tmp/skillsaw-rules-new.txt)
+```
+
+Rules printed by `comm -23` with the files swapped were removed: findings or
+baseline entries naming them are stale, and the triage step handles them.
+
+## When no rule was added
+
+Report that the upgrade adds no new checks and return to the router. The pin
+updates and the verification step still apply.
+
+## Explain each added rule
+
+For every added rule ID, run `<new-prefix> explain <rule-id>` and summarize
+in one line each: what it checks, its default severity, whether it has an
+autofix, and its most useful option. Prefer the explanation's own words over
+the violation message when describing the rule.
+
+## Scan the repository with the new version
+
+Run the new version over the repository and keep the machine-readable result:
+
+```console
+<new-prefix> lint --format json -v > /tmp/skillsaw-update-scan.json
+```
+
+Group the findings by `rule_id`, then present one section per added rule:
+
+- the one-line rule summary from its explanation;
+- the finding count and severities in this repository;
+- two or three representative findings with file paths and line numbers.
+
+Do not propose fixes yet; the triage step sorts each group into fixing,
+baselining, or configuring. Record the per-rule groups and return to
+the router.

--- a/.claude/skills/skillsaw-update/references/03-pins.md
+++ b/.claude/skills/skillsaw-update/references/03-pins.md
@@ -1,0 +1,71 @@
+# Update version pins
+
+Change only pins that reference skillsaw; leave third-party actions and
+unrelated tooling untouched. Track each edited file for the final summary.
+
+## GitHub Actions
+
+Find workflows using the skillsaw action:
+
+```console
+grep -rn "stbenjam/skillsaw@" .github/workflows/
+```
+
+This covers both the lint action (`stbenjam/skillsaw@<SHA>`) and the review
+action (`stbenjam/skillsaw/review@<SHA>`). Resolve the commit SHA of the
+newest release tag before editing:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v{latest}'
+```
+
+An annotated tag yields two lines; use the SHA on the `^{}` line, which is
+the commit the tag points to. Replace the old SHA with it and refresh the
+trailing version comment to `# v{latest}`:
+
+```yaml
+- uses: stbenjam/skillsaw@<NEW_SHA> # v{latest}
+```
+
+## Makefile targets
+
+Find the pinned version:
+
+```console
+grep -n "SKILLSAW_VERSION" Makefile
+```
+
+Set `SKILLSAW_VERSION := {latest}`. When the targets run through a container,
+the image tag below it references the same variable
+(`ghcr.io/stbenjam/skillsaw:v$(SKILLSAW_VERSION)`), so one edit covers both.
+Never overwrite existing `lint` or `lint-fix` target bodies; only the version
+assignment changes.
+
+## Pre-commit hooks
+
+Find the skillsaw entry in `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/stbenjam/skillsaw
+    rev: v{latest}
+    hooks:
+      - id: skillsaw
+```
+
+Set `rev:` to the `v{latest}` tag. Tags are the pre-commit convention here;
+a full commit SHA also works when the project prefers immutable pins.
+
+## Container image tags
+
+A GitLab job or Dockerfile may reference the published image directly:
+
+```console
+grep -rn "ghcr.io/stbenjam/skillsaw" .gitlab-ci.yml Dockerfile* 2>/dev/null
+```
+
+Retag `:v{old}` to `:v{latest}`. A `:latest` tag floats onto the new release
+by itself; recommend pinning it to `:v{latest}` for repeatable pipelines,
+but only change it after the user agrees.
+
+Return to the router with the list of edited files.

--- a/.claude/skills/skillsaw-update/references/04-triage.md
+++ b/.claude/skills/skillsaw-update/references/04-triage.md
@@ -1,0 +1,62 @@
+# Triage findings from new rules
+
+Only findings from added rules are in scope; findings from existing rules
+were already triaged when skillsaw was adopted. For any group with more than
+20 findings or making up over 10% of the scan total, review 3–5 sample
+findings to understand the pattern before sorting it.
+
+Sort each added-rule group into one of three buckets:
+
+## 1. Fix now
+
+Best for high-priority issues and quick wins:
+
+- All `error` severity findings by default; an error the user accepts as debt
+  may move to Baseline instead
+- Findings with `"fixable": true`: safe fixes apply with
+  `skillsaw fix --rule <rule-id>`, suggested ones with `--suggest` added.
+  Naming the rule repairs it at any severity
+- Small groups of straightforward corrections
+
+## 2. Baseline
+
+Best for valid findings that are not urgent to fix immediately. Recording them
+with `skillsaw baseline` absorbs the new findings into the existing baseline
+file so CI passes while preventing regressions on future changes. Only errors
+and warnings can go here: `skillsaw baseline` never records info findings.
+
+A removed rule may leave stale baseline entries behind. Refreshing the
+baseline with `skillsaw baseline` drops entries that no longer match, so
+mention that cleanup when removed rules were reported.
+
+## 3. Configure
+
+Best when a new rule clashes with an intentional project convention. Check
+`skillsaw explain <rule-id>` for options such as `exclude` or limits first,
+then consider lowering to `severity: info`, and use `enabled: false` only as
+a last resort for advisory content rules. Always add a brief `#` comment in
+`.skillsaw.yaml` explaining the rationale.
+
+> [!NOTE]
+> Keep security rules (`security-*`, `content-embedded-secrets`,
+> `claude-settings-dangerous`), hook rules (`hooks-*`), MCP rules, and
+> structural validity rules (`*-valid`, `claude-*-frontmatter`) enabled. Fix
+> or baseline these rather than turning them off.
+
+## Presenting the plan to the user
+
+Share the summary table and confirm the plan:
+
+> The upgrade adds {new rule count} with {total} findings in this repo. Here
+> is a proposed plan:
+> - **Fix now**: {fix count} issues (errors, autofixable findings, and small
+>   manual corrections)
+> - **Baseline**: {baseline count} existing items to resolve over time
+> - **Configure**: {configure count} project-wide conventions in
+>   `.skillsaw.yaml`
+>
+> Would you like to proceed with this plan, or adjust any of the categories?
+
+The fix-now set drives the next edits, the configure set becomes
+`.skillsaw.yaml` settings, and the baseline set is recorded with
+`skillsaw baseline`. Then return to the router.

--- a/.claude/skills/skillsaw-update/references/05-verify.md
+++ b/.claude/skills/skillsaw-update/references/05-verify.md
@@ -1,0 +1,15 @@
+# Run final verification
+
+Run the linter once more with the new version and confirm it exits
+successfully. Summarize:
+
+- installed and latest versions;
+- added rules, with each rule's finding count in this repository;
+- removed rules and any baseline cleanup applied;
+- pins updated (workflows, Makefile, pre-commit config, container tags);
+- triage outcomes: fixed, baselined, and configured counts;
+- every file created or modified.
+
+Remind the user to commit every applicable artifact, including
+`.skillsaw.yaml`, `.skillsaw-baseline.json`, workflow files,
+`.pre-commit-config.yaml`, Makefile changes, and edited context files.

--- a/apm.yml
+++ b/apm.yml
@@ -15,3 +15,4 @@ dependencies:
     - ./skills/skillsaw-fix
     - ./skills/skillsaw-lint
     - ./skills/skillsaw-onboard
+    - ./skills/skillsaw-update

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,6 +74,13 @@ fingerprinting works and configuration options.
     Or consult your agent's documentation for how to install a new
     [agentskills.io](https://agentskills.io) skill.
 
+## Keep skillsaw updated
+
+When a new skillsaw release is out, the **`/skillsaw-update`** skill walks
+your agent through the upgrade: it installs the newest version, reports which
+rules are new and what they find in your repository, and bumps pinned
+versions in GitHub Actions workflows, Makefile targets, and pre-commit hooks.
+
 ## Installation
 
 === "uvx (no install required)"

--- a/skills/skillsaw-update/SKILL.md
+++ b/skills/skillsaw-update/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: skillsaw-update
+description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
+compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
+license: Apache-2.0
+metadata:
+  author: stbenjam
+  version: "1.0"
+---
+
+# skillsaw Update
+
+Update this repository from its installed skillsaw to the newest release:
+upgrade the local install, report which rules are new and what they find in
+this repository, and bump every pinned skillsaw version (GitHub Actions
+SHAs, Makefile targets, pre-commit hooks, container tags).
+
+## Workflow
+
+Ask one routing question at a time and wait for the answer. An explicit choice
+in the user's request already counts as an answer. Read a reference only after
+its condition or a yes answer routes to it; do not read the reference to
+formulate the question. After completing it, return here. If the answer is no,
+continue to the next checkpoint without reading it. Carry forward the command
+prefixes, versions, rule lists, and changed-file list.
+
+Resolve every `references/...` path relative to the directory containing this
+`SKILL.md`, never relative to the target repository or the process's current
+working directory. If this file was fetched from the web, resolve each
+reference against the parent URL of this file and fetch it from that sibling
+location.
+
+Replace brace-delimited fields below with facts from the repository or scan;
+never show placeholders to the user, and render singular or plural wording
+naturally.
+
+### 1. Upgrade to the newest version
+
+Read [versions](references/01-versions.md). It records the installed and
+latest versions, captures the old rule list, upgrades the install (or selects
+the new command prefix), and verifies the result. Report both versions before
+offering changes.
+
+### 2. Report new rules
+
+Read [new rules](references/02-new-rules.md). It diffs the old and new rule
+lists, explains each added rule, and scans the repository with the new
+version so every new rule is presented with its actual findings here.
+
+### 3. Update version pins
+
+If the repository pins skillsaw anywhere (GitHub Actions workflows, Makefile
+targets, pre-commit hooks, container image tags), ask:
+
+> I found skillsaw pinned in {locations}. Bumping them to {latest} keeps CI
+> and local runs on the version just installed. Should I update those pins?
+
+If yes, read [pins](references/03-pins.md). If no, preserve the locations.
+
+### 4. Triage findings from new rules
+
+If the new version reports findings from added rules, read
+[triage](references/04-triage.md) and present its summary table for
+confirmation before making changes. Carry the agreed buckets forward.
+
+### 5. Verify the result
+
+After all accepted routes finish, always read
+[verification](references/05-verify.md).

--- a/skills/skillsaw-update/references/01-versions.md
+++ b/skills/skillsaw-update/references/01-versions.md
@@ -1,0 +1,68 @@
+# Resolve versions and upgrade
+
+Record the installed version first; nothing below upgrades until the old
+rule list is captured in the next section.
+
+## Installed version
+
+Run `skillsaw --version`. If it works, retain that command prefix and note
+the version as `{installed}`.
+
+Otherwise the repository is not on a working install yet: prefer zero-install
+execution with `uvx skillsaw`, then `pip install skillsaw`, then the
+installed container runtime (`podman` or `docker`). Verify with `--version`
+and treat that version as both `{installed}` and the starting prefix.
+
+## Latest version
+
+Resolve the newest release to `{latest}`:
+
+```console
+python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/skillsaw/json'))['info']['version'])"
+```
+
+If PyPI is unreachable:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v*' | sort -t/ -k3 -V | tail -1
+```
+
+Strip the leading `v` from the tag for the `{latest}` version number.
+
+If `{installed}` equals `{latest}`, report that the install is current and
+continue: there are no new rules, but pins may still lag behind.
+
+## Capture the old rule list
+
+Before upgrading, save the rule IDs the installed version knows:
+
+```console
+<installed-prefix> list-rules > /tmp/skillsaw-rules-old.txt
+```
+
+Keep this file; the next section diffs it against the new version.
+
+## Upgrade
+
+Ask before changing the local environment:
+
+> Installed skillsaw is {installed} and the newest release is {latest}.
+> Should I upgrade the local install?
+
+If yes, follow the method behind the retained prefix:
+
+- **uvx**: nothing to install. The new prefix is
+  `uvx skillsaw=={latest}`; the old one stays usable for comparison.
+- **pip**: `pip install "skillsaw=={latest}"`.
+- **Container**: pull the pinned image,
+  `podman pull ghcr.io/stbenjam/skillsaw:v{latest}`
+  (or `docker pull ...`). A `:latest` tag floats and needs no pull to
+  float, but prefer the pinned `v{latest}` tag for repeatability.
+
+Verify the new prefix with `<new-prefix> --version` and save its rules:
+
+```console
+<new-prefix> list-rules > /tmp/skillsaw-rules-new.txt
+```
+
+Retain both prefixes and both files, then return to the router.

--- a/skills/skillsaw-update/references/02-new-rules.md
+++ b/skills/skillsaw-update/references/02-new-rules.md
@@ -1,0 +1,41 @@
+# Report new rules and their findings
+
+Compare the rule-ID lists captured in the versions step. Rule IDs are the
+indented names in `list-rules` output:
+
+```console
+comm -13 <(sort /tmp/skillsaw-rules-old.txt) <(sort /tmp/skillsaw-rules-new.txt)
+```
+
+Rules printed by `comm -23` with the files swapped were removed: findings or
+baseline entries naming them are stale, and the triage step handles them.
+
+## When no rule was added
+
+Report that the upgrade adds no new checks and return to the router. The pin
+updates and the verification step still apply.
+
+## Explain each added rule
+
+For every added rule ID, run `<new-prefix> explain <rule-id>` and summarize
+in one line each: what it checks, its default severity, whether it has an
+autofix, and its most useful option. Prefer the explanation's own words over
+the violation message when describing the rule.
+
+## Scan the repository with the new version
+
+Run the new version over the repository and keep the machine-readable result:
+
+```console
+<new-prefix> lint --format json -v > /tmp/skillsaw-update-scan.json
+```
+
+Group the findings by `rule_id`, then present one section per added rule:
+
+- the one-line rule summary from its explanation;
+- the finding count and severities in this repository;
+- two or three representative findings with file paths and line numbers.
+
+Do not propose fixes yet; the triage step sorts each group into fixing,
+baselining, or configuring. Record the per-rule groups and return to
+the router.

--- a/skills/skillsaw-update/references/03-pins.md
+++ b/skills/skillsaw-update/references/03-pins.md
@@ -1,0 +1,71 @@
+# Update version pins
+
+Change only pins that reference skillsaw; leave third-party actions and
+unrelated tooling untouched. Track each edited file for the final summary.
+
+## GitHub Actions
+
+Find workflows using the skillsaw action:
+
+```console
+grep -rn "stbenjam/skillsaw@" .github/workflows/
+```
+
+This covers both the lint action (`stbenjam/skillsaw@<SHA>`) and the review
+action (`stbenjam/skillsaw/review@<SHA>`). Resolve the commit SHA of the
+newest release tag before editing:
+
+```console
+git ls-remote --tags https://github.com/stbenjam/skillsaw.git 'v{latest}'
+```
+
+An annotated tag yields two lines; use the SHA on the `^{}` line, which is
+the commit the tag points to. Replace the old SHA with it and refresh the
+trailing version comment to `# v{latest}`:
+
+```yaml
+- uses: stbenjam/skillsaw@<NEW_SHA> # v{latest}
+```
+
+## Makefile targets
+
+Find the pinned version:
+
+```console
+grep -n "SKILLSAW_VERSION" Makefile
+```
+
+Set `SKILLSAW_VERSION := {latest}`. When the targets run through a container,
+the image tag below it references the same variable
+(`ghcr.io/stbenjam/skillsaw:v$(SKILLSAW_VERSION)`), so one edit covers both.
+Never overwrite existing `lint` or `lint-fix` target bodies; only the version
+assignment changes.
+
+## Pre-commit hooks
+
+Find the skillsaw entry in `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/stbenjam/skillsaw
+    rev: v{latest}
+    hooks:
+      - id: skillsaw
+```
+
+Set `rev:` to the `v{latest}` tag. Tags are the pre-commit convention here;
+a full commit SHA also works when the project prefers immutable pins.
+
+## Container image tags
+
+A GitLab job or Dockerfile may reference the published image directly:
+
+```console
+grep -rn "ghcr.io/stbenjam/skillsaw" .gitlab-ci.yml Dockerfile* 2>/dev/null
+```
+
+Retag `:v{old}` to `:v{latest}`. A `:latest` tag floats onto the new release
+by itself; recommend pinning it to `:v{latest}` for repeatable pipelines,
+but only change it after the user agrees.
+
+Return to the router with the list of edited files.

--- a/skills/skillsaw-update/references/04-triage.md
+++ b/skills/skillsaw-update/references/04-triage.md
@@ -1,0 +1,62 @@
+# Triage findings from new rules
+
+Only findings from added rules are in scope; findings from existing rules
+were already triaged when skillsaw was adopted. For any group with more than
+20 findings or making up over 10% of the scan total, review 3–5 sample
+findings to understand the pattern before sorting it.
+
+Sort each added-rule group into one of three buckets:
+
+## 1. Fix now
+
+Best for high-priority issues and quick wins:
+
+- All `error` severity findings by default; an error the user accepts as debt
+  may move to Baseline instead
+- Findings with `"fixable": true`: safe fixes apply with
+  `skillsaw fix --rule <rule-id>`, suggested ones with `--suggest` added.
+  Naming the rule repairs it at any severity
+- Small groups of straightforward corrections
+
+## 2. Baseline
+
+Best for valid findings that are not urgent to fix immediately. Recording them
+with `skillsaw baseline` absorbs the new findings into the existing baseline
+file so CI passes while preventing regressions on future changes. Only errors
+and warnings can go here: `skillsaw baseline` never records info findings.
+
+A removed rule may leave stale baseline entries behind. Refreshing the
+baseline with `skillsaw baseline` drops entries that no longer match, so
+mention that cleanup when removed rules were reported.
+
+## 3. Configure
+
+Best when a new rule clashes with an intentional project convention. Check
+`skillsaw explain <rule-id>` for options such as `exclude` or limits first,
+then consider lowering to `severity: info`, and use `enabled: false` only as
+a last resort for advisory content rules. Always add a brief `#` comment in
+`.skillsaw.yaml` explaining the rationale.
+
+> [!NOTE]
+> Keep security rules (`security-*`, `content-embedded-secrets`,
+> `claude-settings-dangerous`), hook rules (`hooks-*`), MCP rules, and
+> structural validity rules (`*-valid`, `claude-*-frontmatter`) enabled. Fix
+> or baseline these rather than turning them off.
+
+## Presenting the plan to the user
+
+Share the summary table and confirm the plan:
+
+> The upgrade adds {new rule count} with {total} findings in this repo. Here
+> is a proposed plan:
+> - **Fix now**: {fix count} issues (errors, autofixable findings, and small
+>   manual corrections)
+> - **Baseline**: {baseline count} existing items to resolve over time
+> - **Configure**: {configure count} project-wide conventions in
+>   `.skillsaw.yaml`
+>
+> Would you like to proceed with this plan, or adjust any of the categories?
+
+The fix-now set drives the next edits, the configure set becomes
+`.skillsaw.yaml` settings, and the baseline set is recorded with
+`skillsaw baseline`. Then return to the router.

--- a/skills/skillsaw-update/references/05-verify.md
+++ b/skills/skillsaw-update/references/05-verify.md
@@ -1,0 +1,15 @@
+# Run final verification
+
+Run the linter once more with the new version and confirm it exits
+successfully. Summarize:
+
+- installed and latest versions;
+- added rules, with each rule's finding count in this repository;
+- removed rules and any baseline cleanup applied;
+- pins updated (workflows, Makefile, pre-commit config, container tags);
+- triage outcomes: fixed, baselined, and configured counts;
+- every file created or modified.
+
+Remind the user to commit every applicable artifact, including
+`.skillsaw.yaml`, `.skillsaw-baseline.json`, workflow files,
+`.pre-commit-config.yaml`, Makefile changes, and edited context files.


### PR DESCRIPTION
## Summary

Like skillsaw-onboard, but for repos already adopted: guides an agent through upgrading to the newest skillsaw release in one interactive session.

## Skill flow

1. **Versions** — records installed vs latest (PyPI, git-tag fallback), captures the old `list-rules`, upgrades per install method (uvx prefix swap, pip, container pull).
2. **New rules** — diffs old/new rule IDs, `explain`s each addition, scans the repo with the new binary and presents per-rule findings with samples; flags removed rules as stale-baseline cleanup.
3. **Pins** — bumps `stbenjam/skillsaw@<SHA>` (lint + review workflows, `^{}` SHA resolution), `SKILLSAW_VERSION`, pre-commit `rev:`, and container tags; third-party pins untouched.
4. **Triage** — fix-now / baseline-absorb / configure buckets for new-rule findings, with the never-disable guard for security/validity/hook/MCP rules.
5. **Verify** — re-lint and summarize.

## Changes

- `skills/skillsaw-update/`: SKILL.md router + 5 references (self-contained; no cross-skill reference links)
- `apm.yml`: new dependency entry; compiled copies under `.agents/` + `.claude/` via `make update` (symmetric with onboard)
- `docs/getting-started.md`: short "Keep skillsaw updated" pointer

## Validation

- `make test`: 5927 passed
- `make lint`: clean
- `make update` + `make verify-apm`: green
- self-lint on touched files: 0 errors, 0 warnings
- new skill dir lints 0/0/0 (matches onboard bar)
- `openshift-eng/ai-helpers`: exit 1 with the same pre-existing `plugins-doc-up-to-date` custom-rule error as clean `origin/main` (verified via worktree, not assumed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided `/skillsaw-update` skill for upgrading Skillsaw, reviewing new rules, updating version pins, triaging findings, and verifying results.
  - Added workflows for handling findings by fixing, baselining, or configuring rules.
  - Added support for updating Skillsaw references across common project configuration files.

- **Documentation**
  - Added getting-started guidance for keeping Skillsaw updated.
  - Documented version checks, rule comparisons, pin updates, triage decisions, and final verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->