### PR TITLE
[Auto] Preserve matcher evidence and strengthen test coverage

### DIFF
--- a/.agents/skills/skillsaw-maintenance/references/grok.md
+++ b/.agents/skills/skillsaw-maintenance/references/grok.md
@@ -415,6 +415,17 @@ auto-trusted counterpart `~/.grok/plugins/` is never in a checkout.
 - The Rust-dialect matcher check is shared with Muse Code:
   `rust_matcher_error` in `src/skillsaw/rules/builtin/utils.py`.
 
+## Portable matcher evidence
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) preserve
+27 Grok 1.0.13 inspection controls plus literal-flag and conservative-abstention
+controls. Exact patterns, source/binary pins, Rust compilation, observed handler
+identities and expected Skillsaw diagnostics are separate evidence. A missing finding
+can mean the checker abstained; it does not establish native acceptance. The optional
+stdin-only ripgrep replay needs no host installation or hook execution. Keep catch-all
+and ignored-event behavior in the host-specific tests.
+
 ## Sync notes
 Hand-copied values and measured facts that drift — re-check each against the shipped
 user guide, or re-verify empirically with the canary matrix above:

--- a/.agents/skills/skillsaw-maintenance/references/muse.md
+++ b/.agents/skills/skillsaw-maintenance/references/muse.md
@@ -22,7 +22,25 @@ file, so the shape and the failure scopes below were verified against Muse Code 
 `.muse/hooks.json` carrying a single variation, every handler writing a token to a log
 file, run under `muse exec --provider echo`. The loader emits no diagnostic in headless
 runs — a rejected file, group, event or handler simply never fires — which is why
-`muse-hooks-valid` exists. Re-run that matrix before changing a rule here.
+`muse-hooks-valid` exists. This historical matrix is not current-version conformance;
+see the evidence limits below before changing the rule.
+
+## Matcher evidence and coverage limits
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) record
+Rust-engine acceptance/refusal separately from Grok inspection and expected Skillsaw
+findings. They protect the shared matcher helper, not current Muse loader conformance.
+A null diagnostic can mean conservative abstention. No Muse acceptance is inferred
+from a Grok observation or a successful ripgrep compilation.
+
+The 0.20.0 audit's Muse 1.0.3-R2198.1 loader-only controls produced indistinguishable
+results for working and malformed input, so their verdict is unresolved. The five
+meaningful public samples were two committed project configs, one installer template
+and two generator transcriptions; the generator authors describe unverified contract
+assumptions. Generators were read, not executed. Zero findings do not establish a
+false-positive rate, and these samples do not meet the ten-repository auto-rule gate.
+`muse-hooks-valid` remains opt-in; shared hook inventory and security rules still run.
 
 ## What to check
 - **Hooks file**: `<project-root>/.muse/hooks.json` — user hooks live in

--- a/.apm/skills/skillsaw-maintenance/references/grok.md
+++ b/.apm/skills/skillsaw-maintenance/references/grok.md
@@ -415,6 +415,17 @@ auto-trusted counterpart `~/.grok/plugins/` is never in a checkout.
 - The Rust-dialect matcher check is shared with Muse Code:
   `rust_matcher_error` in `src/skillsaw/rules/builtin/utils.py`.
 
+## Portable matcher evidence
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) preserve
+27 Grok 1.0.13 inspection controls plus literal-flag and conservative-abstention
+controls. Exact patterns, source/binary pins, Rust compilation, observed handler
+identities and expected Skillsaw diagnostics are separate evidence. A missing finding
+can mean the checker abstained; it does not establish native acceptance. The optional
+stdin-only ripgrep replay needs no host installation or hook execution. Keep catch-all
+and ignored-event behavior in the host-specific tests.
+
 ## Sync notes
 Hand-copied values and measured facts that drift — re-check each against the shipped
 user guide, or re-verify empirically with the canary matrix above:

--- a/.apm/skills/skillsaw-maintenance/references/muse.md
+++ b/.apm/skills/skillsaw-maintenance/references/muse.md
@@ -22,7 +22,25 @@ file, so the shape and the failure scopes below were verified against Muse Code 
 `.muse/hooks.json` carrying a single variation, every handler writing a token to a log
 file, run under `muse exec --provider echo`. The loader emits no diagnostic in headless
 runs — a rejected file, group, event or handler simply never fires — which is why
