### PR TITLE
[Auto] Honour exact directory excludes for conventional skill roots

### DIFF
--- a/src/skillsaw/context.py
+++ b/src/skillsaw/context.py
@@ -20,7 +20,7 @@ from .formats.codex import (
 )
 from .discovery import detect as detect_discovery
 from .discovery.excludes import pattern_variants as _pattern_variants
-from .discovery.excludes import path_matches_patterns
+from .discovery.excludes import is_root_or_ancestor_excluded, path_matches_patterns
 from .paths import safe_is_dir, safe_resolve
 from .utils import read_yaml
 from .repository_external_content import RepositoryExternalContentMixin
@@ -385,7 +385,11 @@ class RepositoryContext(
             self.plugins = [p for p in self.plugins if not self.is_path_excluded(p)]
             self.codex_plugins = [p for p in self.codex_plugins if not self.is_path_excluded(p)]
             self.agent_plugins = [p for p in self.agent_plugins if not self.is_path_excluded(p)]
-            self.skills = [p for p in self.skills if not self.is_path_excluded(p)]
+            self.skills = [
+                p
+                for p in self.skills
+                if not is_root_or_ancestor_excluded(p, self.root_path, self.is_path_excluded)
+            ]
             self.instruction_files = [
                 p for p in self.instruction_files if not self.is_path_excluded(p)
             ]
@@ -430,6 +434,8 @@ class RepositoryContext(
                 self.skills = [
                     skill for skill in self.skills if not self._under_any(skill, dropped_roots)
                 ]
+        if not self.skills and self._overridden_types is None:
+            self.repo_types.discard(RepositoryType.AGENTSKILLS)
         # The claim set folds in both plugin roots and catalog sources, and
         # excludes can drop either — always recompute on the next consult.
         # The unconditional clear is also load-bearing for __init__ ordering:
@@ -494,6 +500,7 @@ class RepositoryContext(
                 promptfoo_named_files=scan.promptfoo_named_files,
                 promptfoo_eval_files=scan.promptfoo_eval_files,
                 tool_dirs=scan.tool_dirs,
+                is_excluded=self.is_path_excluded,
             )
         }
 
@@ -879,6 +886,7 @@ class RepositoryContext(
                 for name in detect_discovery.NESTED_TOOL_SKILL_DIRS
                 for directory in self.agent_tool_dirs(name)
             ),
+            is_excluded=self.is_path_excluded,
         )
 
     def __str__(self):

--- a/src/skillsaw/discovery/claude.py
+++ b/src/skillsaw/discovery/claude.py
@@ -12,6 +12,7 @@ from skillsaw.discovery import (
     agent_plugins as agent_plugins_discovery,
     exact_name_exists,
 )
+from skillsaw.discovery.excludes import is_root_or_ancestor_excluded
 from skillsaw.formats.codex import codex_declared_skill_dirs
 from skillsaw.formats.grok import grok_declared_skill_dirs
 from skillsaw.paths import contained_resolve, safe_exists, safe_is_dir, safe_resolve
@@ -216,6 +217,7 @@ def discover_skills(
     containment_claims_possible: Callable[[], bool],
     is_containment_plugin: Callable[[Path], bool],
     additional_skill_dirs: Iterable[Path] = (),
+    is_excluded: Callable[[Path], bool] = lambda _: False,
 ) -> List[Path]:
     """Discover contained Agent Skill directories across repository roots."""
     skills: List[Path] = []
