### PR TITLE
[Auto] Support remote URLs for Codex plugin interface assets

### DIFF
--- a/docs/rules/codex-plugin-json-valid.md
+++ b/docs/rules/codex-plugin-json-valid.md
@@ -54,13 +54,15 @@ plugin identifier and component namespace. `version` and `description`
 are reported as recommended; adjust `recommended-fields` to change that
 set.
 
-Manifest paths (`skills`, `apps`, `hooks`, `mcpServers` when
-path-valued, and the `interface` asset fields) must resolve inside the
-plugin root and should start with `./`. An absolute path or one
-containing `..` is an error; a missing `./` prefix is informational.
-Paths that point at something not in the repository are reported as
-warnings — set `check-paths-exist: false` to skip that check when
-assets are generated at build time.
+Manifest paths (`skills`, `apps`, `hooks`, and `mcpServers` when
+path-valued) must resolve inside the plugin root and should start with `./`.
+Interface asset fields (`composerIcon`, `logo`, `logoDark`, `screenshots`) accept
+remote HTTP/HTTPS URLs and data URIs as well as local relative paths. When given
+as local paths, they must also resolve inside the plugin root and should start
+with `./`. An absolute path or one containing `..` is an error; a missing `./`
+prefix on a local path is informational. Paths that point at something not in the
+repository are reported as warnings — set `check-paths-exist: false` to skip that
+check when assets are generated at build time.
 
 `mcpServers` is not purely a path field: it accepts a path string, an
 inline server object, or an array mixing both. Only its path-valued
@@ -77,9 +79,11 @@ A path can also exist and still be reported for its *kind*: `hooks` and
 a path-valued `mcpServers` name a file and are warned about when they
 resolve to a directory, and `skills` names a directory and is warned
 about when it resolves to a file. The path is fine — point the field at
