### PR TITLE
docs: fix settings rule link in supply-chain protection

### DIFF
--- a/docs/supply-chain-protection.md
+++ b/docs/supply-chain-protection.md
@@ -26,7 +26,7 @@ skillsaw includes four rules designed to catch these attacks:
 | [`hooks-dangerous`](rules/hooks.md) | auto, error | Flags hook commands matching supply-chain patterns |
 | [`hooks-prohibited`](rules/hooks.md) | disabled, error | Prohibits all hooks unless explicitly allowlisted |
 | [`mcp-prohibited`](rules/mcp.md) | disabled, error | Prohibits all MCP servers unless explicitly allowlisted |
-| [`claude-settings-dangerous`](rules/settings.md) | auto, error | Flags settings keys that execute arbitrary commands or set dangerous env vars |
+| [`claude-settings-dangerous`](rules/claude-settings-dangerous.md) | auto, error | Flags settings keys that execute arbitrary commands or set dangerous env vars |
 
 ### hooks-dangerous
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9868,7 +9868,7 @@ def test_self_installed_skills_keep_authorship_in_a_linked_worktree(tmp_path, li
         assert external.read_bytes() == external_before
         clean = run_lint(repo, "--rule", "agentskill-name", "--no-custom-rules", "--no-plugins")
         assert all(v["file_path"] != "skills/authored-skill/SKILL.md" for v in violations(clean))
-    assert reports[0] == reports[1]
+    assert sorted(reports[0]) == sorted(reports[1])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
The supply-chain protection table linked `claude-settings-dangerous` to the retired settings overview. Link directly to the current rule page at `/rules/claude-settings-dangerous/`. A repository-wide search found no other references to the old `/rules/settings/` URL.

The required full suite also exposed a discovery-order-dependent assertion in the linked-worktree integration test, reproduced on untouched upstream main. A separate commit compares the same findings independent of order.

Validation: all 9,241 tests pass; `make lint`, `make update`, `make build-site`, and linting `openshift-eng/ai-helpers` pass. Verified the generated HTML links to the current rule page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the security rules table link for the `claude-settings-dangerous` rule.

- **Tests**
  - Improved integration test reliability by allowing lint violations to appear in different orders while still producing equivalent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->