### PR TITLE
Fix false Claude plugin requirements for Codex roots hosting marketplaces

### DIFF
--- a/docs/rules/claude-marketplace-registration.md
+++ b/docs/rules/claude-marketplace-registration.md
@@ -21,6 +21,11 @@ A plugin that exists in the repository but is not registered in
 `marketplace.json` is invisible to marketplace tooling — users
 cannot discover or install it through the standard workflow.
 
+This requirement applies to Claude plugins. Hosting a Claude marketplace
+beside a root Codex plugin does not require registering that Codex plugin
+in the Claude catalog. The catalog declares its entries as Claude plugins,
+not its parent directory.
+
 ## Examples
 
 **Bad:**

--- a/docs/rules/claude-plugin-json-required.md
+++ b/docs/rules/claude-plugin-json-required.md
@@ -23,6 +23,12 @@ capabilities. Without this file the plugin directory is just a
 collection of unregistered files. The requirement is scoped to
 directories with Claude provenance.
 
+A `.claude-plugin/marketplace.json` catalog alone does not declare its
+parent directory a Claude plugin. A root Codex plugin may host that catalog
+without needing a Claude manifest. An actual Claude manifest, an empty
+`.claude-plugin/` marker, or an explicit local entry in the Claude catalog
+still declares a Claude plugin.
+
 ## Examples
 
 **Bad:**

--- a/src/skillsaw/repository_provenance.py
+++ b/src/skillsaw/repository_provenance.py
@@ -17,7 +17,7 @@ from .discovery.antigravity import (
 )
 from .formats.codex import codex_manifest_is_contained, codex_marker_escapes
 from .formats.grok import grok_manifest_is_contained, grok_marker_escapes
-from .paths import safe_exists, safe_resolve
+from .paths import safe_exists, safe_is_file, safe_is_symlink, safe_resolve
 
 if TYPE_CHECKING:
     from .lint_target import LintTarget
@@ -176,8 +176,9 @@ class RepositoryProvenanceMixin:
         predicate below is a view over this record. Evidence, in declaration
         strength order:
 
-        * ``claude`` — a ``.claude-plugin`` marker, or a listing in the Claude
-          marketplace (``marketplace_entries``).
+        * ``claude`` — a ``.claude-plugin`` marker that is not just a
+          marketplace catalog, or a listing in the Claude marketplace
+          (``marketplace_entries``).
         * ``codex`` — a contained ``.codex-plugin/plugin.json``, or a local
           source listing in any Codex catalog.
         * ``agent-plugin`` — a contained package carrying an Agent Plugins
@@ -211,7 +212,18 @@ class RepositoryProvenanceMixin:
         # attribute absent and must fall back to "no marketplace listing".
         # Those early records are discarded by the unconditional cache clear
         # at the end of ``apply_excludes``; see the ordering comment there.