-the right kind of filesystem object. Other path fields (`apps`, the
+the right kind of filesystem object. Other path fields (`apps`, and local
 `interface` asset paths) are checked for containment and existence but
-not for kind, because Codex accepts more than one shape for them.
+not for kind, because Codex accepts more than one shape for them. Remote
+interface asset URLs are not resolved as local paths or checked for
+repository existence.
 
 `version` can be any valid version string; semver is recommended but not enforced.
 

--- a/src/skillsaw/rules/builtin/codex/plugin_json_valid.py
+++ b/src/skillsaw/rules/builtin/codex/plugin_json_valid.py
@@ -3,7 +3,8 @@ Rule: codex-plugin-json-valid
 """
 
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from skillsaw.rule import Rule, RuleViolation, Severity
 from skillsaw.context import RepositoryContext
@@ -24,8 +25,8 @@ from ._helpers import (
 # ``hooks`` is excluded — it alone accepts inline objects as well as paths,
 # so it is unpacked separately.
 _PATH_FIELDS = ("skills", "mcpServers", "apps")
-# All three are documented in plugin-json-spec.md, which also requires every
-# asset path to point at a real file inside the plugin.
+# Interface asset fields documented in plugin-json-spec.md. In addition to
+# local relative paths, these accept remote HTTP/HTTPS URLs and data URIs.
 _INTERFACE_PATH_FIELDS = ("composerIcon", "logo", "logoDark")
 _INTERFACE_PATH_LIST_FIELDS = ("screenshots",)
 
@@ -213,6 +214,13 @@ class CodexPluginJsonValidRule(Rule):
                 # below would pass and the field would look fine.
                 violations.append(self.violation(f"'{field}' is an empty path", file_path=manifest))
                 continue
+            if field.startswith("interface."):
+                is_uri, uri_violation = self._check_interface_asset_uri(field, value, manifest)
+                if uri_violation:
+                    violations.append(uri_violation)
+                    continue
+                if is_uri:
+                    continue
             problem = path_problem(value, "plugin root", plugin_dir)
             if problem:
                 violations.append(self.violation(f"'{field}': {problem}", file_path=manifest))
@@ -261,6 +269,49 @@ class CodexPluginJsonValidRule(Rule):
                 )
 
         return violations
+
+    def _check_interface_asset_uri(
+        self, field: str, value: str, manifest: Path
+    ) -> Tuple[bool, Optional[RuleViolation]]:
+        """Check whether an interface asset field value is a URI.
+
+        Returns (is_uri, violation). If the value is a valid URI or URL,
+        returns (True, None). If it is a malformed URL, returns (True, violation).
+        If it is not a URI, returns (False, None) so it can be validated as
+        a local filesystem path.
+        """
+        trimmed = value.strip()
+        try:
+            parsed = urlparse(trimmed)
+        except ValueError:
+            if trimmed.lower().startswith(("https://", "http://")):
+                return True, self.violation(
+                    f"'{field}': '{safe_display(value)}' is not a valid URL",
+                    file_path=manifest,
+                    severity=Severity.WARNING,
+                )
+            return False, None
+
+        scheme = parsed.scheme.lower()
+        if scheme in ("https", "http"):
+            if not parsed.netloc:
+                return True, self.violation(
+                    f"'{field}': '{safe_display(value)}' is not a valid URL — URL must include a host",
+                    file_path=manifest,
+                    severity=Severity.WARNING,
+                )
+            return True, None
+
+        if scheme == "data":
+            if not parsed.path:
+                return True, self.violation(
+                    f"'{field}': '{safe_display(value)}' is an empty data URI",
+                    file_path=manifest,
+                    severity=Severity.WARNING,
+                )
+            return True, None
+
+        return False, None
 
     def _iter_path_values(self, data: dict) -> List[Tuple[str, Any]]:
         """(field label, raw value) for every path-valued manifest field.

--- a/src/skillsaw/rules/docs/codex-plugin-json-valid.md
+++ b/src/skillsaw/rules/docs/codex-plugin-json-valid.md
@@ -39,13 +39,15 @@ plugin identifier and component namespace. `version` and `description`
 are reported as recommended; adjust `recommended-fields` to change that
 set.
 
-Manifest paths (`skills`, `apps`, `hooks`, `mcpServers` when
-path-valued, and the `interface` asset fields) must resolve inside the
-plugin root and should start with `./`. An absolute path or one
-containing `..` is an error; a missing `./` prefix is informational.
-Paths that point at something not in the repository are reported as
-warnings — set `check-paths-exist: false` to skip that check when
-assets are generated at build time.
+Manifest paths (`skills`, `apps`, `hooks`, and `mcpServers` when
+path-valued) must resolve inside the plugin root and should start with `./`.
+Interface asset fields (`composerIcon`, `logo`, `logoDark`, `screenshots`) accept
+remote HTTP/HTTPS URLs and data URIs as well as local relative paths. When given
+as local paths, they must also resolve inside the plugin root and should start
+with `./`. An absolute path or one containing `..` is an error; a missing `./`
+prefix on a local path is informational. Paths that point at something not in the
+repository are reported as warnings — set `check-paths-exist: false` to skip that
+check when assets are generated at build time.
 
 `mcpServers` is not purely a path field: it accepts a path string, an
 inline server object, or an array mixing both. Only its path-valued
@@ -62,8 +64,10 @@ A path can also exist and still be reported for its *kind*: `hooks` and
 a path-valued `mcpServers` name a file and are warned about when they
 resolve to a directory, and `skills` names a directory and is warned
 about when it resolves to a file. The path is fine — point the field at
-the right kind of filesystem object. Other path fields (`apps`, the
+the right kind of filesystem object. Other path fields (`apps`, and local
 `interface` asset paths) are checked for containment and existence but
-not for kind, because Codex accepts more than one shape for them.
+not for kind, because Codex accepts more than one shape for them. Remote
+interface asset URLs are not resolved as local paths or checked for
+repository existence.
 
 `version` can be any valid version string; semver is recommended but not enforced.

--- a/tests/codex/test_plugin_json.py
+++ b/tests/codex/test_plugin_json.py
@@ -662,6 +662,20 @@ class TestInterfaceAssetUris:
         assert any("interface.logo" in m and expected_fragment in m for m in warnings)
         assert not any("should start with './'" in m for m in messages(violations))
 
+    def test_unparseable_non_url_falls_through_to_path_validation(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "bad-path",
+                "version": "1.0.0",
+                "description": "Unparseable path",
+                "interface": {"logo": "//["},
+            },
+        )
+        violations = run_rule(CodexPluginJsonValidRule, repo)
+        msg_list = messages(violations)
+        assert any("interface.logo" in m and "absolute path" in m for m in msg_list)
+
     def test_local_interface_asset_paths_receive_containment_and_existence_checks(self, tmp_path):
         repo = _codex_plugin_repo(
             tmp_path,

--- a/tests/codex/test_plugin_json.py
+++ b/tests/codex/test_plugin_json.py
@@ -601,3 +601,122 @@ class TestEvalsBaselineStability:
             v.message = "a differently worded diagnostic"
         remaining, _ = filter_baselined_violations(found, baseline, skill)
         assert remaining == []
+
+
+class TestInterfaceAssetUris:
+    """Interface branding assets (composerIcon, logo, logoDark, screenshots)
+    accept remote HTTP/HTTPS URLs and data URIs as well as local paths."""
+
+    def test_remote_urls_are_not_resolved_as_local_paths(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "example-plugin",
+                "version": "1.0.0",
+                "description": "Example plugin",
+                "interface": {
+                    "composerIcon": "https://example.com/icon.svg",
+                    "logo": "https://example.com/logo.svg",
+                    "logoDark": "http://example.com/logo-dark.svg",
+                    "screenshots": ["https://example.com/screenshot.png"],
+                },
+            },
+        )
+        assert run_rule(CodexPluginJsonValidRule, repo) == []
+
+    def test_data_uri_asset_passes(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "data-plugin",
+                "version": "1.0.0",
+                "description": "Plugin with data URI icon",
+                "interface": {
+                    "composerIcon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+                },
+            },
+        )
+        assert run_rule(CodexPluginJsonValidRule, repo) == []
+
+    @pytest.mark.parametrize(
+        "value,expected_fragment",
+        [
+            ("https://", "URL must include a host"),
+            ("http://", "URL must include a host"),
+            ("https://[", "is not a valid URL"),
+            ("data:", "empty data URI"),
+        ],
+    )
+    def test_malformed_asset_uri_warns(self, tmp_path, value, expected_fragment):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "bad-uri",
+                "version": "1.0.0",
+                "description": "Malformed URL",
+                "interface": {"logo": value},
+            },
+        )
+        violations = run_rule(CodexPluginJsonValidRule, repo)
+        warnings = messages(by_severity(violations, Severity.WARNING))
+        assert any("interface.logo" in m and expected_fragment in m for m in warnings)
+        assert not any("should start with './'" in m for m in messages(violations))
+
+    def test_local_interface_asset_paths_receive_containment_and_existence_checks(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "local-assets",
+                "version": "1.0.0",
+                "description": "Local asset paths",
+                "interface": {
+                    "logo": "./missing-logo.png",
+                    "composerIcon": "assets/icon.png",
+                    "logoDark": "../escaping-logo.png",
+                },
+            },
+        )
+        violations = run_rule(CodexPluginJsonValidRule, repo)
+        msg_list = messages(violations)
+        assert any("interface.logo" in m and "does not exist in the plugin" in m for m in msg_list)
+        assert any(
+            "interface.composerIcon" in m and "should start with './'" in m for m in msg_list
+        )
+        assert any("interface.logoDark" in m and "'..'" in m for m in msg_list)
+
+    def test_mixed_screenshots_array(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "mixed-shots",
+                "version": "1.0.0",
+                "description": "Mixed screenshots",
+                "interface": {
+                    "screenshots": [
+                        "https://example.com/remote.png",
+                        "./local-exists.png",
+                        "./local-missing.png",
+                    ]
+                },
+            },
+        )
+        (repo / "local-exists.png").write_text("fake image", encoding="utf-8")
+        violations = run_rule(CodexPluginJsonValidRule, repo)
+        msg_list = messages(violations)
+        assert not any("screenshots[0]" in m for m in msg_list)
+        assert not any("screenshots[1]" in m for m in msg_list)
+        assert any("screenshots[2]" in m and "does not exist in the plugin" in m for m in msg_list)
+
+    def test_non_interface_path_fields_do_not_accept_urls(self, tmp_path):
+        repo = _codex_plugin_repo(
+            tmp_path,
+            {
+                "name": "url-skills",
+                "version": "1.0.0",
+                "description": "URL in skills",
+                "skills": "https://example.com/skills",
+            },
+        )
+        violations = run_rule(CodexPluginJsonValidRule, repo)
+        msg_list = messages(violations)
+        assert any("'skills'" in m and "does not exist in the plugin" in m for m in msg_list)