-`muse-hooks-valid` exists. Re-run that matrix before changing a rule here.
+`muse-hooks-valid` exists. This historical matrix is not current-version conformance;
+see the evidence limits below before changing the rule.
+
+## Matcher evidence and coverage limits
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) record
+Rust-engine acceptance/refusal separately from Grok inspection and expected Skillsaw
+findings. They protect the shared matcher helper, not current Muse loader conformance.
+A null diagnostic can mean conservative abstention. No Muse acceptance is inferred
+from a Grok observation or a successful ripgrep compilation.
+
+The 0.20.0 audit's Muse 1.0.3-R2198.1 loader-only controls produced indistinguishable
+results for working and malformed input, so their verdict is unresolved. The five
+meaningful public samples were two committed project configs, one installer template
+and two generator transcriptions; the generator authors describe unverified contract
+assumptions. Generators were read, not executed. Zero findings do not establish a
+false-positive rate, and these samples do not meet the ten-repository auto-rule gate.
+`muse-hooks-valid` remains opt-in; shared hook inventory and security rules still run.
 
 ## What to check
 - **Hooks file**: `<project-root>/.muse/hooks.json` — user hooks live in

--- a/.claude/skills/skillsaw-maintenance/references/grok.md
+++ b/.claude/skills/skillsaw-maintenance/references/grok.md
@@ -415,6 +415,17 @@ auto-trusted counterpart `~/.grok/plugins/` is never in a checkout.
 - The Rust-dialect matcher check is shared with Muse Code:
   `rust_matcher_error` in `src/skillsaw/rules/builtin/utils.py`.
 
+## Portable matcher evidence
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) preserve
+27 Grok 1.0.13 inspection controls plus literal-flag and conservative-abstention
+controls. Exact patterns, source/binary pins, Rust compilation, observed handler
+identities and expected Skillsaw diagnostics are separate evidence. A missing finding
+can mean the checker abstained; it does not establish native acceptance. The optional
+stdin-only ripgrep replay needs no host installation or hook execution. Keep catch-all
+and ignored-event behavior in the host-specific tests.
+
 ## Sync notes
 Hand-copied values and measured facts that drift — re-check each against the shipped
 user guide, or re-verify empirically with the canary matrix above:

--- a/.claude/skills/skillsaw-maintenance/references/muse.md
+++ b/.claude/skills/skillsaw-maintenance/references/muse.md
@@ -22,7 +22,25 @@ file, so the shape and the failure scopes below were verified against Muse Code 
 `.muse/hooks.json` carrying a single variation, every handler writing a token to a log
 file, run under `muse exec --provider echo`. The loader emits no diagnostic in headless
 runs — a rejected file, group, event or handler simply never fires — which is why
-`muse-hooks-valid` exists. Re-run that matrix before changing a rule here.
+`muse-hooks-valid` exists. This historical matrix is not current-version conformance;
+see the evidence limits below before changing the rule.
+
+## Matcher evidence and coverage limits
+
+The [matcher evidence notes](../../../../tests/fixtures/hooks/rust-matchers/README.md)
+and [pinned rows](../../../../tests/fixtures/hooks/rust-matchers/evidence.json) record
+Rust-engine acceptance/refusal separately from Grok inspection and expected Skillsaw
+findings. They protect the shared matcher helper, not current Muse loader conformance.
+A null diagnostic can mean conservative abstention. No Muse acceptance is inferred
+from a Grok observation or a successful ripgrep compilation.
+
+The 0.20.0 audit's Muse 1.0.3-R2198.1 loader-only controls produced indistinguishable
+results for working and malformed input, so their verdict is unresolved. The five
+meaningful public samples were two committed project configs, one installer template
+and two generator transcriptions; the generator authors describe unverified contract
+assumptions. Generators were read, not executed. Zero findings do not establish a
+false-positive rate, and these samples do not meet the ten-repository auto-rule gate.
+`muse-hooks-valid` remains opt-in; shared hook inventory and security rules still run.
 
 ## What to check
 - **Hooks file**: `<project-root>/.muse/hooks.json` — user hooks live in

