### PR TITLE
[Auto] add user-invocable frontmatter to skillsaw-update skill

### DIFF
--- a/.agents/skills/skillsaw-update/SKILL.md
+++ b/.agents/skills/skillsaw-update/SKILL.md
@@ -3,6 +3,8 @@ name: skillsaw-update
 description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
 compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
 license: Apache-2.0
+user-invocable: true
+disable-model-invocation: true
 metadata:
   author: stbenjam
   version: "1.0"

--- a/.claude/skills/skillsaw-update/SKILL.md
+++ b/.claude/skills/skillsaw-update/SKILL.md
@@ -3,6 +3,8 @@ name: skillsaw-update
 description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
 compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
 license: Apache-2.0
+user-invocable: true
+disable-model-invocation: true
 metadata:
   author: stbenjam
   version: "1.0"

--- a/skills/skillsaw-update/SKILL.md
+++ b/skills/skillsaw-update/SKILL.md
@@ -3,6 +3,8 @@ name: skillsaw-update
 description: "Update a repository to the newest skillsaw — upgrade the install, report new rules and their findings in your repo, and bump version pins (GitHub Action SHAs, Makefile targets, pre-commit hooks). Use when a new skillsaw release is out and you want its latest checks."
 compatibility: "Requires skillsaw already adopted (uvx skillsaw, pip install skillsaw, or container). Network access for version lookup."
 license: Apache-2.0
+user-invocable: true
+disable-model-invocation: true
 metadata:
   author: stbenjam
   version: "1.0"


### PR DESCRIPTION
Follow-up to #572 (merged): addresses stbenjam's inline comment on `skills/skillsaw-update/SKILL.md:1\ general progress.

Adds `user-invocable: true` + `disable-model-invocation: true` to the frontmatter, matching the other user-facing skills, and regenerates the compiled copies via `make update`.

Validation: `make test` 5927 passed, `make lint` clean, self-lint 0/0, skill dir 0/0/0.