-        if safe_exists(plugin_dir / ".claude-plugin") or (
+        claude_marker = plugin_dir / ".claude-plugin"
+        claude_manifest = claude_marker / "plugin.json"
+        # A catalog publishes its entries, not the directory hosting it.
+        # Otherwise a root Codex plugin beside a Claude marketplace becomes
+        # a Claude plugin too. Keep empty markers and malformed manifests
+        # as declarations so their missing/invalid-manifest checks survive.
+        claude_plugin_marker = safe_exists(claude_marker) and (
+            safe_exists(claude_manifest)
+            or safe_is_symlink(claude_manifest)
+            or not safe_is_file(claude_marker / "marketplace.json")
+        )
+        if claude_plugin_marker or (
             resolved is not None and resolved in getattr(self, "marketplace_entries", {})
         ):
             ecosystems.add("claude")
@@ -270,7 +282,7 @@ class RepositoryProvenanceMixin:
         return record
 
     def is_codex_only_plugin(self, plugin_dir: Path) -> bool:
-        """Codex-claimed with no ``.claude-plugin`` marker.
+        """Codex-claimed with no Claude plugin declaration.
 
         The provenance line the Claude-format rules gate on: a Codex-only
         directory is exempt from Claude manifest, frontmatter, and naming

--- a/src/skillsaw/rules/builtin/plugins/json_required.py
+++ b/src/skillsaw/rules/builtin/plugins/json_required.py
@@ -22,7 +22,8 @@ class PluginJsonRequiredRule(Rule):
     # carry — one report per ecosystem. Two things take a plugin back out
     # of the exemption, both of them the author declaring it a Claude
     # plugin: the Claude marketplace listing it, or the directory carrying
-    # a ``.claude-plugin/`` of its own (provenance reads the marker, so a
+    # a ``.claude-plugin/`` that is not just a marketplace catalog
+    # (provenance reads the marker, so a
     # deleted or never-added manifest inside it is precisely the defect
     # this rule reports, with `strict: false` as the designed opt-out).
     provenance_scope = "claude"

--- a/src/skillsaw/rules/docs/claude-marketplace-registration.md
+++ b/src/skillsaw/rules/docs/claude-marketplace-registration.md
@@ -4,6 +4,11 @@ A plugin that exists in the repository but is not registered in
 `marketplace.json` is invisible to marketplace tooling — users
 cannot discover or install it through the standard workflow.
 
+This requirement applies to Claude plugins. Hosting a Claude marketplace
+beside a root Codex plugin does not require registering that Codex plugin
+in the Claude catalog. The catalog declares its entries as Claude plugins,
+not its parent directory.
+
 ## Examples
 
 **Bad:**

--- a/src/skillsaw/rules/docs/claude-plugin-json-required.md
+++ b/src/skillsaw/rules/docs/claude-plugin-json-required.md
@@ -6,6 +6,12 @@ capabilities. Without this file the plugin directory is just a
 collection of unregistered files. The requirement is scoped to
 directories with Claude provenance.
 
+A `.claude-plugin/marketplace.json` catalog alone does not declare its
+parent directory a Claude plugin. A root Codex plugin may host that catalog
+without needing a Claude manifest. An actual Claude manifest, an empty
+`.claude-plugin/` marker, or an explicit local entry in the Claude catalog
+still declares a Claude plugin.
+
 ## Examples
 
 **Bad:**

--- a/tests/codex/test_marketplace_provenance.py
+++ b/tests/codex/test_marketplace_provenance.py
@@ -1,0 +1,103 @@
+"""A marketplace catalog declares its entries, not its parent, as plugins."""
+
+import json
+
+import pytest
+
+from skillsaw.context import RepositoryContext, RepositoryType
+from skillsaw.lint_target import CodexPluginConfigNode, PluginNode
+from skillsaw.rules.builtin.marketplace.registration import MarketplaceRegistrationRule
+from skillsaw.rules.builtin.marketplace.json_valid import MarketplaceJsonValidRule
+from skillsaw.rules.builtin.plugins.json_required import PluginJsonRequiredRule
+
+from ._helpers import copy_fixture
+
+FIXTURE = "codex/root-plugin-claude-marketplace"
+
+
+@pytest.mark.parametrize(
+    "repo_types", [None, {RepositoryType.MARKETPLACE}, {RepositoryType.CODEX_PLUGIN}]
+)
+def test_catalog_does_not_claim_its_codex_parent(tmp_path, repo_types):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    context = RepositoryContext(repo, repo_types=repo_types)
+
+    assert context.provenance(repo).codex_only
+    assert context.provenance(repo / "plugins/claude-helper").claude
+    assert all(node.path != repo for node in context.lint_tree.find(PluginNode))
+    if repo_types is None or RepositoryType.CODEX_PLUGIN in repo_types:
+        assert any(
+            node.plugin_dir == repo for node in context.lint_tree.find(CodexPluginConfigNode)
+        )
+    assert PluginJsonRequiredRule({}).check(context) == []
+    assert MarketplaceRegistrationRule({}).check(context) == []
+
+
+def test_claude_marketplace_without_codex_does_not_discover_root(tmp_path):
+    """The ai-helpers layout never adds the root to the plugin union."""
+    repo = copy_fixture(FIXTURE, tmp_path)
+    (repo / ".codex-plugin/plugin.json").unlink()
+    (repo / ".codex-plugin").rmdir()
+    context = RepositoryContext(repo)
+
+    assert [node.path for node in context.lint_tree.find(PluginNode)] == [
+        repo / "plugins/claude-helper"
+    ]
+    assert MarketplaceRegistrationRule({}).check(context) == []
+
+
+@pytest.mark.parametrize("manifest_contents", ['{"name": "root-claude"}', '{"name":'])
+def test_claude_manifest_beside_catalog_keeps_claude_provenance(tmp_path, manifest_contents):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    (repo / ".claude-plugin/plugin.json").write_text(manifest_contents, encoding="utf-8")
+    context = RepositoryContext(repo)
+
+    assert context.provenance(repo).claude
+    assert len(MarketplaceRegistrationRule({}).check(context)) == 1
+
+
+def test_empty_claude_marker_still_reports_missing_manifest(tmp_path):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    (repo / ".claude-plugin/marketplace.json").unlink()
+    context = RepositoryContext(repo)
+
+    assert context.provenance(repo).claude
+    assert any(
+        v.file_path == repo / ".claude-plugin/plugin.json"
+        for v in PluginJsonRequiredRule({}).check(context)
+    )
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_catalog_explicitly_listing_root_keeps_claude_provenance(tmp_path, strict):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    catalog = repo / ".claude-plugin/marketplace.json"
+    data = json.loads(catalog.read_text(encoding="utf-8"))
+    data["plugins"].append({"name": repo.name, "source": "./", "strict": strict})
+    catalog.write_text(json.dumps(data), encoding="utf-8")
+    context = RepositoryContext(repo)
+
+    assert context.provenance(repo).claude
+    violations = PluginJsonRequiredRule({}).check(context)
+    assert len(violations) == int(strict)
+    assert MarketplaceRegistrationRule({}).check(context) == []
+
+
+def test_malformed_catalog_does_not_turn_codex_parent_into_claude_plugin(tmp_path):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    (repo / ".claude-plugin/marketplace.json").write_text('{"plugins":', encoding="utf-8")
+    context = RepositoryContext(repo)
+
+    assert context.provenance(repo).codex_only
+    assert PluginJsonRequiredRule({}).check(context) == []
+    assert MarketplaceJsonValidRule({}).check(context)
+
+
+def test_dangling_claude_manifest_beside_catalog_keeps_missing_manifest_error(tmp_path):
+    repo = copy_fixture(FIXTURE, tmp_path)
+    manifest = repo / ".claude-plugin/plugin.json"
+    manifest.symlink_to("missing.json")
+    context = RepositoryContext(repo)
+
+    assert context.provenance(repo).claude
+    assert any(v.file_path == manifest for v in PluginJsonRequiredRule({}).check(context))

--- a/tests/codex/test_marketplace_provenance.py
+++ b/tests/codex/test_marketplace_provenance.py
@@ -34,7 +34,7 @@ def test_catalog_does_not_claim_its_codex_parent(tmp_path, repo_types):
 
 
 def test_claude_marketplace_without_codex_does_not_discover_root(tmp_path):
-    """The ai-helpers layout never adds the root to the plugin union."""
+    """A standalone Claude marketplace does not add its root to the plugin union."""
     repo = copy_fixture(FIXTURE, tmp_path)
     (repo / ".codex-plugin/plugin.json").unlink()
     (repo / ".codex-plugin").rmdir()

--- a/tests/fixtures/codex/root-plugin-claude-marketplace/.claude-plugin/marketplace.json
+++ b/tests/fixtures/codex/root-plugin-claude-marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-plugins",
+  "owner": {"name": "Example"},
+  "plugins": [
+    {"name": "claude-helper", "source": "./plugins/claude-helper"}
+  ]
+}