--- a/scripts/replay-rust-matchers.py
+++ b/scripts/replay-rust-matchers.py
@@ -1,0 +1,52 @@
+"""Optional Rust-engine replay of literal matcher evidence; no host is invoked."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+
+def main() -> int:
+    rg = shutil.which("rg")
+    if rg is None:
+        raise SystemExit("Install ripgrep to run this optional evidence replay.")
+    evidence = json.loads(
+        (
+            Path(__file__).resolve().parents[1] / "tests/fixtures/hooks/rust-matchers/evidence.json"
+        ).read_text(encoding="utf-8")
+    )
+    version = subprocess.check_output([rg, "--version"], text=True).splitlines()[0]
+    results = []
+    for case in evidence["cases"]:
+        result = subprocess.run(
+            [rg, "--no-config", "--engine", "default", "-e", case["pattern"]],
+            input=evidence["ripgrep"]["stdin"],
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode in (0, 1):
+            verdict = "accepted"
+        elif result.returncode == 2 and "regex parse error:" in result.stderr:
+            verdict = "refused"
+        else:
+            verdict = "unresolved"
+        results.append(
+            {
+                "id": case["id"],
+                "pattern": case["pattern"],
+                "verdict": verdict,
+                "expected": case["rust_verdict"],
+                "exit": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+    print(json.dumps({"version": version, "results": results}, indent=2))
+    return int(any(row["verdict"] != row["expected"] for row in results))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/hooks/rust-matchers/README.md
+++ b/tests/fixtures/hooks/rust-matchers/README.md
@@ -1,0 +1,102 @@
+# Pinned hook matcher evidence
+
+[evidence.json](evidence.json) records 34 exact patterns and their expected Skillsaw
+findings. The helper tests consume these rows, and the CLI tests check the existing
+Grok and Muse fixtures against them. Nothing here runs a hook or installs a host.
+
+## What each observation means
+
+- `pattern` is the decoded regex string, including any newline or literal backslash.
+- `record` identifies the original saved audit batch and case. The top-level hashes
+  identify those original records; the portable observations are copied into each row.
+- `rust_verdict` records compilation by ripgrep 15.2.0 (revision `e89fff89ac`), with
+  `--no-config --engine default`. `rust_exit` distinguishes a match (0), a compiled
+  pattern with no match (1), and a compiler refusal (2). Compilation acceptance does
+  not prove a hook fires or that a particular tool name matches.
+- `grok_verdict` records whether Grok 1.0.13 retained the target matcher group in
+  `inspect --json`; `grok_handler_targets` preserves the observed command identities.
+  `unresolved` with `null` targets means there is no Grok observation for that row.
+- `skillsaw_finding` is the expected matcher diagnostic with the host rule explicitly
+  selected and default severity: `warning` or `null`. `skillsaw_assessment` separately
+  marks conservative abstention. For example, Rust refuses `(?x)(`, while Skillsaw
+  withholds a finding because extended-mode parsing is unresolved. A null finding
+  therefore cannot be used as evidence of native acceptance.
+
+There are 27 saved Grok controls: 13 retained their target group and 14 lost it.
+Four further controls distinguish literal flag-like text from real inline flags.
+Three existing extended-mode abstention controls make the checker limit explicit.
+All 34 have Rust-engine observations; the latter seven have no Grok observation.
+
+## Grok provenance and inspection input
+
+The evidence pins the executable version and SHA-256 independently from the official
+source revision. The source snapshot is **not claimed to be the binary's source**.
+The pinned [`matcher.rs`](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-hooks/src/matcher.rs)
+compiles non-simple patterns with `regex::Regex::new`, and
+[`config.rs`](https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-hooks/src/config.rs)
+applies this when constructing matcher groups. Source file hashes are also recorded.
+
+[inspection-input.json](inspection-input.json) preserves the synthetic four-handler
+input. Replace only `hooks.PreToolUse[0].matcher` with a row's exact `pattern` to
+reconstruct its JSON input. The first two command strings identify the target and
+same-group canary; the next two identify the same-event and other-event canaries.
+The 27 observations retain both unaffected canaries, so missing target groups cannot
+be mistaken for an empty inspection or an undiscovered file.
+
+The saved inspection used one user-scope file under an isolated `GROK_HOME/hooks/`,
+an empty session directory, a masked home, disabled Claude/Cursor compatibility hooks
+and an unavailable network. Only `grok inspect --json` ran; the command strings were
+metadata and no hook was dispatched. These observations establish load-time retention,
+not hook execution, project trust, or runtime tool-name matching.
+
+The host's empty/`*` catch-alls, exact-name alternatives, and ignored matcher events
+have separate rule tests. Do not feed those host conventions to a generic compiler
+and infer host rejection. The portable table covers active regex-form PreToolUse
+matchers only.
+
+## Optional Rust-engine replay
+
+From the repository root, with ripgrep already installed:
+
+```sh
+.venv/bin/python3 scripts/replay-rust-matchers.py
+```
+
+The script passes each pattern as an argument and a tiny constant subject through
+stdin. It does not read repository files through ripgrep, use a shell, execute fixture
+commands, contact a service, or invoke Grok/Muse. It prints the current ripgrep version,
+compiler outcome, and matching output separately; exit 1 means a verdict changed or
+could not be established. It never overwrites the pinned observations. Normal tests
+need neither ripgrep nor either host binary.
+
+The [Rust regex syntax reference](https://docs.rs/regex/1.13.1/regex/#syntax) explains
+flags and scalar escapes, but does not replace a host observation. Ripgrep itself
+wraps regex patterns: the accepted extended-mode comment control intentionally ends
+with a newline so its comment cannot consume ripgrep's wrapper. Preserve that newline;
+changing it creates a different input and can change the engine comparison.
+
+## Muse limit
+
+The matcher helper is shared with Muse; this table does not validate a current Muse
+loader. The historical Muse 1.0.2-R2040.1 canary matrix described in the maintenance
+reference predates this audit. Loader-only 1.0.3-R2198.1 controls did not distinguish
+working from malformed inputs and are inconclusive.
+
+The public corpus supplied five meaningful samples: two committed project configs,
+one installer template, and two generator transcriptions. No generator was executed.
+The latter authors describe unverified contract assumptions. Zero findings in these
+samples neither validate the current loader nor establish a false-positive rate.
+`muse-hooks-valid` remains opt-in; shared hook inventory and security rules are unchanged.
+
+The audit's pinned public origins are:
+
+| Kind | Source |
+|---|---|
+| Project config | [rmems/grok-ozempic](https://github.com/rmems/grok-ozempic/blob/4464a74ce5e7a7dbac34ec12dfa285041966e700/.muse/hooks.json) |
+| Project config | [ducnd58233/vibe-agent](https://github.com/ducnd58233/vibe-agent/blob/ca2af14fcee8cfc2b904c0b93c78e037329c561b/.muse/hooks.json) |
+| Installer template | [cgraf78/agentguard](https://github.com/cgraf78/agentguard/blob/a86483be48843aa303a32203f673c382e76d22ad/share/agentguard/integrations/muse/hooks.json) |
+| Generator read for transcription | [corveil/crow](https://github.com/corveil/crow/blob/4a95b30ded75ec2a0cf6492159d914e58d7aeb1f/Packages/CrowMuse/Sources/CrowMuse/MuseHookConfigWriter.swift#L64) |
+| Generator read for transcription | [intutic/intutic](https://github.com/intutic/intutic/blob/18b720d183d4a3500d3c4955c9b51b50df50eb3d/services/sync-daemon/src/harness/museHooks.ts#L200) |
+
+These links identify the original sources. The generator sources are not exact JSON
+payloads; the audit transcribed their shapes and substituted parameter values.

--- a/tests/fixtures/hooks/rust-matchers/evidence.json
+++ b/tests/fixtures/hooks/rust-matchers/evidence.json
@@ -1,0 +1,526 @@
+{
+  "assembled_at": "2026-09-05",
+  "grok": {
+    "version": "1.0.13 (5e9a58528b76, stable)",
+    "binary_sha256": "b926fc5308374396e260e7efbd6107231a8dae13c084ddaf0fe89b7ebb3edd25",
+    "source_revision": "72a61251fcffb464bcc687aeb5a998e5a98ec0c9",
+    "source": {
+      "matcher.rs": {
+        "url": "https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-hooks/src/matcher.rs",
+        "sha256": "c295133a859e17bc6e964f93581192a7f7e41882519d2116affca1649de4aff7"
+      },
+      "config.rs": {
+        "url": "https://github.com/xai-org/grok-build/blob/72a61251fcffb464bcc687aeb5a998e5a98ec0c9/crates/codegen/xai-grok-hooks/src/config.rs",
+        "sha256": "2e37edd875fef6b0ac1f6ef7535654a9e113ab0f02b754b35077135a0553a7f9"
+      }
+    },
+    "method": "Saved inspect --json metadata from isolated user-scope hooks, network disabled; no hooks dispatched."
+  },
+  "ripgrep": {
+    "version": "ripgrep 15.2.0 (rev e89fff89ac)",
+    "source": "https://github.com/BurntSushi/ripgrep/tree/15.2.0",
+    "engine": "default",
+    "stdin": "Bash\nWrite\nwrite\n(Bash\n"
+  },
+  "muse": {
+    "verdict": "unresolved",
+    "historical_version": "1.0.2-R2040.1",
+    "inconclusive_version": "1.0.3-R2198.1"
+  },
+  "audit_record_sha256": {
+    "implementation-rust-hook-matchers": {
+      "native.json": "73b439667612ee27348b71bb3b3b90751331518fee08e2834e74974e18d665f4",
+      "rust-oracle.json": "f60c6f8ed1c08f0c711317864776d142901d3395cb653d737cc44a8ff02fd253"
+    },
+    "implementation-rust-unicode-escapes": {
+      "native.json": "dbada5d6e9ca7edc44e74d1947e81fafeedadec5e3dd088ee2a01b627c092b05",
+      "rust-oracle.json": "f90a5abbe57ddb747d77888009be8b9e38a7396039e5d67ca07795a2db39b0eb"
+    },
+    "implementation-p2-controls": {
+      "native-matcher-controls.json": "64286367c7f2d3b6e803a1bde3c84d1eacc6105c59533a727a7a044b8014cc74"
+    }
+  },
+  "cases": [
+    {
+      "id": "hook-matchers/valid-0",
+      "pattern": "Bash|(?i)Write",
+      "record": "implementation-rust-hook-matchers/valid-0",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-1",
+      "pattern": "(?-u:\\w+)",
+      "record": "implementation-rust-hook-matchers/valid-1",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-2",
+      "pattern": "(?U).*",
+      "record": "implementation-rust-hook-matchers/valid-2",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-3",
+      "pattern": "\\x{42}ash",
+      "record": "implementation-rust-hook-matchers/valid-3",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-4",
+      "pattern": "(?R)^Bash$",
+      "record": "implementation-rust-hook-matchers/valid-4",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-5",
+      "pattern": "(?i-m:Write)",
+      "record": "implementation-rust-hook-matchers/valid-5",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-6",
+      "pattern": "\\x{28}Bash",
+      "record": "implementation-rust-hook-matchers/valid-6",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-7",
+      "pattern": "(?U)(Bash|Write)",
+      "record": "implementation-rust-hook-matchers/valid-7",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/valid-8",
+      "pattern": "(?x)Bash # (?=literal comment\n",
+      "record": "implementation-rust-hook-matchers/valid-8",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "unresolved",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "hook-matchers/invalid-0",
+      "pattern": "Bash(",
+      "record": "implementation-rust-hook-matchers/invalid-0",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-1",
+      "pattern": "(?=Bash)",
+      "record": "implementation-rust-hook-matchers/invalid-1",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-2",
+      "pattern": "(?U)(Bash",
+      "record": "implementation-rust-hook-matchers/invalid-2",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-3",
+      "pattern": "(?-u:[a-z)",
+      "record": "implementation-rust-hook-matchers/invalid-3",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-4",
+      "pattern": "\\x{110000}",
+      "record": "implementation-rust-hook-matchers/invalid-4",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-5",
+      "pattern": "\\x{d800}",
+      "record": "implementation-rust-hook-matchers/invalid-5",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-6",
+      "pattern": "\\x{}",
+      "record": "implementation-rust-hook-matchers/invalid-6",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "hook-matchers/invalid-7",
+      "pattern": "\\x{42}(",
+      "record": "implementation-rust-hook-matchers/invalid-7",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/valid-0",
+      "pattern": "\\u{42}ash",
+      "record": "implementation-rust-unicode-escapes/valid-0",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "unicode-escapes/valid-1",
+      "pattern": "\\U{42}ash",
+      "record": "implementation-rust-unicode-escapes/valid-1",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "unicode-escapes/valid-2",
+      "pattern": "\\u{28}Bash",
+      "record": "implementation-rust-unicode-escapes/valid-2",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "unicode-escapes/valid-3",
+      "pattern": "\\U{28}Bash",
+      "record": "implementation-rust-unicode-escapes/valid-3",
+      "rust_verdict": "accepted",
+      "grok_verdict": "accepted",
+      "grok_handler_targets": [
+        "true probe_target",
+        "true probe_same_group",
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 0
+    },
+    {
+      "id": "unicode-escapes/invalid-0",
+      "pattern": "\\u{110000}",
+      "record": "implementation-rust-unicode-escapes/invalid-0",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/invalid-1",
+      "pattern": "\\U{110000}",
+      "record": "implementation-rust-unicode-escapes/invalid-1",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/invalid-2",
+      "pattern": "\\u{d800}",
+      "record": "implementation-rust-unicode-escapes/invalid-2",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/invalid-3",
+      "pattern": "\\U{d800}",
+      "record": "implementation-rust-unicode-escapes/invalid-3",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/invalid-4",
+      "pattern": "\\u{42}(",
+      "record": "implementation-rust-unicode-escapes/invalid-4",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "unicode-escapes/invalid-5",
+      "pattern": "\\U{42}(",
+      "record": "implementation-rust-unicode-escapes/invalid-5",
+      "rust_verdict": "refused",
+      "grok_verdict": "refused",
+      "grok_handler_targets": [
+        "true probe_same_event",
+        "true probe_other_event"
+      ],
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "literal-flags/0",
+      "pattern": "[(?x)](?=foo)",
+      "record": "implementation-p2-controls/0",
+      "rust_verdict": "refused",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "literal-flags/2",
+      "pattern": "[(?x)]foo",
+      "record": "implementation-p2-controls/2",
+      "rust_verdict": "accepted",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 1
+    },
+    {
+      "id": "literal-flags/4",
+      "pattern": "\\(\\?x\\)foo",
+      "record": "implementation-p2-controls/4",
+      "rust_verdict": "accepted",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": null,
+      "rust_exit": 1
+    },
+    {
+      "id": "literal-flags/5",
+      "pattern": "\\(?x)(?=foo)",
+      "record": "implementation-p2-controls/5",
+      "rust_verdict": "refused",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "checked",
+      "skillsaw_finding": "warning",
+      "rust_exit": 2
+    },
+    {
+      "id": "abstention/0",
+      "pattern": "(?x)(",
+      "record": "portable-evidence/2026-09-05",
+      "rust_verdict": "refused",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "unresolved",
+      "skillsaw_finding": null,
+      "rust_exit": 2
+    },
+    {
+      "id": "abstention/1",
+      "pattern": "[(?x)](?x)(",
+      "record": "portable-evidence/2026-09-05",
+      "rust_verdict": "refused",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "unresolved",
+      "skillsaw_finding": null,
+      "rust_exit": 2
+    },
+    {
+      "id": "abstention/2",
+      "pattern": "(?-x)(",
+      "record": "portable-evidence/2026-09-05",
+      "rust_verdict": "refused",
+      "grok_verdict": "unresolved",
+      "grok_handler_targets": null,
+      "skillsaw_assessment": "unresolved",
+      "skillsaw_finding": null,
+      "rust_exit": 2
+    }
+  ]
+}

--- a/tests/fixtures/hooks/rust-matchers/inspection-input.json
+++ b/tests/fixtures/hooks/rust-matchers/inspection-input.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "REPLACE_WITH_CASE_PATTERN",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "true probe_target"
+          },
+          {
+            "type": "command",
+            "command": "true probe_same_group"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "true probe_same_event"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "true probe_other_event"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -954,10 +954,9 @@ class TestCommandRenameFix:
         assert fix.rename_from is None
 
     def test_case_only_rename(self, temp_dir):
-        """Case-only rename (e.g. MyCommand.md -> mycommand.md) must work
-        on both case-sensitive and case-insensitive filesystems."""
+        """A letter-case-only rename must leave one correctly named file."""
         content = "---\ndescription: test\n---\n"
-        plugin_dir = _make_plugin(temp_dir, "my-plugin", {"MyCommand.md": content})
+        plugin_dir = _make_plugin(temp_dir, "my-plugin", {"Deploy.md": content})
         context = RepositoryContext(plugin_dir)
         rule = CommandNamingRule()
 
@@ -972,9 +971,10 @@ class TestCommandRenameFix:
         assert len(applied) == 1
 
         commands_dir = plugin_dir / "commands"
-        # The kebab-case file must exist with correct content
-        assert (commands_dir / "my-command.md").exists()
-        assert (commands_dir / "my-command.md").read_text() == content
+        # Enumerate actual spelling: exists() alone can accept the old name
+        # on a case-insensitive filesystem.
+        assert [path.name for path in commands_dir.iterdir()] == ["deploy.md"]
+        assert (commands_dir / "deploy.md").read_text() == content
 
     def test_apply_fix_isolates_oserror(self, temp_dir):
         """One fix raising OSError must not prevent subsequent fixes."""

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -406,23 +406,6 @@ class TestLinterFix:
 
 
 class TestApplyFixes:
-    def test_apply_safe_fixes(self, temp_dir):
-        target = temp_dir / "test.txt"
-        target.write_text("original")
-
-        fix = AutofixResult(
-            rule_id="test",
-            file_path=target,
-            confidence=AutofixConfidence.SAFE,
-            original_content="original",
-            fixed_content="fixed",
-            description="test fix",
-        )
-
-        applied = Linter.apply_fixes([fix])
-        assert len(applied) == 1
-        assert target.read_text() == "fixed"
-
     def test_apply_refuses_symlink_target(self, temp_dir, caplog):
         victim = temp_dir / "victim.txt"
         victim.write_text("original")

--- a/tests/test_integration_rust_hook_matchers.py
+++ b/tests/test_integration_rust_hook_matchers.py
@@ -1,4 +1,4 @@
-"""Both hook consumers accept Rust syntax under a warning exit threshold."""
+"""Both hook rules follow the recorded diagnostic policy through the CLI."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from skillsaw.blocks.json_config import GrokHooksBlock, MuseHooksBlock
 from skillsaw.context import RepositoryContext
 from tests.cli_runner import run_cli
 from tests.test_integration import copy_fixture
