### PR TITLE
[Auto] Report skipped symlink autofixes

### DIFF
--- a/docs/autofixing.md
+++ b/docs/autofixing.md
@@ -38,8 +38,8 @@ Summary:
   [*] 1 violation(s) fixable with `skillsaw fix` ([?] 1 more with `skillsaw fix --suggest`)
 ```
 
-- `[*]` — a **SAFE** fix exists; `skillsaw fix` resolves it.
-- `[?]` — a **SUGGEST** fix exists; it is only applied with `skillsaw fix --suggest`.
+- `[*]` — the rule declares a **SAFE** fix, eligible for `skillsaw fix`.
+- `[?]` — the rule declares a **SUGGEST** fix, requiring `skillsaw fix --suggest`.
 
 Autofix never rewrites vendor-managed plugins under `.codex/plugins/`, even
 when a rule reports a finding there. It likewise never rewrites externally
@@ -50,13 +50,26 @@ remain diagnostic even when `lint-external-content` is left at its default
 
 Symbolic-link files are also diagnostic-only for autofix. Lint does not mark
 these findings as fixable. When a selected fix would change a symbolic link,
-`skillsaw fix` and `--dry-run` list the skipped path and explain why; edit the
-target file directly instead. Skips are reported once per path and reason,
+`skillsaw fix` and `--dry-run` list the skipped path and explain why. For a
+content edit, edit the target file directly. For a rename, manually remove,
+replace, or rename the symbolic link. Skips are reported once per path and reason,
 within the selected severity and confidence, and do not prevent independent
 regular-file fixes. A policy-only skip exits successfully; a failed write
 still exits nonzero. Dry-run never writes files or runs fix callbacks.
 
-The JSON format carries an additive `fixable` boolean (plus `fix_confidence`: `safe` or `suggest` when fixable) on each violation — whether a deterministic fix exists, even for findings `skillsaw lint` does not show by default; a consumer deciding what a plain fix run repairs should also check `severity`. Fixability is per violation, not per rule — a rule that can only fix some shapes of a problem (e.g. `content-unlinked-internal-reference` only wraps references whose target file exists) marks only those violations. Because `skillsaw fix` batches several violations into one fix per file, its `Fixed N issue(s)` count can differ from the number of marked violations.
+The JSON format carries an additive `fixable` boolean, plus `fix_confidence`
+(`safe` or `suggest`) when fixable. These fields describe declared deterministic
+fix support after known path policies: vendor-managed, external, diagnostic-only
+and symbolic-link findings have their fixability and confidence cleared. They
+do not guarantee application; proposal generation and final filesystem checks
+can still skip a fix, including a rename involving another symbolic-link path.
+Metadata also covers findings hidden by the default severity threshold, so a
+consumer deciding what a plain fix run repairs should check `severity`.
+
+Fixability is per violation, not per rule: for example,
+`content-unlinked-internal-reference` marks only references whose target exists.
+Because `skillsaw fix` batches several violations into one fix per file, its
+`Fixed N issue(s)` count can differ from the number of marked violations.
 
 !!! note "Removed in 0.15"
     The deprecated `skillsaw lint --fix` flag was removed. `skillsaw fix` is the single entry point for autofixes.

--- a/docs/autofixing.md
+++ b/docs/autofixing.md
@@ -48,6 +48,14 @@ skills installed from external `skills-lock.json` sources; those findings
 remain diagnostic even when `lint-external-content` is left at its default
 `true`.
 
+Symbolic-link files are also diagnostic-only for autofix. Lint does not mark
+these findings as fixable. When a selected fix would change a symbolic link,
+`skillsaw fix` and `--dry-run` list the skipped path and explain why; edit the
+target file directly instead. Skips are reported once per path and reason,
+within the selected severity and confidence, and do not prevent independent
+regular-file fixes. A policy-only skip exits successfully; a failed write
+still exits nonzero. Dry-run never writes files or runs fix callbacks.
+
 The JSON format carries an additive `fixable` boolean (plus `fix_confidence`: `safe` or `suggest` when fixable) on each violation — whether a deterministic fix exists, even for findings `skillsaw lint` does not show by default; a consumer deciding what a plain fix run repairs should also check `severity`. Fixability is per violation, not per rule — a rule that can only fix some shapes of a problem (e.g. `content-unlinked-internal-reference` only wraps references whose target file exists) marks only those violations. Because `skillsaw fix` batches several violations into one fix per file, its `Fixed N issue(s)` count can differ from the number of marked violations.
 
 !!! note "Removed in 0.15"

--- a/docs/autofixing.md
+++ b/docs/autofixing.md
@@ -52,10 +52,19 @@ Symbolic-link files are also diagnostic-only for autofix. Lint does not mark
 these findings as fixable. When a selected fix would change a symbolic link,
 `skillsaw fix` and `--dry-run` list the skipped path and explain why. For a
 content edit, edit the target file directly. For a rename, manually remove,
-replace, or rename the symbolic link. Skips are reported once per path and reason,
-within the selected severity and confidence, and do not prevent independent
-regular-file fixes. A policy-only skip exits successfully; a failed write
+replace, or rename the symbolic link. Skips for discovered findings are reported
+once per path and reason, within the selected severity and confidence, and do
+not prevent independent regular-file fixes. A policy-only skip exits successfully; a failed write
 still exits nonzero. Dry-run never writes files or runs fix callbacks.
+
+Explicit file and directory symlinks passed to `skillsaw fix` are skipped
+before CLI path resolution, including dangling links. Name the real file or
+directory directly to select it. Other explicitly selected roots still run;
+this leaf check does not redefine paths through ancestor directory aliases.
+
+A fix can also update supporting metadata. If that follow-up write fails after
+the primary edit, the command reports partial completion and exits nonzero;
+the already applied edit is retained.
 
 The JSON format carries an additive `fixable` boolean, plus `fix_confidence`
 (`safe` or `suggest`) when fixable. These fields describe declared deterministic

--- a/docs/autofixing.md
+++ b/docs/autofixing.md
@@ -55,7 +55,9 @@ content edit, edit the target file directly. For a rename, manually remove,
 replace, or rename the symbolic link. Skips for discovered findings are reported
 once per path and reason, within the selected severity and confidence, and do
 not prevent independent regular-file fixes. A policy-only skip exits successfully; a failed write
-still exits nonzero. Dry-run never writes files or runs fix callbacks.
+still exits nonzero. Dry-run does not apply proposed fixes or run fix callbacks. Existing rename
+bookkeeping can still prune stale entries while checking; dry-run is not yet
+a fully read-only operation.
 
 Explicit file and directory symlinks passed to `skillsaw fix` are skipped
 before CLI path resolution, including dangling links. Name the real file or

--- a/src/skillsaw/cli/_fix.py
+++ b/src/skillsaw/cli/_fix.py
@@ -49,6 +49,7 @@ def _run_fix(args):
     applied = []
     suggested = []
     failed = []
+    skipped = {}
     deprecation_messages = []
     for fix_path in paths:
         context = RepositoryContext(
@@ -83,6 +84,7 @@ def _run_fix(args):
         # The rename pass below replaces the linter; keep the first pass's
         # failed writes or a partial fix could still report success.
         path_failures = list(linter.fix_failures)
+        path_skips = list(linter.fix_skips)
 
         if not dry_run and any(f.rule_id == "agentskill-name" for f in path_applied):
             context = RepositoryContext(
@@ -105,10 +107,13 @@ def _run_fix(args):
             path_applied.extend(rename_applied)
             path_suggested.extend(rename_suggested)
             path_failures.extend(linter.fix_failures)
+            path_skips.extend(linter.fix_skips)
 
         applied.extend((f, context.root_path) for f in path_applied)
         suggested.extend((f, context.root_path) for f in path_suggested)
         failed.extend((f, error, context.root_path) for f, error in path_failures)
+        for path, reason in path_skips:
+            skipped.setdefault((path, reason), context.root_path)
 
         # fix output only lists fixes, so the deprecation notices carried in
         # the violations list would otherwise never reach the user.
@@ -153,7 +158,7 @@ def _run_fix(args):
                     else:
                         print(f"      {line}")
                 print(f"      {c['dim']}{'─' * 40}{c['reset']}")
-    elif not failed:
+    elif not failed and not skipped:
         if suggested:
             print("No safe fixes found.")
         else:
@@ -166,7 +171,12 @@ def _run_fix(args):
         print("\nRun `skillsaw fix --suggest` to apply suggested fixes.")
         print("Run `skillsaw fix --suggest --dry-run` to preview changes.")
 
-    if dry_run and applied:
+    if skipped:
+        print(f"\nSkipped {len(skipped)} path(s):")
+        for (path, reason), root in skipped.items():
+            print(f"  - [{_display(path, root)}] {reason}")
+
+    if dry_run and (applied or skipped):
         print(f"\n{c['yellow']}dry-run — no files were modified{c['reset']}")
 
     if applied and not dry_run:

--- a/src/skillsaw/cli/_fix.py
+++ b/src/skillsaw/cli/_fix.py
@@ -26,22 +26,35 @@ def _rel(path, root):
 
 
 def _run_fix(args):
-    missing = [p for p in args.path if not p.exists()]
-    for p in missing:
-        print(f"Error: Path not found: {p}", file=sys.stderr)
-    if missing:
-        sys.exit(1)
-
-    paths = _resolve_lint_paths(args.path)
-
-    config, _config_path = load_config(args, paths[0])
-    severity_threshold = resolve_fix_level(args, config)
-
     rule_ids = set(args.rule_ids) if args.rule_ids else None
     skip_rule_ids = set(args.skip_rule_ids) if args.skip_rule_ids else None
     if rule_ids and skip_rule_ids:
         print("Error: --rule and --skip-rule cannot be combined", file=sys.stderr)
         sys.exit(1)
+
+    # Resolving a named leaf symlink erases the identity needed by the
+    # autofix policy. Admit inputs before resolving them, including dangling
+    # links and directory links, while retaining independently named roots.
+    admitted = []
+    input_skips = {}
+    for path in args.path:
+        skip = Linter._symlink_skip(path)
+        if skip is None:
+            admitted.append(path)
+        else:
+            input_skips.setdefault(skip, skip[0].parent)
+
+    missing = [p for p in admitted if not p.exists()]
+    for p in missing:
+        print(f"Error: Path not found: {p}", file=sys.stderr)
+    if missing:
+        sys.exit(1)
+
+    paths = _resolve_lint_paths(admitted)
+
+    if paths:
+        config, _config_path = load_config(args, paths[0])
+        severity_threshold = resolve_fix_level(args, config)
 
     dry_run = getattr(args, "dry_run", False)
     confidence = AutofixConfidence.SUGGEST if args.suggest else AutofixConfidence.SAFE
@@ -49,7 +62,7 @@ def _run_fix(args):
     applied = []
     suggested = []
     failed = []
-    skipped = {}
+    skipped = dict(input_skips)
     deprecation_messages = []
     for fix_path in paths:
         context = RepositoryContext(
@@ -132,7 +145,7 @@ def _run_fix(args):
     # Multi-root runs keep absolute paths — the same relative name in two
     # repos (e.g. CLAUDE.md) would be ambiguous.
     def _display(file_path, root):
-        return _rel(file_path, root) if len(paths) == 1 else file_path
+        return _rel(file_path, root) if len(paths) == 1 and not input_skips else file_path
 
     if applied:
         label = "Would fix" if dry_run else "Fixed"
@@ -183,10 +196,9 @@ def _run_fix(args):
         print("\nRun `skillsaw lint` to see remaining issues.")
 
     if failed:
-        # A write that failed is not a fix that was applied. Say so, and
-        # exit non-zero: "No auto-fixable violations found." over a
-        # read-only tree was a lie the exit code agreed with.
-        print(f"\n{c['red']}Failed to apply {len(failed)} fix(es):{c['reset']}", file=sys.stderr)
+        # Primary writes can fail, or a supporting write can fail after the
+        # primary edit applied. Both need a visible nonzero outcome.
+        print(f"\n{c['red']}Failed to complete {len(failed)} fix(es):{c['reset']}", file=sys.stderr)
         for fix, error, root in failed:
             print(
                 f"  ✗ [{_display(fix.file_path, root)}] {fix.description}: {error}", file=sys.stderr

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -1501,7 +1501,7 @@ class Linter:
         Returns:
             Tuple of (applied fixes, suggested-but-not-applied fixes).
         """
-        #: (fix, error) for every write that failed in this run; the CLI
+        #: (fix, error) for every write or follow-up that failed in this run; the CLI
         #: reports them and exits non-zero rather than claiming success.
         self.fix_failures: List[Tuple[AutofixResult, str]] = []
         #: Selected paths refused by policy, separate from failed writes.
@@ -1589,10 +1589,10 @@ class Linter:
                         (SAFE = only safe,
                          SUGGEST = safe + suggest)
             root_path: Trusted repository boundary for atomic writes
-            failures: When given, every fix whose write failed is appended
-                      with the OS error text, so a caller can report it
-                      instead of announcing success over a file it never
-                      changed
+            failures: When given, every fix whose write or post-apply step
+                      failed is appended with the OS error text. A primary edit
+                      whose follow-up failed remains in the applied results,
+                      with an explicit partial-failure message here.
             skips: Optional collector for selected path/policy refusals
 
         Returns:
@@ -1675,6 +1675,8 @@ class Linter:
                         fix.file_path,
                         exc,
                     )
+                    if failures is not None:
+                        failures.append((fix, f"File edit applied, but follow-up failed: {exc}"))
 
             applied.append(fix)
 

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -1171,6 +1171,13 @@ class Linter:
         fix() masks that metadata before returning it to callers.
         """
         kept: List[RuleViolation] = []
+        symlink_status: Dict[Optional[Path], bool] = {}
+
+        def _is_symlink(file_path: Optional[Path]) -> bool:
+            if file_path not in symlink_status:
+                symlink_status[file_path] = self._symlink_skip(file_path) is not None
+            return symlink_status[file_path]
+
         for v in violations:
             if self._is_excluded(v):
                 logger.info(
@@ -1213,11 +1220,7 @@ class Linter:
                 self._is_on_external_source(v)
                 or self._is_vendor_managed(v.file_path)
                 or (v.block is not None and v.block.diagnostic_only)
-                or (
-                    not preserve_symlink_fixability
-                    and v.fixable
-                    and self._symlink_skip(v.file_path) is not None
-                )
+                or (not preserve_symlink_fixability and v.fixable and _is_symlink(v.file_path))
             ):
                 # Still reported — hostile third-party content is worth
                 # knowing about — but never advertised as fixable, because

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -11,6 +11,7 @@ import hashlib
 import importlib.util
 import inspect
 import logging
+import os
 import re
 import sys
 import warnings
@@ -1143,8 +1144,22 @@ class Linter:
             self._vendor_managed_cache[file_path] = cached
         return cached
 
+    @staticmethod
+    def _symlink_skip(
+        file_path: Optional[Path], rename_from: Optional[Path] = None
+    ) -> Optional[Tuple[Path, str]]:
+        """Fresh leaf-only refusal, retaining the selected path for reporting."""
+        for path in (file_path, rename_from):
+            if path is not None and safe_is_symlink(path):
+                return Path(os.path.abspath(path)), "symbolic link; edit its target directly"
+        return None
+
     def _filter_violations(
-        self, violations: List[RuleViolation], record_baseline: bool = True
+        self,
+        violations: List[RuleViolation],
+        record_baseline: bool = True,
+        *,
+        preserve_symlink_fixability: bool = False,
     ) -> List[RuleViolation]:
         """Filter violations by global excludes, per-rule excludes, and inline suppression.
 
@@ -1152,6 +1167,8 @@ class Linter:
         but stale/suppressed accounting is left untouched — used for the
         per-rule calls in :meth:`fix`, which would otherwise overwrite the
         accounting with only the last rule's view of the baseline.
+        ``preserve_symlink_fixability`` is private to proposal generation;
+        fix() masks that metadata before returning it to callers.
         """
         kept: List[RuleViolation] = []
         for v in violations:
@@ -1196,6 +1213,11 @@ class Linter:
                 self._is_on_external_source(v)
                 or self._is_vendor_managed(v.file_path)
                 or (v.block is not None and v.block.diagnostic_only)
+                or (
+                    not preserve_symlink_fixability
+                    and v.fixable
+                    and self._symlink_skip(v.file_path) is not None
+                )
             ):
                 # Still reported — hostile third-party content is worth
                 # knowing about — but never advertised as fixable, because
@@ -1344,7 +1366,14 @@ class Linter:
                     continue
 
                 checked.extend(rule_violations)
-                visible = self._filter_violations(rule_violations, record_baseline=False)
+                # Some fixers use declared fixability to form their proposal.
+                # Keep it privately until the proposal supplies its confidence;
+                # public findings are masked again below.
+                visible = self._filter_violations(
+                    rule_violations,
+                    record_baseline=False,
+                    preserve_symlink_fixability=True,
+                )
 
                 # Diagnostic-only blocks never reach a fixer at all. Clearing
                 # their fixability metadata is presentation; a third-party rule's
@@ -1380,6 +1409,11 @@ class Linter:
                         all_violations.extend(visible)
                 else:
                     all_violations.extend(visible)
+
+                for violation in visible:
+                    if violation.fixable and self._symlink_skip(violation.file_path) is not None:
+                        violation.fixable = False
+                        violation.fix_confidence = None
 
             _ = self.context.lint_tree
             all_violations.extend(self._lint_tree_error_violations())
@@ -1457,6 +1491,8 @@ class Linter:
         #: (fix, error) for every write that failed in this run; the CLI
         #: reports them and exits non-zero rather than claiming success.
         self.fix_failures: List[Tuple[AutofixResult, str]] = []
+        #: Selected paths refused by policy, separate from failed writes.
+        self.fix_skips: List[Tuple[Path, str]] = []
         from .rules.builtin.utils import invalidate_read_caches
 
         all_applied: List[AutofixResult] = []
@@ -1471,9 +1507,16 @@ class Linter:
             if not fixes:
                 break
 
-            applicable = [f for f in fixes if f.confidence in allowed]
-            suggested = [f for f in fixes if f.confidence not in allowed]
-            all_suggested.extend(suggested)
+            applicable = []
+            for fix in fixes:
+                skip = self._symlink_skip(fix.file_path, fix.rename_from)
+                if skip is not None:
+                    if fix.confidence in allowed:
+                        self.fix_skips.append(skip)
+                elif fix.confidence in allowed:
+                    applicable.append(fix)
+                else:
+                    all_suggested.append(fix)
 
             if not applicable:
                 break
@@ -1489,6 +1532,7 @@ class Linter:
                 confidence,
                 root_path=self.context.root_path,
                 failures=self.fix_failures,
+                skips=self.fix_skips,
             )
             all_applied.extend(applied)
 
@@ -1512,6 +1556,7 @@ class Linter:
             if not (has_conflicts or state_changed):
                 break
 
+        self.fix_skips = list(dict.fromkeys(self.fix_skips))
         return all_applied, all_suggested
 
     @staticmethod
@@ -1520,6 +1565,7 @@ class Linter:
         confidence: AutofixConfidence = AutofixConfidence.SAFE,
         root_path: Optional[Path] = None,
         failures: Optional[List[Tuple[AutofixResult, str]]] = None,
+        skips: Optional[List[Tuple[Path, str]]] = None,
     ) -> List[AutofixResult]:
         """
         Write fix results to disk.
@@ -1534,6 +1580,7 @@ class Linter:
                       with the OS error text, so a caller can report it
                       instead of announcing success over a file it never
                       changed
+            skips: Optional collector for selected path/policy refusals
 
         Returns:
             List of fixes that were actually applied
@@ -1550,10 +1597,11 @@ class Linter:
             # A target may be swapped for a symlink after discovery or
             # between fixed-point passes. Re-check at the write boundary so
             # autofix never follows it outside the repository.
-            if safe_is_symlink(fix.file_path) or (
-                fix.rename_from is not None and safe_is_symlink(fix.rename_from)
-            ):
-                logger.warning("Skipping autofix for symlinked path: %s", fix.file_path)
+            skip = Linter._symlink_skip(fix.file_path, fix.rename_from)
+            if skip is not None:
+                logger.warning("Skipping autofix for symlinked path: %s", skip[0])
+                if skips is not None:
+                    skips.append(skip)
                 continue
 
             try:

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -1399,6 +1399,11 @@ class Linter:
                                 or not self._is_external_source_path(f.rename_from)
                             )
                         ]
+                        for fix in fixes:
+                            if self._symlink_skip(fix.file_path, fix.rename_from) is not None:
+                                for violation in fix.violations_fixed:
+                                    violation.fixable = False
+                                    violation.fix_confidence = None
                         all_fixes.extend(fixes)
                         fixed_violations = {id(v) for fix in fixes for v in fix.violations_fixed}
                         remaining = [v for v in visible if id(v) not in fixed_violations]

--- a/src/skillsaw/linter.py
+++ b/src/skillsaw/linter.py
@@ -1151,7 +1151,12 @@ class Linter:
         """Fresh leaf-only refusal, retaining the selected path for reporting."""
         for path in (file_path, rename_from):
             if path is not None and safe_is_symlink(path):
-                return Path(os.path.abspath(path)), "symbolic link; edit its target directly"
+                remedy = (
+                    "remove, replace, or rename the symbolic link manually"
+                    if rename_from is not None
+                    else "edit its target directly"
+                )
+                return Path(os.path.abspath(path)), f"symbolic link; {remedy}"
         return None
 
     def _filter_violations(

--- a/src/skillsaw/rules/builtin/agentskills/_helpers.py
+++ b/src/skillsaw/rules/builtin/agentskills/_helpers.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
 from skillsaw.context import SKILL_REPO_TYPES  # noqa: F401  — re-export for package rules
-from skillsaw.paths import contained_resolve, safe_exists
+from skillsaw.paths import contained_resolve, safe_exists, safe_is_symlink
+from skillsaw.utils import write_bytes_atomic
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime
     from skillsaw.context import RepositoryContext
@@ -96,13 +97,16 @@ def _read_renames_manifest(root: Path) -> list[dict]:
 
 def _write_renames_manifest(root: Path, renames: list[dict]) -> None:
     path = root / RENAMES_MANIFEST
+    if safe_is_symlink(path):
+        raise OSError(f"Refusing to write through symlink: {path}")
     if not renames:
         if path.exists():
             path.unlink()
         return
-    path.write_text(
-        json.dumps({"renames": renames}, indent=2) + "\n",
-        encoding="utf-8",
+    write_bytes_atomic(
+        path,
+        (json.dumps({"renames": renames}, indent=2) + "\n").encode("utf-8"),
+        root=root,
     )
 
 

--- a/src/skillsaw/rules/builtin/agentskills/rename_refs.py
+++ b/src/skillsaw/rules/builtin/agentskills/rename_refs.py
@@ -134,7 +134,12 @@ class AgentSkillRenameRefsRule(Rule):
             current = _read_renames_manifest(context.root_path)
             still_active = [r for r in current if r["old"] in referenced_olds]
             if len(still_active) < len(current):
-                _write_renames_manifest(context.root_path, still_active)
+                try:
+                    _write_renames_manifest(context.root_path, still_active)
+                except OSError:
+                    # Optional bookkeeping must not discard the findings above.
+                    # Required rename callbacks still report their write failures.
+                    pass
 
         return violations
 

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -3,6 +3,7 @@ Tests for the autofix framework infrastructure
 """
 
 import json
+import os
 import shutil
 from pathlib import Path
 from typing import List
@@ -422,6 +423,36 @@ class TestApplyFixes:
         applied = Linter.apply_fixes([fix])
         assert len(applied) == 1
         assert target.read_text() == "fixed"
+
+    def test_callback_failure_retains_applied_edits_and_reports_partial_failure(self, temp_dir):
+        target = temp_dir / "first.txt"
+        other = temp_dir / "second.txt"
+        target.write_text("first original")
+        other.write_text("second original")
+
+        def refuse_metadata():
+            raise OSError("Metadata write refused")
+
+        fixes = [
+            AutofixResult(
+                rule_id="test",
+                file_path=path,
+                confidence=AutofixConfidence.SAFE,
+                original_content=path.read_text(),
+                fixed_content="updated",
+                description="Update note",
+                on_apply=refuse_metadata if path == target else None,
+            )
+            for path in (target, other)
+        ]
+        failures = []
+        applied = Linter.apply_fixes(fixes, root_path=temp_dir, failures=failures)
+
+        assert applied == fixes
+        assert target.read_text() == other.read_text() == "updated"
+        assert failures == [
+            (fixes[0], "File edit applied, but follow-up failed: Metadata write refused")
+        ]
 
     def test_apply_refuses_symlink_target(self, temp_dir, caplog):
         victim = temp_dir / "victim.txt"
@@ -1009,6 +1040,55 @@ class TestCommandRenameFix:
         assert len(applied) == 1
         assert applied[0].rule_id == "b"
         assert good_target.read_text() == "fixed"
+
+
+class TestRenameManifest:
+    def test_metadata_merge_uses_anchored_writer_and_retains_json_bytes(
+        self, tmp_path, monkeypatch
+    ):
+        from skillsaw.rules.builtin.agentskills import _helpers
+
+        path = tmp_path / _helpers.RENAMES_MANIFEST
+        retained = {"old": "earlier", "new": "current", "note": "retain this"}
+        path.write_text(json.dumps({"renames": [retained, {"old": "before", "new": "stale"}]}))
+        calls = []
+        original = _helpers.write_bytes_atomic
+
+        def record(destination, data, *, root):
+            calls.append((destination, data, root))
+            original(destination, data, root=root)
+
+        monkeypatch.setattr(_helpers, "write_bytes_atomic", record)
+        _helpers._add_rename(tmp_path, "before", "after")
+        expected = (
+            json.dumps({"renames": [retained, {"old": "before", "new": "after"}]}, indent=2) + "\n"
+        ).encode("utf-8")
+        assert calls == [(path, expected, tmp_path)]
+        assert path.read_bytes() == expected
+        _helpers._add_rename(tmp_path, "before", "after")
+        assert path.read_bytes() == expected
+        assert len(calls) == 2
+        _helpers._write_renames_manifest(tmp_path, [])
+        assert not path.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
+    @pytest.mark.parametrize(
+        "renames", [[{"old": "before", "new": "after"}], []], ids=["update", "cleanup"]
+    )
+    def test_metadata_alias_is_refused_after_guard(self, tmp_path, renames):
+        from skillsaw.rules.builtin.agentskills import _helpers
+
+        original = b'{"renames": []}\n'
+        regular = tmp_path / "saved-renames.json"
+        regular.write_bytes(original)
+        path = tmp_path / _helpers.RENAMES_MANIFEST
+        path.symlink_to(regular.name)
+
+        with pytest.raises(OSError, match="Refusing to write through symlink"):
+            _helpers._write_renames_manifest(tmp_path, renames)
+
+        assert path.is_symlink()
+        assert regular.read_bytes() == original
 
 
 class TestSkillRenameRefsEndToEnd:

--- a/tests/test_autofix_skips.py
+++ b/tests/test_autofix_skips.py
@@ -1,9 +1,6 @@
 """Policy skips preserve diagnostics, previews and independent eligible fixes."""
 
-import json
 import os
-import shutil
-from pathlib import Path
 
 import pytest
 
@@ -11,24 +8,10 @@ from skillsaw.baseline import build_baseline
 from skillsaw.context import RepositoryContext
 from skillsaw.linter import Linter
 from skillsaw.rule import AutofixConfidence, AutofixResult, Rule, Severity
-from tests.cli_runner import run_cli
+from tests.test_integration import copy_autofix_skip_repo
 
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
-FIXTURES = Path(__file__).parent / "fixtures"
 RULE = "content-unlinked-internal-reference"
-
-
-def _copy_repo(tmp_path, name="repo", *, linked=True):
-    repo = tmp_path / name
-    shutil.copytree(FIXTURES / "autofix/unlinked-ref-multiple-paths", repo)
-    if linked:
-        (repo / "CLAUDE.md").rename(repo / "instructions.txt")
-        (repo / "CLAUDE.md").symlink_to("instructions.txt")
-    return repo
-
-
-def _cli(command, *args):
-    return run_cli([command, *args, "--no-custom-rules", "--no-plugins"])
 
 
 def _linter(repo, **kwargs):
@@ -37,53 +20,8 @@ def _linter(repo, **kwargs):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize("linked", [False, True], ids=["regular", "symlink"])
-def test_symlink_metadata_preview_and_fix_agree(tmp_path, linked):
-    repo = _copy_repo(tmp_path, linked=linked)
-    path = repo / "CLAUDE.md"
-    original = path.read_bytes()
-    report = _cli("lint", repo, "--rule", RULE, "--format", "json", "--verbose")
-    assert report.returncode == 0, report.stderr
-    findings = json.loads(report.stdout)["violations"]
-    assert len(findings) == 3
-    assert {v["file_path"] for v in findings} == {"CLAUDE.md"}
-    assert all(v["fixable"] is (not linked) for v in findings)
-    assert all(v.get("fix_confidence") == (None if linked else "safe") for v in findings)
-
-    preview = _cli("fix", repo, "--rule", RULE, "--dry-run")
-    assert preview.returncode == 0, preview.stderr
-    assert path.read_bytes() == original
-    assert "dry-run — no files were modified" in preview.stdout
-    result = _cli("fix", repo, "--rule", RULE)
-    assert result.returncode == 0, result.stderr
-    if linked:
-        for output in (preview.stdout, result.stdout):
-            assert "Skipped 1 path(s):" in output
-            assert "[CLAUDE.md] symbolic link; edit its target directly" in output
-            assert "Would fix" not in output and "Fixed " not in output
-            assert "No auto-fixable" not in output
-            assert "--- a/" not in output
-        assert path.is_symlink()
-        assert path.read_bytes() == original
-    else:
-        assert "Would fix 1 issue(s)" in preview.stdout
-        assert "Fixed 1 issue(s)" in result.stdout
-        assert "Skipped" not in result.stdout
-        assert path.read_bytes() != original
-        assert path.read_bytes().count(b"\n") == original.count(b"\n")
-        assert b"[docs/guide.md](docs/guide.md)" in path.read_bytes()
-        clean = _cli("lint", repo, "--rule", RULE, "--format", "json", "--verbose")
-        assert clean.returncode == 0, clean.stderr
-        assert json.loads(clean.stdout)["violations"] == []
-    after = path.read_bytes()
-    repeated = _cli("fix", repo, "--rule", RULE)
-    assert repeated.returncode == 0, repeated.stderr
-    assert path.read_bytes() == after
-
-
 def test_proposal_generation_does_not_leak_symlink_fixability(tmp_path):
-    repo = _copy_repo(tmp_path)
+    repo = copy_autofix_skip_repo(tmp_path)
     remaining, proposals = _linter(repo).fix()
     assert len(proposals) == 1
     assert len(proposals[0].violations_fixed) == 3
@@ -97,26 +35,8 @@ def test_proposal_generation_does_not_leak_symlink_fixability(tmp_path):
     assert all(not v.fixable and v.fix_confidence is None for v in remaining)
 
 
-@pytest.mark.integration
-def test_hidden_and_suppressed_findings_do_not_become_skips(tmp_path):
-    repo = _copy_repo(tmp_path)
-    (repo / ".skillsaw.yaml").write_text(f"rules:\n  {RULE}:\n    severity: info\n")
-    hidden = _cli("fix", repo)
-    assert hidden.returncode == 0, hidden.stderr
-    assert "Skipped" not in hidden.stdout
-    visible = _cli("fix", repo, "--rule", RULE)
-    assert visible.returncode == 0, visible.stderr
-    assert "Skipped 1 path(s):" in visible.stdout
-
-    target = repo / "instructions.txt"
-    target.write_text(f"<!-- skillsaw-disable {RULE} -->\n" + target.read_text())
-    suppressed = _cli("fix", repo, "--rule", RULE)
-    assert suppressed.returncode == 0, suppressed.stderr
-    assert "Skipped" not in suppressed.stdout
-
-
 def test_baselined_findings_do_not_become_skips(tmp_path):
-    repo = _copy_repo(tmp_path)
+    repo = copy_autofix_skip_repo(tmp_path)
     linter = _linter(repo)
     visible = linter.run()
     assert len(visible) == 3
@@ -314,56 +234,3 @@ def test_write_boundary_reports_newly_symlinked_rename_source(tmp_path):
     ]
     assert not proposal.file_path.exists()
     assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
-
-
-@pytest.mark.integration
-def test_two_roots_keep_distinct_lexical_skip_paths(tmp_path):
-    first = _copy_repo(tmp_path, "first")
-    second = _copy_repo(tmp_path, "second")
-    result = _cli("fix", first, second, "--rule", RULE)
-    assert result.returncode == 0, result.stderr
-    assert "Skipped 2 path(s):" in result.stdout
-    assert f"[{first / 'CLAUDE.md'}] symbolic link" in result.stdout
-    assert f"[{second / 'CLAUDE.md'}] symbolic link" in result.stdout
-
-
-@pytest.mark.integration
-def test_rename_followup_retains_and_deduplicates_skips(tmp_path, monkeypatch):
-    repo = _copy_repo(tmp_path)
-    shutil.copytree(FIXTURES / "autofix/fixable-accuracy-name/My_Skill", repo / "handoff")
-    calls = []
-    original = Linter.fix_and_apply
-
-    def record(self, *args, **kwargs):
-        result = original(self, *args, **kwargs)
-        calls.append(list(self.fix_skips))
-        return result
-
-    monkeypatch.setattr(Linter, "fix_and_apply", record)
-    result = _cli("fix", repo, "--rule", RULE, "--rule", "agentskill-name")
-    assert result.returncode == 0, result.stderr
-    assert len(calls) == 2 and all(calls)
-    assert "name: handoff" in (repo / "handoff/SKILL.md").read_text()
-    assert "Skipped 1 path(s):" in result.stdout
-    assert result.stdout.count("[CLAUDE.md] symbolic link") == 1
-
-
-@pytest.mark.integration
-def test_write_failure_still_fails_with_policy_skips(tmp_path, monkeypatch):
-    import skillsaw.linter as module
-
-    linked = _copy_repo(tmp_path, "linked")
-    regular = _copy_repo(tmp_path, "regular", linked=False)
-    original = (regular / "CLAUDE.md").read_bytes()
-
-    def refused(*args, **kwargs):
-        raise OSError("Test write refusal")
-
-    monkeypatch.setattr(module, "write_text_preserving", refused)
-    result = _cli("fix", linked, regular, "--rule", RULE)
-    assert result.returncode == 1
-    assert "Skipped 1 path(s):" in result.stdout
-    assert "Failed to apply 1 fix(es)" in result.stderr
-    assert "Test write refusal" in result.stderr
-    assert "Fixed " not in result.stdout and "No auto-fixable" not in result.stdout
-    assert (regular / "CLAUDE.md").read_bytes() == original

--- a/tests/test_autofix_skips.py
+++ b/tests/test_autofix_skips.py
@@ -200,6 +200,54 @@ def test_unselected_confidence_does_not_report_skips_or_unusable_suggestions(tmp
     assert len(linter.fix_skips) == 1
 
 
+@pytest.mark.parametrize("linked_source", [False, True], ids=["regular-source", "linked-source"])
+def test_rename_proposal_metadata_tracks_both_endpoints(tmp_path, linked_source):
+    class RenameRule(_AliasRule):
+        def check(self, context):
+            source = context.root_path / "notes.txt"
+            if not source.exists():
+                return []
+            return [
+                self.violation(
+                    "Rename note",
+                    file_path=source,
+                    fixable=True,
+                    fix_confidence=AutofixConfidence.SAFE,
+                )
+            ]
+
+        def fix(self, context, violations):
+            proposal = super().fix(context, violations)[0]
+            proposal.rename_from = context.root_path / (
+                "alias.txt" if linked_source else "notes.txt"
+            )
+            proposal.file_path = context.root_path / "renamed.txt"
+            return [proposal]
+
+    linter = _alias_linter(tmp_path)
+    linter.rules = [RenameRule()]
+    remaining, proposals = linter.fix()
+    assert remaining == [] and len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.confidence == AutofixConfidence.SAFE
+    assert len(proposal.violations_fixed) == 1
+    violation = proposal.violations_fixed[0]
+    assert violation.file_path == tmp_path / "notes.txt"
+    assert violation.fixable is (not linked_source)
+    assert violation.fix_confidence == (None if linked_source else AutofixConfidence.SAFE)
+    applied, suggested = linter.fix_and_apply()
+    assert suggested == []
+    if linked_source:
+        assert applied == []
+        assert [path for path, _ in linter.fix_skips] == [tmp_path / "alias.txt"]
+        assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
+        assert not (tmp_path / "renamed.txt").exists()
+    else:
+        assert len(applied) == 1 and linter.fix_skips == []
+        assert not (tmp_path / "notes.txt").exists()
+        assert (tmp_path / "renamed.txt").read_text() == "Updated note.\n"
+
+
 def test_write_boundary_reports_symlinked_rename_source(tmp_path):
     linter = _alias_linter(tmp_path)
     _remaining, proposals = linter.fix()

--- a/tests/test_autofix_skips.py
+++ b/tests/test_autofix_skips.py
@@ -1,0 +1,266 @@
+"""Policy skips preserve diagnostics, previews and independent eligible fixes."""
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from skillsaw.baseline import build_baseline
+from skillsaw.context import RepositoryContext
+from skillsaw.linter import Linter
+from skillsaw.rule import AutofixConfidence, AutofixResult, Rule, Severity
+from tests.cli_runner import run_cli
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
+FIXTURES = Path(__file__).parent / "fixtures"
+RULE = "content-unlinked-internal-reference"
+
+
+def _copy_repo(tmp_path, name="repo", *, linked=True):
+    repo = tmp_path / name
+    shutil.copytree(FIXTURES / "autofix/unlinked-ref-multiple-paths", repo)
+    if linked:
+        (repo / "CLAUDE.md").rename(repo / "instructions.txt")
+        (repo / "CLAUDE.md").symlink_to("instructions.txt")
+    return repo
+
+
+def _cli(command, *args):
+    return run_cli([command, *args, "--no-custom-rules", "--no-plugins"])
+
+
+def _linter(repo, **kwargs):
+    return Linter(
+        RepositoryContext(repo), rule_ids={RULE}, no_custom_rules=True, no_plugins=True, **kwargs
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("linked", [False, True], ids=["regular", "symlink"])
+def test_symlink_metadata_preview_and_fix_agree(tmp_path, linked):
+    repo = _copy_repo(tmp_path, linked=linked)
+    path = repo / "CLAUDE.md"
+    original = path.read_bytes()
+    report = _cli("lint", repo, "--rule", RULE, "--format", "json", "--verbose")
+    assert report.returncode == 0, report.stderr
+    findings = json.loads(report.stdout)["violations"]
+    assert len(findings) == 3
+    assert {v["file_path"] for v in findings} == {"CLAUDE.md"}
+    assert all(v["fixable"] is (not linked) for v in findings)
+    assert all(v.get("fix_confidence") == (None if linked else "safe") for v in findings)
+
+    preview = _cli("fix", repo, "--rule", RULE, "--dry-run")
+    assert preview.returncode == 0, preview.stderr
+    assert path.read_bytes() == original
+    assert "dry-run — no files were modified" in preview.stdout
+    result = _cli("fix", repo, "--rule", RULE)
+    assert result.returncode == 0, result.stderr
+    if linked:
+        for output in (preview.stdout, result.stdout):
+            assert "Skipped 1 path(s):" in output
+            assert "[CLAUDE.md] symbolic link" in output
+            assert "Would fix" not in output and "Fixed " not in output
+            assert "No auto-fixable" not in output
+            assert "--- a/" not in output
+        assert path.is_symlink()
+        assert path.read_bytes() == original
+    else:
+        assert "Would fix 1 issue(s)" in preview.stdout
+        assert "Fixed 1 issue(s)" in result.stdout
+        assert "Skipped" not in result.stdout
+        assert path.read_bytes() != original
+        assert path.read_bytes().count(b"\n") == original.count(b"\n")
+        assert b"[docs/guide.md](docs/guide.md)" in path.read_bytes()
+        clean = _cli("lint", repo, "--rule", RULE, "--format", "json", "--verbose")
+        assert clean.returncode == 0, clean.stderr
+        assert json.loads(clean.stdout)["violations"] == []
+    after = path.read_bytes()
+    repeated = _cli("fix", repo, "--rule", RULE)
+    assert repeated.returncode == 0, repeated.stderr
+    assert path.read_bytes() == after
+
+
+def test_proposal_generation_does_not_leak_symlink_fixability(tmp_path):
+    repo = _copy_repo(tmp_path)
+    remaining, proposals = _linter(repo).fix()
+    assert len(proposals) == 1
+    assert len(proposals[0].violations_fixed) == 3
+    assert proposals[0].confidence == AutofixConfidence.SAFE
+    assert all(
+        not v.fixable and v.fix_confidence is None
+        for v in [*remaining, *proposals[0].violations_fixed]
+    )
+    remaining, proposals = _linter(repo).fix(severity_threshold="error")
+    assert len(remaining) == 3 and proposals == []
+    assert all(not v.fixable and v.fix_confidence is None for v in remaining)
+
+
+@pytest.mark.integration
+def test_hidden_and_suppressed_findings_do_not_become_skips(tmp_path):
+    repo = _copy_repo(tmp_path)
+    (repo / ".skillsaw.yaml").write_text(f"rules:\n  {RULE}:\n    severity: info\n")
+    hidden = _cli("fix", repo)
+    assert hidden.returncode == 0, hidden.stderr
+    assert "Skipped" not in hidden.stdout
+    visible = _cli("fix", repo, "--rule", RULE)
+    assert visible.returncode == 0, visible.stderr
+    assert "Skipped 1 path(s):" in visible.stdout
+
+    target = repo / "instructions.txt"
+    target.write_text(f"<!-- skillsaw-disable {RULE} -->\n" + target.read_text())
+    suppressed = _cli("fix", repo, "--rule", RULE)
+    assert suppressed.returncode == 0, suppressed.stderr
+    assert "Skipped" not in suppressed.stdout
+
+
+def test_baselined_findings_do_not_become_skips(tmp_path):
+    repo = _copy_repo(tmp_path)
+    linter = _linter(repo)
+    visible = linter.run()
+    assert len(visible) == 3
+    baseline = build_baseline(visible, repo, "test")
+    baselined = _linter(repo, baseline=baseline)
+    assert baselined.fix_and_apply() == ([], [])
+    assert baselined.fix_skips == []
+    assert baselined.baseline_suppressed_count == 3
+
+
+class _AliasRule(Rule):
+    """Legacy rule: confidence is on results, not violation metadata."""
+
+    rule_id = "test-alias-proposals"
+    description = "Independent proposals for two names of one file"
+    result_confidence = AutofixConfidence.SAFE
+
+    def default_severity(self):
+        return Severity.WARNING
+
+    def check(self, context):
+        return [
+            self.violation("Update note", file_path=context.root_path / name)
+            for name in ("alias.txt", "notes.txt")
+        ]
+
+    def fix(self, context, violations):
+        return [
+            AutofixResult(
+                rule_id=self.rule_id,
+                file_path=v.file_path,
+                confidence=self.result_confidence,
+                original_content=v.file_path.read_text(),
+                fixed_content="Updated note.\n",
+                description="Update note",
+                violations_fixed=[v],
+            )
+            for v in violations
+        ]
+
+
+def _alias_linter(tmp_path):
+    (tmp_path / "notes.txt").write_text("Original note.\n")
+    (tmp_path / "alias.txt").symlink_to("notes.txt")
+    linter = Linter(RepositoryContext(tmp_path), no_custom_rules=True, no_plugins=True)
+    linter.rules = [_AliasRule()]
+    return linter
+
+
+def test_skipped_alias_does_not_reserve_eligible_target(tmp_path):
+    linter = _alias_linter(tmp_path)
+    applied, suggested = linter.fix_and_apply()
+    assert [fix.file_path for fix in applied] == [tmp_path / "notes.txt"]
+    assert suggested == []
+    assert [path for path, _ in linter.fix_skips] == [tmp_path / "alias.txt"]
+    assert (tmp_path / "notes.txt").read_text() == "Updated note.\n"
+    assert (tmp_path / "alias.txt").is_symlink()
+
+
+def test_nonfixable_symlink_diagnostic_is_not_a_skip(tmp_path):
+    class DiagnosticRule(_AliasRule):
+        fix = Rule.fix
+
+    linter = _alias_linter(tmp_path)
+    linter.rules = [DiagnosticRule()]
+    assert len(linter.run()) == 2
+    assert linter.fix_and_apply() == ([], [])
+    assert linter.fix_skips == []
+
+
+def test_unselected_confidence_does_not_report_skips_or_unusable_suggestions(tmp_path):
+    linter = _alias_linter(tmp_path)
+    linter.rules[0].result_confidence = AutofixConfidence.SUGGEST
+    applied, suggested = linter.fix_and_apply()
+    assert applied == []
+    assert [fix.file_path for fix in suggested] == [tmp_path / "notes.txt"]
+    assert linter.fix_skips == []
+    assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
+    applied, _ = linter.fix_and_apply(AutofixConfidence.SUGGEST)
+    assert [fix.file_path for fix in applied] == [tmp_path / "notes.txt"]
+    assert len(linter.fix_skips) == 1
+
+
+def test_write_boundary_reports_symlinked_rename_source(tmp_path):
+    linter = _alias_linter(tmp_path)
+    _remaining, proposals = linter.fix()
+    proposal = proposals[0]
+    proposal.rename_from = proposal.file_path
+    proposal.file_path = tmp_path / "renamed.txt"
+    skips = []
+    assert Linter.apply_fixes([proposal], skips=skips) == []
+    assert [path for path, _ in skips] == [tmp_path / "alias.txt"]
+    assert not proposal.file_path.exists()
+    assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
+
+
+@pytest.mark.integration
+def test_two_roots_keep_distinct_lexical_skip_paths(tmp_path):
+    first = _copy_repo(tmp_path, "first")
+    second = _copy_repo(tmp_path, "second")
+    result = _cli("fix", first, second, "--rule", RULE)
+    assert result.returncode == 0, result.stderr
+    assert "Skipped 2 path(s):" in result.stdout
+    assert f"[{first / 'CLAUDE.md'}] symbolic link" in result.stdout
+    assert f"[{second / 'CLAUDE.md'}] symbolic link" in result.stdout
+
+
+@pytest.mark.integration
+def test_rename_followup_retains_and_deduplicates_skips(tmp_path, monkeypatch):
+    repo = _copy_repo(tmp_path)
+    shutil.copytree(FIXTURES / "autofix/fixable-accuracy-name/My_Skill", repo / "handoff")
+    calls = []
+    original = Linter.fix_and_apply
+
+    def record(self, *args, **kwargs):
+        result = original(self, *args, **kwargs)
+        calls.append(list(self.fix_skips))
+        return result
+
+    monkeypatch.setattr(Linter, "fix_and_apply", record)
+    result = _cli("fix", repo, "--rule", RULE, "--rule", "agentskill-name")
+    assert result.returncode == 0, result.stderr
+    assert len(calls) == 2 and all(calls)
+    assert "name: handoff" in (repo / "handoff/SKILL.md").read_text()
+    assert "Skipped 1 path(s):" in result.stdout
+    assert result.stdout.count("[CLAUDE.md] symbolic link") == 1
+
+
+@pytest.mark.integration
+def test_write_failure_still_fails_with_policy_skips(tmp_path, monkeypatch):
+    import skillsaw.linter as module
+
+    linked = _copy_repo(tmp_path, "linked")
+    regular = _copy_repo(tmp_path, "regular", linked=False)
+    original = (regular / "CLAUDE.md").read_bytes()
+
+    def refused(*args, **kwargs):
+        raise OSError("Test write refusal")
+
+    monkeypatch.setattr(module, "write_text_preserving", refused)
+    result = _cli("fix", linked, regular, "--rule", RULE)
+    assert result.returncode == 1
+    assert "Skipped 1 path(s):" in result.stdout
+    assert "Failed to apply 1 fix(es)" in result.stderr
+    assert "Test write refusal" in result.stderr
+    assert "Fixed " not in result.stdout and "No auto-fixable" not in result.stdout
+    assert (regular / "CLAUDE.md").read_bytes() == original

--- a/tests/test_autofix_skips.py
+++ b/tests/test_autofix_skips.py
@@ -166,6 +166,48 @@ def _alias_linter(tmp_path):
     return linter
 
 
+def test_filter_reuses_symlink_status_only_within_one_call(tmp_path, monkeypatch):
+    import skillsaw.linter as module
+
+    linter = _alias_linter(tmp_path)
+    calls = []
+    original = module.safe_is_symlink
+
+    def record(path):
+        calls.append(path)
+        return original(path)
+
+    monkeypatch.setattr(module, "safe_is_symlink", record)
+
+    def findings():
+        return [
+            linter.rules[0].violation(
+                "Update note",
+                file_path=tmp_path / name,
+                fixable=True,
+                fix_confidence=AutofixConfidence.SAFE,
+            )
+            for name in ("alias.txt", "alias.txt", "notes.txt", "notes.txt")
+        ]
+
+    filtered = linter._filter_violations(findings())
+    assert calls == [tmp_path / "alias.txt", tmp_path / "notes.txt"]
+    assert [v.fixable for v in filtered] == [False, False, True, True]
+    assert [v.fix_confidence for v in filtered] == [
+        None,
+        None,
+        AutofixConfidence.SAFE,
+        AutofixConfidence.SAFE,
+    ]
+
+    (tmp_path / "alias.txt").unlink()
+    (tmp_path / "alias.txt").write_text("Independent note.\n")
+    calls.clear()
+    filtered = linter._filter_violations(findings())
+    assert calls == [tmp_path / "alias.txt", tmp_path / "notes.txt"]
+    assert all(v.fixable and v.fix_confidence == AutofixConfidence.SAFE for v in filtered)
+
+
 def test_skipped_alias_does_not_reserve_eligible_target(tmp_path):
     linter = _alias_linter(tmp_path)
     applied, suggested = linter.fix_and_apply()

--- a/tests/test_autofix_skips.py
+++ b/tests/test_autofix_skips.py
@@ -60,7 +60,7 @@ def test_symlink_metadata_preview_and_fix_agree(tmp_path, linked):
     if linked:
         for output in (preview.stdout, result.stdout):
             assert "Skipped 1 path(s):" in output
-            assert "[CLAUDE.md] symbolic link" in output
+            assert "[CLAUDE.md] symbolic link; edit its target directly" in output
             assert "Would fix" not in output and "Fixed " not in output
             assert "No auto-fixable" not in output
             assert "--- a/" not in output
@@ -281,7 +281,12 @@ def test_rename_proposal_metadata_tracks_both_endpoints(tmp_path, linked_source)
     assert suggested == []
     if linked_source:
         assert applied == []
-        assert [path for path, _ in linter.fix_skips] == [tmp_path / "alias.txt"]
+        assert linter.fix_skips == [
+            (
+                tmp_path / "alias.txt",
+                "symbolic link; remove, replace, or rename the symbolic link manually",
+            )
+        ]
         assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
         assert not (tmp_path / "renamed.txt").exists()
     else:
@@ -290,15 +295,23 @@ def test_rename_proposal_metadata_tracks_both_endpoints(tmp_path, linked_source)
         assert (tmp_path / "renamed.txt").read_text() == "Updated note.\n"
 
 
-def test_write_boundary_reports_symlinked_rename_source(tmp_path):
+def test_write_boundary_reports_newly_symlinked_rename_source(tmp_path):
     linter = _alias_linter(tmp_path)
+    alias = tmp_path / "alias.txt"
+    alias.unlink()
+    alias.write_text("Original alias note.\n")
     _remaining, proposals = linter.fix()
     proposal = proposals[0]
     proposal.rename_from = proposal.file_path
     proposal.file_path = tmp_path / "renamed.txt"
+    # The proposal was eligible, but the source changed before application.
+    alias.unlink()
+    alias.symlink_to("notes.txt")
     skips = []
     assert Linter.apply_fixes([proposal], skips=skips) == []
-    assert [path for path, _ in skips] == [tmp_path / "alias.txt"]
+    assert skips == [
+        (alias, "symbolic link; remove, replace, or rename the symbolic link manually")
+    ]
     assert not proposal.file_path.exists()
     assert (tmp_path / "notes.txt").read_text() == "Original note.\n"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7012,7 +7012,7 @@ class TestUnlinkedInternalReferenceAutofix:
             repo.chmod(0o755)
 
         assert result.returncode == 1
-        assert "Failed to apply 1 fix(es)" in result.stderr
+        assert "Failed to complete 1 fix(es)" in result.stderr
         assert "CLAUDE.md" in result.stderr
         assert "No auto-fixable violations found" not in result.stdout
         assert (repo / "CLAUDE.md").read_text() == before
@@ -7550,6 +7550,100 @@ def copy_autofix_skip_repo(tmp_path, name="repo", *, linked=True):
 @pytest.mark.integration
 @pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
 class TestAutofixSkips:
+    @pytest.mark.parametrize("kind", ["file", "directory", "dangling"])
+    @pytest.mark.parametrize("dry_run", [False, True], ids=["apply", "preview"])
+    def test_explicit_leaf_symlinks_stop_before_resolution(
+        self, tmp_path, monkeypatch, kind, dry_run
+    ):
+        from skillsaw.cli import _fix
+
+        repo = copy_autofix_skip_repo(tmp_path, linked=False)
+        target = repo if kind == "directory" else repo / "CLAUDE.md"
+        if kind == "dangling":
+            target = repo / "missing.md"
+        alias = tmp_path / "selected-link"
+        alias.symlink_to(target, target_is_directory=kind == "directory")
+        original = (repo / "CLAUDE.md").read_bytes()
+        resolver = _fix._resolve_lint_paths
+
+        def guarded_resolver(paths):
+            assert paths == [], "explicit alias reached path resolution"
+            return resolver(paths)
+
+        def unexpected_config(*args, **kwargs):
+            pytest.fail("all-skipped selections should not load repository configuration")
+
+        monkeypatch.setattr(_fix, "_resolve_lint_paths", guarded_resolver)
+        monkeypatch.setattr(_fix, "load_config", unexpected_config)
+        result = run_cli(["fix", alias, *(["--dry-run"] if dry_run else [])])
+        assert result.returncode == 0, result.stderr
+        assert "Skipped 1 path(s):" in result.stdout
+        assert f"[{alias}] symbolic link" in result.stdout
+        assert "Fixed " not in result.stdout and "Would fix" not in result.stdout
+        assert "No auto-fixable" not in result.stdout
+        assert ("dry-run — no files were modified" in result.stdout) is dry_run
+        assert alias.is_symlink()
+        assert (repo / "CLAUDE.md").read_bytes() == original
+
+    @pytest.mark.parametrize("dry_run", [False, True], ids=["apply", "preview"])
+    def test_explicit_alias_keeps_independently_selected_target(
+        self, tmp_path, monkeypatch, dry_run
+    ):
+        from skillsaw.cli import _fix
+
+        repo = copy_autofix_skip_repo(tmp_path, linked=False)
+        alias = tmp_path / "selected-link"
+        alias.symlink_to(repo, target_is_directory=True)
+        original = (repo / "CLAUDE.md").read_bytes()
+        resolver = _fix._resolve_lint_paths
+
+        def guarded_resolver(paths):
+            assert paths == [repo], "alias identity must not enter normalized-root deduplication"
+            return resolver(paths)
+
+        monkeypatch.setattr(_fix, "_resolve_lint_paths", guarded_resolver)
+        result = run_cli(
+            [
+                "fix",
+                alias,
+                repo,
+                "--rule",
+                "content-unlinked-internal-reference",
+                "--no-custom-rules",
+                "--no-plugins",
+                *(["--dry-run"] if dry_run else []),
+            ]
+        )
+        assert result.returncode == 0, result.stderr
+        assert ("Would fix 1 issue(s):" if dry_run else "Fixed 1 issue(s):") in result.stdout
+        assert f"[{repo / 'CLAUDE.md'}]" in result.stdout
+        assert f"[{alias}] symbolic link" in result.stdout
+        assert "Skipped 1 path(s):" in result.stdout
+        assert alias.is_symlink()
+        assert ((repo / "CLAUDE.md").read_bytes() == original) is dry_run
+
+    @pytest.mark.parametrize("error", ["missing", "rule-conflict"])
+    def test_explicit_skip_preserves_independent_input_errors(self, tmp_path, monkeypatch, error):
+        from skillsaw.cli import _fix
+
+        alias = tmp_path / "selected-link"
+        alias.symlink_to(tmp_path / "missing-target")
+        extra = (
+            [tmp_path / "missing-input"]
+            if error == "missing"
+            else ["--rule", "agentskill-name", "--skip-rule", "agentskill-name"]
+        )
+
+        def unexpected_resolver(paths):
+            pytest.fail("invalid inputs should stop before path resolution")
+
+        monkeypatch.setattr(_fix, "_resolve_lint_paths", unexpected_resolver)
+        result = run_cli(["fix", alias, *extra])
+        assert result.returncode == 1
+        assert ("Path not found" if error == "missing" else "cannot be combined") in result.stderr
+        assert "Fixed " not in result.stdout and "Would fix" not in result.stdout
+        assert alias.is_symlink()
+
     """Policy skips preserve diagnostics, previews and independent eligible fixes."""
 
     rule_id = "content-unlinked-internal-reference"
@@ -7695,7 +7789,7 @@ class TestAutofixSkips:
         )
         assert result.returncode == 1
         assert "Skipped 1 path(s):" in result.stdout
-        assert "Failed to apply 1 fix(es)" in result.stderr
+        assert "Failed to complete 1 fix(es)" in result.stderr
         assert "Test write refusal" in result.stderr
         assert "Fixed " not in result.stdout and "No auto-fixable" not in result.stdout
         assert (regular / "CLAUDE.md").read_bytes() == original

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7550,6 +7550,8 @@ def copy_autofix_skip_repo(tmp_path, name="repo", *, linked=True):
 @pytest.mark.integration
 @pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
 class TestAutofixSkips:
+    """Policy skips preserve diagnostics, previews and independent eligible fixes."""
+
     @pytest.mark.parametrize("kind", ["file", "directory", "dangling"])
     @pytest.mark.parametrize("dry_run", [False, True], ids=["apply", "preview"])
     def test_explicit_leaf_symlinks_stop_before_resolution(
@@ -7643,8 +7645,6 @@ class TestAutofixSkips:
         assert ("Path not found" if error == "missing" else "cannot be combined") in result.stderr
         assert "Fixed " not in result.stdout and "Would fix" not in result.stdout
         assert alias.is_symlink()
-
-    """Policy skips preserve diagnostics, previews and independent eligible fixes."""
 
     rule_id = "content-unlinked-internal-reference"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7539,6 +7539,168 @@ def _snapshot_contents(repo: Path) -> Dict[str, str]:
     return contents
 
 
+def copy_autofix_skip_repo(tmp_path, name="repo", *, linked=True):
+    repo = copy_fixture("autofix/unlinked-ref-multiple-paths", tmp_path / name)
+    if linked:
+        (repo / "CLAUDE.md").rename(repo / "instructions.txt")
+        (repo / "CLAUDE.md").symlink_to("instructions.txt")
+    return repo
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(os.name == "nt", reason="Requires ordinary POSIX symlinks")
+class TestAutofixSkips:
+    """Policy skips preserve diagnostics, previews and independent eligible fixes."""
+
+    rule_id = "content-unlinked-internal-reference"
+
+    @pytest.mark.parametrize("linked", [False, True], ids=["regular", "symlink"])
+    def test_symlink_metadata_preview_and_fix_agree(self, tmp_path, linked):
+        repo = copy_autofix_skip_repo(tmp_path, linked=linked)
+        path = repo / "CLAUDE.md"
+        original = path.read_bytes()
+        report = run_cli(
+            [
+                "lint",
+                repo,
+                "--rule",
+                self.rule_id,
+                "--format",
+                "json",
+                "--verbose",
+                "--no-custom-rules",
+                "--no-plugins",
+            ]
+        )
+        assert report.returncode == 0, report.stderr
+        findings = json.loads(report.stdout)["violations"]
+        assert len(findings) == 3
+        assert {v["file_path"] for v in findings} == {"CLAUDE.md"}
+        assert all(v["fixable"] is (not linked) for v in findings)
+        assert all(v.get("fix_confidence") == (None if linked else "safe") for v in findings)
+
+        preview = _run_fix(
+            repo, "--rule", self.rule_id, "--dry-run", "--no-custom-rules", "--no-plugins"
+        )
+        assert preview.returncode == 0, preview.stderr
+        assert path.read_bytes() == original
+        assert "dry-run — no files were modified" in preview.stdout
+        result = _run_fix(repo, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins")
+        assert result.returncode == 0, result.stderr
+        if linked:
+            for output in (preview.stdout, result.stdout):
+                assert "Skipped 1 path(s):" in output
+                assert "[CLAUDE.md] symbolic link; edit its target directly" in output
+                assert "Would fix" not in output and "Fixed " not in output
+                assert "No auto-fixable" not in output
+                assert "--- a/" not in output
+            assert path.is_symlink()
+            assert path.read_bytes() == original
+        else:
+            assert "Would fix 1 issue(s)" in preview.stdout
+            assert "Fixed 1 issue(s)" in result.stdout
+            assert "Skipped" not in result.stdout
+            assert path.read_bytes() != original
+            assert path.read_bytes().count(b"\n") == original.count(b"\n")
+            assert b"[docs/guide.md](docs/guide.md)" in path.read_bytes()
+            clean = run_cli(
+                [
+                    "lint",
+                    repo,
+                    "--rule",
+                    self.rule_id,
+                    "--format",
+                    "json",
+                    "--verbose",
+                    "--no-custom-rules",
+                    "--no-plugins",
+                ]
+            )
+            assert clean.returncode == 0, clean.stderr
+            assert json.loads(clean.stdout)["violations"] == []
+        after = path.read_bytes()
+        repeated = _run_fix(repo, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins")
+        assert repeated.returncode == 0, repeated.stderr
+        assert path.read_bytes() == after
+
+    def test_hidden_and_suppressed_findings_do_not_become_skips(self, tmp_path):
+        repo = copy_autofix_skip_repo(tmp_path)
+        (repo / ".skillsaw.yaml").write_text(f"rules:\n  {self.rule_id}:\n    severity: info\n")
+        hidden = _run_fix(repo, "--no-custom-rules", "--no-plugins")
+        assert hidden.returncode == 0, hidden.stderr
+        assert "Skipped" not in hidden.stdout
+        visible = _run_fix(repo, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins")
+        assert visible.returncode == 0, visible.stderr
+        assert "Skipped 1 path(s):" in visible.stdout
+
+        target = repo / "instructions.txt"
+        target.write_text(f"<!-- skillsaw-disable {self.rule_id} -->\n" + target.read_text())
+        suppressed = _run_fix(repo, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins")
+        assert suppressed.returncode == 0, suppressed.stderr
+        assert "Skipped" not in suppressed.stdout
+
+    def test_two_roots_keep_distinct_lexical_skip_paths(self, tmp_path):
+        first = copy_autofix_skip_repo(tmp_path, "first")
+        second = copy_autofix_skip_repo(tmp_path, "second")
+        result = run_cli(
+            ["fix", first, second, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins"]
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Skipped 2 path(s):" in result.stdout
+        assert f"[{first / 'CLAUDE.md'}] symbolic link" in result.stdout
+        assert f"[{second / 'CLAUDE.md'}] symbolic link" in result.stdout
+
+    def test_rename_followup_retains_and_deduplicates_skips(self, tmp_path, monkeypatch):
+        from skillsaw.linter import Linter
+
+        repo = copy_autofix_skip_repo(tmp_path)
+        shutil.copytree(FIXTURES / "autofix/fixable-accuracy-name/My_Skill", repo / "handoff")
+        calls = []
+        original = Linter.fix_and_apply
+
+        def record(self, *args, **kwargs):
+            result = original(self, *args, **kwargs)
+            calls.append(list(self.fix_skips))
+            return result
+
+        monkeypatch.setattr(Linter, "fix_and_apply", record)
+        result = _run_fix(
+            repo,
+            "--rule",
+            self.rule_id,
+            "--rule",
+            "agentskill-name",
+            "--no-custom-rules",
+            "--no-plugins",
+        )
+        assert result.returncode == 0, result.stderr
+        assert len(calls) == 2 and all(calls)
+        assert "name: handoff" in (repo / "handoff/SKILL.md").read_text()
+        assert "Skipped 1 path(s):" in result.stdout
+        assert result.stdout.count("[CLAUDE.md] symbolic link") == 1
+
+    def test_write_failure_still_fails_with_policy_skips(self, tmp_path, monkeypatch):
+        import skillsaw.linter as module
+
+        linked = copy_autofix_skip_repo(tmp_path, "linked")
+        regular = copy_autofix_skip_repo(tmp_path, "regular", linked=False)
+        original = (regular / "CLAUDE.md").read_bytes()
+
+        def refused(*args, **kwargs):
+            raise OSError("Test write refusal")
+
+        monkeypatch.setattr(module, "write_text_preserving", refused)
+        result = run_cli(
+            ["fix", linked, regular, "--rule", self.rule_id, "--no-custom-rules", "--no-plugins"]
+        )
+        assert result.returncode == 1
+        assert "Skipped 1 path(s):" in result.stdout
+        assert "Failed to apply 1 fix(es)" in result.stderr
+        assert "Test write refusal" in result.stderr
+        assert "Fixed " not in result.stdout and "No auto-fixable" not in result.stdout
+        assert (regular / "CLAUDE.md").read_bytes() == original
+
+
 @pytest.mark.integration
 class TestEncodingPreservingAutofix:
     """Autofix must not rewrite a file's byte shape (issue #315).

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9272,6 +9272,63 @@ class TestRenameRefsAutofix:
         stale = [v for v in violations(r) if v["rule_id"] == "agentskill-rename-refs"]
         assert stale == [], f"rename-refs violations remain after fix: {stale}"
 
+    @pytest.mark.parametrize(
+        "cleanup_failure",
+        [
+            pytest.param(
+                "symlink",
+                marks=pytest.mark.skipif(
+                    os.name == "nt", reason="Requires ordinary POSIX symlinks"
+                ),
+            ),
+            "write-refusal",
+        ],
+    )
+    def test_optional_metadata_cleanup_failure_preserves_findings(
+        self, tmp_path, monkeypatch, cleanup_failure
+    ):
+        from skillsaw.rules.builtin.agentskills import _helpers, rename_refs
+
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        _run_fix(repo, "--rule", "agentskill-name", "--no-custom-rules", "--no-plugins")
+        args = ["--rule", "agentskill-rename-refs", "--no-custom-rules", "--no-plugins"]
+        expected = run_lint(repo, *args)
+        assert expected["rc"] == 0, expected["stderr"]
+        assert [(v["file_path"], v["line"]) for v in violations(expected)] == [
+            ("CLAUDE.md", 5),
+            ("CLAUDE.md", 7),
+            ("CLAUDE.md", 12),
+        ]
+        metadata = repo / _helpers.RENAMES_MANIFEST
+        active = json.loads(metadata.read_text())["renames"]
+        original = (
+            json.dumps({"renames": [*active, {"old": "retired-entry", "new": "current-entry"}]})
+            + "\n"
+        ).encode()
+        metadata.write_bytes(original)
+        if cleanup_failure == "symlink":
+            saved = repo / "saved-renames.json"
+            metadata.rename(saved)
+            metadata.symlink_to(saved.name)
+
+        attempts = []
+        write = rename_refs._write_renames_manifest
+
+        def cleanup(root, remaining):
+            assert root == repo
+            attempts.append(remaining)
+            if cleanup_failure == "write-refusal":
+                raise OSError("Optional cleanup refused")
+            write(root, remaining)
+
+        monkeypatch.setattr(rename_refs, "_write_renames_manifest", cleanup)
+        actual = run_lint(repo, *args)
+        assert actual["rc"] == 0, actual["stderr"]
+        assert violations(actual) == violations(expected)
+        assert attempts == [active]
+        assert metadata.is_symlink() is (cleanup_failure == "symlink")
+        assert metadata.read_bytes() == original
+
     def test_metadata_failure_reports_applied_edit_and_exits_nonzero(self, tmp_path, monkeypatch):
         from skillsaw.rules.builtin.agentskills import _helpers
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9178,6 +9178,29 @@ class TestRenameRefsAutofix:
         stale = [v for v in violations(r) if v["rule_id"] == "agentskill-rename-refs"]
         assert stale == [], f"rename-refs violations remain after fix: {stale}"
 
+    def test_metadata_failure_reports_applied_edit_and_exits_nonzero(self, tmp_path, monkeypatch):
+        from skillsaw.rules.builtin.agentskills import _helpers
+
+        repo = copy_fixture(self.FIXTURE, tmp_path)
+        metadata = repo / _helpers.RENAMES_MANIFEST
+        original = b'{"renames": [{"old": "earlier", "new": "current"}]}\n'
+        metadata.write_bytes(original)
+
+        def refuse_metadata(path, data, *, root):
+            assert path == metadata and root == repo
+            raise OSError("Metadata write refused")
+
+        monkeypatch.setattr(_helpers, "write_bytes_atomic", refuse_metadata)
+        result = run_cli(
+            ["fix", repo, "--rule", "agentskill-name", "--no-custom-rules", "--no-plugins"]
+        )
+
+        assert result.returncode == 1
+        assert "Fixed 1 issue(s)" in result.stdout
+        assert "File edit applied, but follow-up failed: Metadata write refused" in result.stderr
+        assert "name: data-parser-v2" in (repo / "data-parser-v2/SKILL.md").read_text()
+        assert metadata.read_bytes() == original
+
     def test_dry_run_is_side_effect_free(self, tmp_path):
         """``fix --dry-run`` must not write the renames manifest or modify any
         file, and a subsequent lint must not report phantom stale references."""


### PR DESCRIPTION
A symlinked instruction file can currently advertise an autofix and print “Would fix,” then remain unchanged with “No auto-fixable violations found.” This reports the selected skip with its path and reason, removes misleading fixability metadata, and lets independent regular-file fixes proceed.

The same eligibility check applies before dry-run and at the write boundary, including both rename endpoints. Presentation-time checks are memoized only within each filtering call. Skip reports survive rename passes and multiple roots, respect selected severity/confidence, and are deduplicated. Policy skips remain successful; write failures remain errors. Existing vendor/external-content policy and public return tuples are preserved.

Validation: 9,206 tests pass, including explicit-path admission, metadata writer, and partial-completion controls. Independent reviews cover proposal metadata, fresh write checks, per-call memoization, and canonical CLI coverage. `make lint`, `make update`, and configured ai-helpers compatibility pass with zero errors/warnings. The final seven-repeat benchmark regression check passes. Documentation updated.

Explicit file/directory leaf symlinks are refused before CLI path normalization; independently selected regular roots still run. Supporting rename metadata uses the existing anchored atomic writer, and a failed callback now reports partial completion and exits nonzero after any already applied edit. Optional rename-check cleanup preserves findings when its write is refused. Existing metadata pruning remains a documented limitation: dry-run does not apply proposals or callbacks, but is not fully read-only.

Follow-up to #595.