@@ -264,7 +266,7 @@ def discover_skills(
                 boundary = claim_boundary(parent)
         try:
             for item in parent.iterdir():
-                if should_skip(item):
+                if should_skip(item) or is_excluded(item):
                     continue
                 resolved = safe_resolve(item)
                 if resolved is None or resolved in discovered or resolved in visited:
@@ -274,6 +276,8 @@ def discover_skills(
                 if boundary is not None and not resolved.is_relative_to(boundary):
                     continue
                 if exact_name_exists(item, "SKILL.md"):
+                    if is_excluded(item / "SKILL.md"):
+                        continue
                     if boundary is not None:
                         entrypoint = safe_resolve(item / "SKILL.md")
                         if entrypoint is None or not entrypoint.is_relative_to(boundary):
@@ -298,6 +302,8 @@ def discover_skills(
             repo_root is not None
             and exact_name_exists(root, "SKILL.md")
             and contained_resolve(root / "SKILL.md", repo_root) is not None
+            and not is_excluded(root / "SKILL.md")
+            and not is_excluded(root)
         ):
             skills.append(root)
             discovered.add(root)
@@ -310,6 +316,7 @@ def discover_skills(
                 and contained_resolve(path, repo_root) is not None
                 and path.is_dir()
                 and not in_apm_compiled_dir(path)
+                and not is_root_or_ancestor_excluded(path, repo_root, is_excluded)
             ):
                 walk(path, repo_root)
         for path in additional_skill_dirs:
@@ -318,11 +325,12 @@ def discover_skills(
                 and contained_resolve(path, repo_root) is not None
                 and path.is_dir()
                 and not in_apm_compiled_dir(path)
+                and not is_root_or_ancestor_excluded(path, repo_root, is_excluded)
             ):
                 walk(path, repo_root)
     for plugin in plugins:
         path = plugin / "skills"
-        if path.is_dir():
+        if path.is_dir() and not is_root_or_ancestor_excluded(path, repo_root, is_excluded):
             walk(path)
 
     def contained_plugin_skills(plugin: Path, declared: Iterable[Path]) -> None:
@@ -339,7 +347,11 @@ def discover_skills(
         for path in (plugin / "skills", *declared):
             if not path.is_dir():
                 continue
+            if is_root_or_ancestor_excluded(path, plugin_root, is_excluded):
+                continue
             if exact_name_exists(path, "SKILL.md"):
+                if is_excluded(path / "SKILL.md"):
+                    continue
                 resolved = contained_resolve(path, plugin_root)
                 if (
                     resolved is not None

--- a/src/skillsaw/discovery/detect.py
+++ b/src/skillsaw/discovery/detect.py
@@ -13,6 +13,7 @@ import os
 from typing import Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 
 from skillsaw.discovery import CONVENTIONAL_SKILL_DIRS, exact_name_exists
+from skillsaw.discovery.excludes import is_root_or_ancestor_excluded
 from skillsaw.formats.promptfoo import is_promptfoo_config
 from skillsaw.formats import codex, devin, grok, muse
 from skillsaw.paths import contained_resolve, safe_resolve
@@ -446,6 +447,7 @@ def has_skill_md_recursive(
     should_skip: Callable[[Path], bool],
     _visited: Optional[Set[Path]] = None,
     _boundary: Optional[Path] = None,
+    is_excluded: Callable[[Path], bool] = lambda _: False,
 ) -> bool:
     """Return whether a contained recursive walk finds an Agent Skill."""
     if _visited is None:
@@ -461,13 +463,17 @@ def has_skill_md_recursive(
     if (
         exact_name_exists(root, "SKILL.md")
         and contained_resolve(root / "SKILL.md", _boundary) is not None
+        and not is_excluded(root / "SKILL.md")
+        and not is_excluded(root)
     ):
         return True
     try:
         for item in root.iterdir():
-            if should_skip(item):
+            if should_skip(item) or is_excluded(item):
                 continue
-            if item.is_dir() and has_skill_md_recursive(item, should_skip, _visited, _boundary):
+            if item.is_dir() and has_skill_md_recursive(
+                item, should_skip, _visited, _boundary, is_excluded=is_excluded
+            ):
                 return True
     except OSError:
         pass
@@ -478,6 +484,7 @@ def is_agentskills_repo(
     root: Path,
     should_skip: Callable[[Path], bool],
     extra_skill_roots: Iterable[Path] = (),
+    is_excluded: Callable[[Path], bool] = lambda _: False,
 ) -> bool:
     """Return whether the repository contains an Agent Skill entrypoint."""
     resolved_root = safe_resolve(root)
@@ -486,6 +493,8 @@ def is_agentskills_repo(
     if (
         exact_name_exists(root, "SKILL.md")
         and contained_resolve(root / "SKILL.md", resolved_root) is not None
+        and not is_excluded(root / "SKILL.md")
+        and not is_excluded(root)
     ):
         return True
     for rel in CONVENTIONAL_SKILL_DIRS:
@@ -493,17 +502,25 @@ def is_agentskills_repo(
         if (
             contained_resolve(path, resolved_root) is not None
             and path.is_dir()
-            and has_skill_md_recursive(path, should_skip, _boundary=resolved_root)
+            and not is_root_or_ancestor_excluded(path, resolved_root, is_excluded)
+            and has_skill_md_recursive(
+                path, should_skip, _boundary=resolved_root, is_excluded=is_excluded
+            )
         ):
             return True
     for path in extra_skill_roots:
         if (
             contained_resolve(path, resolved_root) is not None
             and path.is_dir()
-            and has_skill_md_recursive(path, should_skip, _boundary=resolved_root)
+            and not is_root_or_ancestor_excluded(path, resolved_root, is_excluded)
+            and has_skill_md_recursive(
+                path, should_skip, _boundary=resolved_root, is_excluded=is_excluded
+            )
         ):
             return True
-    return has_skill_md_recursive(root, should_skip, _boundary=resolved_root)
+    return has_skill_md_recursive(
+        root, should_skip, _boundary=resolved_root, is_excluded=is_excluded
+    )
 
 
 def is_dot_claude(root: Path, apm: bool) -> bool:
@@ -544,6 +561,7 @@ def marker_types(
     promptfoo_named_files: Iterable[Path],
     promptfoo_eval_files: Mapping[Path, Iterable[Path]],
     tool_dirs: Optional[Mapping[str, Iterable[Path]]] = None,
+    is_excluded: Callable[[Path], bool] = lambda _: False,
 ) -> Set[str]:
     """Return independently detectable type labels (excluding ecosystems)."""
     found: Set[str] = set()
@@ -558,7 +576,7 @@ def marker_types(
                     resolved_root
                 ):
                     nested_skill_roots.append(skill_root)
-    if is_agentskills_repo(root, should_skip, nested_skill_roots):
+    if is_agentskills_repo(root, should_skip, nested_skill_roots, is_excluded=is_excluded):
         found.add("agentskills")
     if apm:
         found.add("apm")

--- a/src/skillsaw/discovery/excludes.py
+++ b/src/skillsaw/discovery/excludes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 from pathlib import Path
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from skillsaw.paths import relative_to_str, safe_resolve
 
@@ -35,3 +35,25 @@ def path_matches_patterns(
     return any(
         fnmatch.fnmatch(rel, variant) for pattern in patterns for variant in variants_for(pattern)
     )
+
+
+def is_root_or_ancestor_excluded(
+    path: Path,
+    boundary: Optional[Path],
+    is_excluded: Callable[[Path], bool],
+) -> bool:
+    """Whether *path* or any ancestor within *boundary* is excluded."""
+    current = path
+    resolved_boundary = safe_resolve(boundary) if boundary is not None else None
+    while True:
+        if is_excluded(current):
+            return True
+        if boundary is not None and current == boundary:
+            break
+        if resolved_boundary is not None and current == resolved_boundary:
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return False

--- a/tests/fixtures/config/exclude-conventional-skill-root/.claude/settings.json
+++ b/tests/fixtures/config/exclude-conventional-skill-root/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write"]
+  }
+}

--- a/tests/fixtures/config/exclude-conventional-skill-root/.claude/skills/demo/SKILL.md
+++ b/tests/fixtures/config/exclude-conventional-skill-root/.claude/skills/demo/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: demo-helper
+description: Helper for demonstration workflows.
+---
+
+# Demo Helper
+
+Run the demonstration workflow for local testing.
+
+## Instructions
+
+Follow the steps to execute the workflow.

--- a/tests/fixtures/config/exclude-conventional-skill-root/.skillsaw.yaml
+++ b/tests/fixtures/config/exclude-conventional-skill-root/.skillsaw.yaml
@@ -1,0 +1,3 @@
+version: "0.20.0"
+exclude:
+  - ".claude/skills"

--- a/tests/fixtures/config/exclude-conventional-skill-root/CLAUDE.md
+++ b/tests/fixtures/config/exclude-conventional-skill-root/CLAUDE.md
@@ -1,0 +1,8 @@
+# Project Guidelines
+
+Guidelines for contributing to the repository.
+
+## Development
+
+- Run tests before submitting changes.
+- Keep configuration clean and documented.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -766,6 +766,47 @@ def test_excluded_devin_tree_does_not_drive_detection_or_attachment(temp_dir):
     assert context.lint_tree.find(DevinRuleBlock) == []
 
 
+def test_exact_directory_exclude_on_conventional_skill_root(temp_dir):
+    """Exact directory exclude on a conventional skill root prevents discovery and agentskills type."""
+    demo_skill = temp_dir / ".claude" / "skills" / "demo"
+    demo_skill.mkdir(parents=True)
+    (demo_skill / "SKILL.md").write_text("---\nname: demo\ndescription: A demo skill.\n---\n")
+
+    context = RepositoryContext(temp_dir, exclude_patterns=[".claude/skills"])
+
+    assert RepositoryType.AGENTSKILLS not in context.repo_types
+    assert context.skills == []
+
+
+def test_ancestor_directory_exclude_on_conventional_skill_root(temp_dir):
+    """Excluding an ancestor directory suppresses conventional skills beneath it."""
+    demo_skill = temp_dir / ".claude" / "skills" / "demo"
+    demo_skill.mkdir(parents=True)
+    (demo_skill / "SKILL.md").write_text("---\nname: demo\ndescription: A demo skill.\n---\n")
+
+    context = RepositoryContext(temp_dir, exclude_patterns=[".claude"])
+
+    assert RepositoryType.AGENTSKILLS not in context.repo_types
+    assert context.skills == []
+
+
+def test_post_init_exclude_mutation_drops_skills_and_agentskills_type(temp_dir):
+    """Mutating exclude_patterns after construction prunes skills and drops AGENTSKILLS."""
+    demo_skill = temp_dir / ".claude" / "skills" / "demo"
+    demo_skill.mkdir(parents=True)
+    (demo_skill / "SKILL.md").write_text("---\nname: demo\ndescription: A demo skill.\n---\n")
+
+    context = RepositoryContext(temp_dir)
+    assert RepositoryType.AGENTSKILLS in context.repo_types
+    assert len(context.skills) == 1
+
+    context.exclude_patterns = [".claude/skills"]
+    context.apply_excludes()
+
+    assert RepositoryType.AGENTSKILLS not in context.repo_types
+    assert context.skills == []
+
+
 def test_detects_cursor_rules_dir(temp_dir):
     """Detect .cursor/rules/ directory"""
     (temp_dir / ".cursor" / "rules").mkdir(parents=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4433,6 +4433,17 @@ class TestConfigFeatures:
         violated_files = {v["file_path"] for v in violations(r)}
         assert not any("generated.md" in f for f in violated_files)
 
+    def test_exact_directory_exclude_covers_conventional_skill_root(self, tmp_path):
+        """Exact directory exclude on a conventional skill root suppresses its skills (issue #581)."""
+        repo = copy_fixture("config/exclude-conventional-skill-root", tmp_path)
+        r = run_lint(repo)
+        assert r["out"] is not None
+        assert r["rc"] == 0
+        assert r["out"]["stats"]["skills"] == []
+        assert "agentskills" not in r["out"]["stats"]["repo_types"]
+        violated_files = {v["file_path"] for v in violations(r)}
+        assert not any(".claude/skills" in f for f in violated_files)
+
     def test_default_exclude_covers_top_level_templates(self, tmp_path):
         """Default **/templates/** must exclude a templates/ dir at the repo
         root, not just nested ones (issue #322)."""


### PR DESCRIPTION
## Summary
When an exact directory exclude pattern like `.claude/skills` (or `.grok/skills`, `.devin/skills`, etc.) is specified in configuration, `discover_skills()` and `is_agentskills_repo()` did not check whether the conventional/additional skill root or its ancestors were excluded before walking into them. The per-child check within the walk would evaluate `.claude/skills/demo`, which did not match the exact pattern `.claude/skills`, causing the nested skill to be discovered, attached, and linted, and the repository to be classified as `agentskills`.

## Changes
- **Ancestor & root exclusion helper**: Added `is_root_or_ancestor_excluded(path, boundary, is_excluded)` in `skillsaw.discovery.excludes` to check exclusions along the path hierarchy up to `boundary` without extra path allocations.
- **Skill discovery**: In `skillsaw.discovery.claude.discover_skills()`, check `not is_root_or_ancestor_excluded(path, repo_root, is_excluded)` before entering conventional and additional skill roots, and skip excluded items and `SKILL.md` files.
- **Agent skills repo detection**: In `skillsaw.discovery.detect`, check root and ancestor exclusions before probing conventional or extra skill roots for `SKILL.md`.
- **Exclude application**: In `RepositoryContext.apply_excludes()`, filter `self.skills` against root and ancestor exclusions, and discard `RepositoryType.AGENTSKILLS` when all skills are excluded and types were not explicitly overridden.
- **Tests & Fixtures**:
  - Added static fixture `tests/fixtures/config/exclude-conventional-skill-root`.
  - Added unit tests in `tests/test_context.py` verifying exact directory excludes, ancestor directory excludes, and post-init exclude mutations.
  - Added integration test `test_exact_directory_exclude_covers_conventional_skill_root` in `tests/test_integration.py`.

Closes #581

---
Generated by the [skillsaw-issue-solver](https://github.com/stbenjam/skillsaw) skill.