+from tests.test_rust_matcher_dialects import CASES
 
 
 @pytest.mark.integration
@@ -46,12 +47,20 @@ def test_rust_matchers_use_host_dialect_in_cli(tmp_path, host, block_type, path,
     report = json.loads(result.stdout)
     assert report["stats"]["rules_run"] == [rule]
     found = report["violations"]
+    by_pattern = {case["pattern"]: case for case in CASES}
+    groups = json.loads((repo / path).read_text(encoding="utf-8"))["hooks"]["PreToolUse"]
+    expected = [
+        index
+        for index, group in enumerate(groups)
+        if by_pattern[group["matcher"]]["skillsaw_finding"] == "warning"
+    ]
     if outcome == "valid":
+        assert expected == []
         assert found == []
     else:
-        assert len(found) == 12
+        assert len(found) == len(expected) == 12
         assert {(v["rule_id"], v["file_path"], v["severity"]) for v in found} == {
             (rule, path, "warning")
         }
-        for index in range(12):
+        for index in expected:
             assert sum(f"PreToolUse[{index}] 'matcher'" in v["message"] for v in found) == 1

--- a/tests/test_perf_helpers.py
+++ b/tests/test_perf_helpers.py
@@ -154,9 +154,6 @@ class TestPatternsMatchingAnywhere:
         (re.compile(r"\bproperly\b", re.IGNORECASE), "vagueness"),
     ]
 