### PR DESCRIPTION
## Summary

Fixes false-positive existence warnings in `codex-plugin-json-valid` when Codex plugin manifests reference remote HTTP/HTTPS URLs or data URIs for interface branding assets (`composerIcon`, `logo`, `logoDark`, and `screenshots`).

Closes #583

## Problem

`codex-plugin-json-valid` previously treated every path field — including `interface` branding assets — strictly as local filesystem paths relative to the plugin directory. When plugins (such as daisyUI in `saadeghi/daisyui`) specified remote HTTPS URLs like `https://img.daisyui.com/...` for `composerIcon`, `logo`, or `screenshots`, skillsaw reported:
- `INFO: path '...' should start with './'`
- `WARNING: ... does not exist in the plugin`

## Solution

1. Added URI detection in `_check_paths` for all fields under `interface.` (`composerIcon`, `logo`, `logoDark`, `screenshots`):
   - Valid HTTP/HTTPS URLs (`http://`, `https://`) with a host and data URIs (`data:`) are recognized as valid remote asset URIs and exempted from local filesystem existence and `./` prefix checks.
   - Malformed URLs (missing host such as `https://` or unparseable URLs) produce an explicit warning.
   - Local relative paths (such as `./assets/logo.png` or `assets/logo.png`) continue to receive the full suite of containment and existence checks.
   - Non-interface fields (`skills`, `apps`, `hooks`, `mcpServers`) are unaffected and remain local filesystem paths.
2. Updated documentation in `src/skillsaw/rules/docs/codex-plugin-json-valid.md` and regenerated site docs.
3. Added comprehensive test coverage in `tests/codex/test_plugin_json.py`:
   - Remote HTTPS/HTTP asset URLs
   - Data URIs
   - Malformed URLs (`https://`, `http://`, `https://[`, `data:`)
   - Local path regression protection (containment, missing `./`, missing files)
   - Mixed screenshot arrays containing both remote URLs and local file paths
   - Non-interface fields rejecting URLs

## Verification

- `make test`: All 6,491 tests pass cleanly.
- `make lint`: Clean (black formatted).
- `make update`: Clean and idempotent, self-lint Grade A+.
- `openshift-eng/ai-helpers`: Tested clean with Grade A+ (exit 0).

---

Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.