--- a/tests/fixtures/codex/root-plugin-claude-marketplace/.codex-plugin/plugin.json
+++ b/tests/fixtures/codex/root-plugin-claude-marketplace/.codex-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-tools",
+  "version": "1.0.0",
+  "description": "Shared workspace tools for Codex."
+}

--- a/tests/fixtures/codex/root-plugin-claude-marketplace/plugins/claude-helper/.claude-plugin/plugin.json
+++ b/tests/fixtures/codex/root-plugin-claude-marketplace/plugins/claude-helper/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "claude-helper",
+  "version": "1.0.0",
+  "author": {"name": "Example"},
+  "description": "Workspace tools packaged for Claude Code."
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9944,3 +9944,53 @@ def test_cli_scope_severity_uses_explicit_config_and_exit_threshold(
     assert len(found) == 1 and found[0]["rule_id"] == rule_id
     assert found[0]["severity"] == expected
     assert result["rc"] == (0 if expected == "info" else 1), result
+
+
+@pytest.mark.integration
+class TestCodexRootWithClaudeMarketplace:
+    """Catalog ownership must not become a Claude plugin claim or autofix."""
+
+    def test_lint_and_suggest_fix_leave_codex_root_unregistered(self, tmp_path):
+        repo = copy_fixture("codex/root-plugin-claude-marketplace", tmp_path)
+        catalog = repo / ".claude-plugin/marketplace.json"
+        original = catalog.read_bytes()
+        rules = [
+            "--rule",
+            "claude-marketplace-registration",
+            "--rule",
+            "claude-plugin-json-required",
+        ]
+
+        result = run_cli(["lint", repo, "--format", "json", *rules])
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(result.stdout)["violations"] == []
+
+        for _ in range(2):
+            result = run_cli(["fix", repo, "--suggest", *rules])
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert catalog.read_bytes() == original
+            assert not (repo / ".claude-plugin/plugin.json").exists()
+
+        result = run_cli(["lint", repo, "--format", "json", *rules])
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(result.stdout)["violations"] == []
+
+    def test_missing_manifest_in_claude_entry_is_still_reported(self, tmp_path):
+        repo = copy_fixture("codex/root-plugin-claude-marketplace", tmp_path)
+        (repo / "plugins/claude-helper/.claude-plugin/plugin.json").unlink()
+
+        result = run_cli(
+            [
+                "lint",
+                repo,
+                "--format",
+                "json",
+                "--rule",
+                "claude-plugin-json-required",
+            ]
+        )
+        assert result.returncode == 1, result.stdout + result.stderr
+        findings = json.loads(result.stdout)["violations"]
+        assert len(findings) == 1
+        assert findings[0]["rule_id"] == "claude-plugin-json-required"
+        assert findings[0]["file_path"] == "plugins/claude-helper/.claude-plugin/plugin.json"


### PR DESCRIPTION
A root Codex plugin can also host a Claude marketplace that publishes plugins from subdirectories. In this layout, skillsaw incorrectly reports that the root needs `.claude-plugin/plugin.json` and a Claude marketplace registration. `fix --suggest` can then add a spurious root entry to the catalog.

This was observed in `stripe/link-cli`, which reports `Plugin 'link-cli' not registered in marketplace.json` even though the actual Claude plugin under `plugins/link` is already registered.

### Root cause

Codex discovery adds the repository root to the shared plugin-directory union because it contains `.codex-plugin/plugin.json`. `RepositoryContext.provenance()` then treats the mere existence of `.claude-plugin/` as a Claude plugin declaration, even when that directory only hosts `marketplace.json`. The tree consequently creates a Claude `PluginNode` for the root, and the Claude manifest and registration rules run against it. With no Claude manifest, the plugin name falls back to the checkout directory name.

This explains why `openshift-eng/ai-helpers` does not report the same error: it has a Claude marketplace but no root Codex manifest, so its root never enters the plugin-directory union. This is a discovery/provenance interaction, not a suppression or baseline difference; the comparison was also reproduced with baselines disabled.

### Fix

Treat a `.claude-plugin/` marker containing a marketplace catalog, without a plugin manifest, as catalog evidence rather than a declaration that its parent is a Claude plugin. Make that decision centrally in provenance so all Claude-scoped rules and autofixes agree.

Preserve Claude ownership for actual manifests (including malformed or dangling ones), empty plugin markers, and directories explicitly listed by the Claude catalog. Preserve the existing `strict: false` behavior. Malformed catalogs still receive their catalog validation errors.

### Validation

- Added a static fixture with a root Codex manifest, a Claude marketplace, and a registered nested Claude plugin.
- Confirmed the new ownership regression tests fail on the unmodified implementation, then pass with the fix.
- Added CLI coverage verifying clean lint, two idempotent `fix --suggest` runs that leave the catalog unchanged, and continued reporting for a missing manifest in the registered Claude plugin.
- Covered automatic detection and packaging-type overrides, a Claude-only marketplace, actual/malformed/dangling manifests, empty markers, explicit root registrations, relaxed entries, and malformed catalogs.
- `make test`: **9,255 passed**.
- `make lint`, `make update`, `make verify-apm`, and repository self-lint pass.
- Fresh clone of `openshift-eng/ai-helpers`: full lint exits 0, with 0 errors and 0 warnings under its existing configuration.
- On `link-cli`, the false root registration and root missing-manifest errors disappear. Existing Cursor plugin findings remain.

Updated both rule explanations and their generated documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin detection for Claude marketplace catalogs and standalone Claude plugins.
  * Prevented Codex projects hosting a Claude marketplace catalog from being incorrectly identified as Claude plugins.
  * Preserved missing-manifest checks for standalone Claude plugins and marketplace entries with missing or invalid manifests.
  * Ensured automated suggestions do not create unnecessary plugin manifests or modify marketplace catalogs.

* **Documentation**
  * Clarified Claude plugin registration and manifest requirements, including marketplace catalog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->