-    def test_no_match_returns_empty(self):
-        assert patterns_matching_anywhere("clean direct text", self.PATTERNS) == []
-
     def test_subset_preserves_order(self):
         text = "you should properly try to do this"
         active = patterns_matching_anywhere(text, self.PATTERNS)

--- a/tests/test_rust_matcher_dialects.py
+++ b/tests/test_rust_matcher_dialects.py
@@ -2,55 +2,22 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from skillsaw.rules.builtin.utils import _to_python_regex, rust_matcher_error
 
-VALID = [
-    "[(?x)]foo",
-    r"\(\?x\)foo",
-    "\\u{42}ash",
-    "\\U{42}ash",
-    "\\u{28}Bash",
-    "\\U{28}Bash",
-    "Bash|(?i)Write",
-    "(?-u:\\w+)",
-    "(?U).*",
-    "\\x{42}ash",
-    "(?R)^Bash$",
-    "(?i-m:Write)",
-    "\\x{28}Bash",
-    "(?U)(Bash|Write)",
-    "(?x)Bash # (?=literal comment\n",
-]
-INVALID = [
-    "[(?x)](?=foo)",
-    r"\(?x)(?=foo)",
-    "\\u{110000}",
-    "\\U{110000}",
-    "\\u{d800}",
-    "\\U{d800}",
-    "\\u{42}(",
-    "\\U{42}(",
-    "Bash(",
-    "(?=Bash)",
-    "(?U)(Bash",
-    "(?-u:[a-z)",
-    "\\x{110000}",
-    "\\x{d800}",
-    "\\x{}",
-    "\\x{42}(",
-]
+EVIDENCE_PATH = Path(__file__).parent / "fixtures" / "hooks" / "rust-matchers" / "evidence.json"
+CASES = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))["cases"]
 
 
-@pytest.mark.parametrize("pattern", VALID)
-def test_supported_rust_flags_and_braced_hex_do_not_warn(pattern):
-    assert rust_matcher_error(pattern) is None
-
-
-@pytest.mark.parametrize("pattern", INVALID)
-def test_invalid_structure_is_still_checked_after_translation(pattern):
-    assert rust_matcher_error(pattern) is not None
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case["id"])
+def test_pinned_matcher_diagnostics(case):
+    # A missing finding can mean abstention; native verdicts are separate evidence.
+    error = rust_matcher_error(case["pattern"])
+    assert ("warning" if error is not None else None) == case["skillsaw_finding"]
 
 
 @pytest.mark.parametrize(
@@ -58,10 +25,4 @@ def test_invalid_structure_is_still_checked_after_translation(pattern):
 )
 def test_literal_flag_and_escape_text_is_not_rewritten(pattern):
     assert _to_python_regex(pattern) == pattern
-    assert rust_matcher_error(pattern) is None
-
-
-@pytest.mark.parametrize("pattern", ["(?x)(", "[(?x)](?x)(", "(?-x)("])
-def test_extended_mode_is_unresolved_even_when_structure_looks_invalid(pattern):
-    # No Rust parser is shipped; comments change what apparent delimiters mean.
     assert rust_matcher_error(pattern) is None


### PR DESCRIPTION
The Rust hook matcher tests depended on audit evidence outside the repository, and two smoke tests duplicated stronger checks. This commits the evidence needed to review the existing matcher decisions and removes those two redundant tests.

- Preserve all 34 existing matcher pattern/diagnostic pairs in a portable table, with separate Rust compilation, native Grok, and Skillsaw outcomes. Keep unresolved Muse/native cases explicit.
- Add an optional tiny stdin-only ripgrep replay; normal tests need no host executable. Preserve the CLI fixture assertions and five independent literal-translation checks.
- Repair the “case-only rename” test to use `Deploy.md` → `deploy.md` and inspect actual directory-entry spelling. Remove the redundant SAFE-apply and no-match prefilter smoke tests while retaining stronger counterparts.
- Link the evidence from the canonical maintenance references and regenerate their distributed copies.

Validation: all 9,173 tests pass (two removals, one new Markdown fixture parity case); independent review passes 50 focused tests and verifies all 34 evidence records. `make lint`, `make update`, `make verify-apm`, the site build, and configured ai-helpers compatibility pass. No runtime source or rule enablement changes.

Follow-up to #595.
